### PR TITLE
[00064] Add Vault Theme CLI Command Branch

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/07_Vault.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/07_Vault.md
@@ -8,6 +8,7 @@ searchHints:
   - discover
   - connect
   - auto-sync
+  - theme
 ---
 
 # vault
@@ -32,6 +33,13 @@ Manage team configuration vaults, discover and connect shared repositories on Gi
 >tendril vault import <project-name> [options]
 >tendril vault push <projects...> [options]
 >tendril vault delete <project-name> [--vault <vault-id>]
+>tendril vault theme list [--vault <vault-id>] [--json]
+>tendril vault theme get <theme-id> [--vault <vault-id>] [--json]
+>tendril vault theme add [--file <path>] [--stdin] [--id <id>] [--name <name>] [--vault <vault-id>]
+>tendril vault theme create <id> --name <name> [options]
+>tendril vault theme set <id> <field> <value> [--vault <vault-id>]
+>tendril vault theme delete <theme-id> [--vault <vault-id>]
+>tendril vault theme apply <theme-id>
 ```
 
 ## Vault Management
@@ -167,6 +175,91 @@ Collects project configuration, custom skills, MCP servers, memories, review act
 
 Deletes a project from the vault repository and creates a pull request on GitHub to apply the deletion.
 
+## Vault Themes
+
+#### theme list
+
+```terminal
+>tendril vault theme list
+>tendril vault theme list --json
+```
+
+Lists all themes saved in the vault with their ID, name, mode, description, preview colors, updated timestamp, and author.
+
+#### theme get
+
+```terminal
+>tendril vault theme get <theme-id>
+>tendril vault theme get <theme-id> --json
+```
+
+Shows full details for a vault theme including font, font size, border radii, shadows, and a complete table of color token values for light and dark modes.
+
+#### theme add
+
+```terminal
+>tendril vault theme add --file theme.json
+>cat theme.json | tendril vault theme add --stdin
+>tendril vault theme add --file theme.json --id my-theme --name "My Theme"
+```
+
+Imports a theme manifest or theme configuration JSON file into the vault repository. Accepts standard vault theme manifests as well as Ivy theme definitions.
+
+#### theme create
+
+```terminal
+>tendril vault theme create <id> --name <name> [options]
+>tendril vault theme create cyber --name "Cyber" --base dracula --dark --primary "#00ffcc"
+```
+
+Creates a new theme optionally based on an existing preset, applies custom styles or color token overrides, and saves the theme to the vault.
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name <name>` | Display name for the theme (required) |
+| `-d, --description <text>` | Theme description |
+| `-b, --base <preset>` | Base preset theme ID |
+| `--dark / --light` | Mode flag for the theme |
+| `--primary <hex>` | Primary color override |
+| `--secondary <hex>` | Secondary color override |
+| `--accent <hex>` | Accent color override |
+| `--background <hex>` | Background color override |
+| `--foreground <hex>` | Foreground color override |
+| `--color <token=hex>` | Override any specific color token (repeatable) |
+| `--font <family>` | Font family |
+| `--font-size <size>` | Font size (e.g. 14px) |
+| `--radius <value>` | Border radius for boxes, fields, and selectors |
+| `--apply-to <mode>` | Target mode for overrides: light, dark, or both |
+| `--force` | Allow creating even if ID matches a built-in preset |
+| `--vault <vault-id>` | Target vault ID |
+
+#### theme set
+
+```terminal
+>tendril vault theme set <id> <field> <value>
+>tendril vault theme set cyber description "Updated theme description"
+>tendril vault theme set cyber primary "#ff007f"
+>tendril vault theme set cyber light.primary "#3b82f6"
+```
+
+Updates a single metadata property, font, radius, shadow setting, preview colors, or color token on an existing vault theme.
+
+#### theme delete
+
+```terminal
+>tendril vault theme delete <theme-id>
+```
+
+Deletes a theme from the vault repository.
+
+#### theme apply
+
+```terminal
+>tendril vault theme apply <theme-id>
+```
+
+Loads all vault themes into the active theme registry, resolves the theme ID across all built-in and vault themes, and sets it as the active Tendril theme in configuration.
+
 ## Examples
 
 **Connect and sync a team vault:**
@@ -197,4 +290,14 @@ Deletes a project from the vault repository and creates a pull request on GitHub
 ```terminal
 ># Push changes and open a pull request
 >tendril vault push BackendService --changelog "Added Playwright E2E verification"
+```
+
+**Create and apply a team vault theme:**
+
+```terminal
+># Create a custom theme based on the Dracula preset
+>tendril vault theme create team-neon --name "Team Neon" --base dracula --dark --primary "#00ffcc" --accent "#ff007f"
+
+># Apply the theme as active
+>tendril vault theme apply team-neon
 ```

--- a/src/Ivy.Tendril.Test/Commands/VaultCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/VaultCommandTests.cs
@@ -43,6 +43,13 @@ public class FakeVaultService : IVaultService
     public VaultResult MergeResultToReturn { get; set; } = new(true, "Project merged successfully.");
     public VaultPrResult DeleteResultToReturn { get; set; } = new(true, PrUrl: "https://github.com/org/vault/pull/2");
     public VaultSyncResult PullResultToReturn { get; set; } = new(true, UpdatedProjectsCount: 2, Message: "Synced successfully.");
+    public List<VaultThemeManifest> ThemesToReturn { get; set; } = [];
+    public VaultResult SaveThemeResultToReturn { get; set; } = new(true, "Theme saved.");
+    public VaultResult DeleteThemeResultToReturn { get; set; } = new(true, "Theme deleted.");
+    public VaultThemeManifest? LastSavedTheme { get; set; }
+    public string? LastDeletedThemeId { get; set; }
+    public string? LastVaultId { get; set; }
+    public int LoadThemesCallCount { get; set; }
 
     public event Action? VaultChanged { add { } remove { } }
 
@@ -63,10 +70,27 @@ public class FakeVaultService : IVaultService
     public Task<VaultSyncResult> PullLatestAsync(string? vaultId = null) => Task.FromResult(PullResultToReturn);
     public ProjectAssets CollectProjectAssets(string projectName) => new() { ProjectName = projectName };
     public Task<ProjectAssets> CollectProjectAssetsAsync(string projectName) => Task.FromResult(CollectProjectAssets(projectName));
-    public Task<List<VaultThemeManifest>> GetThemesAsync(string? vaultId = null) => Task.FromResult(new List<VaultThemeManifest>());
-    public Task<VaultResult> SaveThemeToVaultAsync(VaultThemeManifest theme, string? vaultId = null) => Task.FromResult(new VaultResult(true, "Theme saved."));
-    public Task<VaultResult> DeleteThemeFromVaultAsync(string themeId, string? vaultId = null) => Task.FromResult(new VaultResult(true, "Theme deleted."));
-    public void LoadThemesIntoRegistry() { }
+    public Task<List<VaultThemeManifest>> GetThemesAsync(string? vaultId = null)
+    {
+        LastVaultId = vaultId;
+        return Task.FromResult(ThemesToReturn);
+    }
+    public Task<VaultResult> SaveThemeToVaultAsync(VaultThemeManifest theme, string? vaultId = null)
+    {
+        LastSavedTheme = theme;
+        LastVaultId = vaultId;
+        return Task.FromResult(SaveThemeResultToReturn);
+    }
+    public Task<VaultResult> DeleteThemeFromVaultAsync(string themeId, string? vaultId = null)
+    {
+        LastDeletedThemeId = themeId;
+        LastVaultId = vaultId;
+        return Task.FromResult(DeleteThemeResultToReturn);
+    }
+    public void LoadThemesIntoRegistry()
+    {
+        LoadThemesCallCount++;
+    }
 }
 
 public class VaultCommandSettingsValidationTests

--- a/src/Ivy.Tendril.Test/Commands/VaultThemeCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/VaultThemeCommandTests.cs
@@ -1,0 +1,741 @@
+using System.Text.Json;
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Infrastructure;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Vault;
+using Ivy.Tendril.Themes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using Spectre.Console.Testing;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Commands;
+
+public class VaultThemeSettingsValidationTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void VaultThemeGetSettings_RejectsEmptyThemeId(string id)
+    {
+        var settings = new VaultThemeGetSettings { ThemeId = id };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("theme-id", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VaultThemeAddSettings_RequiresSource()
+    {
+        var settings = new VaultThemeAddSettings();
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("Provide theme JSON", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeAddSettings_RejectsMultipleSources()
+    {
+        var settings = new VaultThemeAddSettings { FilePath = "theme.json", Stdin = true };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("exactly one way", result.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void VaultThemeCreateSettings_RejectsEmptyId(string id)
+    {
+        var settings = new VaultThemeCreateSettings { Id = id, Name = "My Theme" };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("id", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VaultThemeCreateSettings_RejectsBuiltInCollisionWithoutForce()
+    {
+        var settings = new VaultThemeCreateSettings { Id = "dracula", Name = "Dracula Clone", Force = false };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("collides with a built-in theme", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeCreateSettings_AllowsBuiltInCollisionWithForce()
+    {
+        var settings = new VaultThemeCreateSettings { Id = "dracula", Name = "Dracula Clone", Force = true };
+        var result = settings.Validate();
+        Assert.True(result.Successful);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void VaultThemeCreateSettings_RejectsEmptyName(string name)
+    {
+        var settings = new VaultThemeCreateSettings { Id = "my-theme", Name = name };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("name", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VaultThemeCreateSettings_RejectsUnknownBasePreset()
+    {
+        var settings = new VaultThemeCreateSettings { Id = "my-theme", Name = "My Theme", BasePreset = "non-existent" };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("Unknown base preset", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeCreateSettings_RejectsBothDarkAndLight()
+    {
+        var settings = new VaultThemeCreateSettings { Id = "my-theme", Name = "My Theme", Dark = true, Light = true };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("both --dark and --light", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeCreateSettings_RejectsInvalidHexPrimary()
+    {
+        var settings = new VaultThemeCreateSettings { Id = "my-theme", Name = "My Theme", Primary = "blue" };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("Invalid hex color", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeCreateSettings_RejectsInvalidColorOverrideFormat()
+    {
+        var settings = new VaultThemeCreateSettings { Id = "my-theme", Name = "My Theme", Colors = ["primary"] };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("Expected '<token>=<hex>'", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeCreateSettings_RejectsUnknownColorToken()
+    {
+        var settings = new VaultThemeCreateSettings { Id = "my-theme", Name = "My Theme", Colors = ["fakeToken=#ff0000"] };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("Unknown color token", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeCreateSettings_RejectsInvalidHexInColorOverride()
+    {
+        var settings = new VaultThemeCreateSettings { Id = "my-theme", Name = "My Theme", Colors = ["primary=notAColor"] };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("Invalid hex color", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeSetSettings_RejectsUnknownField()
+    {
+        var settings = new VaultThemeSetSettings { Id = "my-theme", Field = "unknownField", Value = "val" };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("Unknown field", result.Message);
+        Assert.Contains("Valid fields:", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeSetSettings_RejectsNonHexColor()
+    {
+        var settings = new VaultThemeSetSettings { Id = "my-theme", Field = "primary", Value = "red" };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("Invalid hex color", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeSetSettings_RejectsInvalidPreview()
+    {
+        var settings = new VaultThemeSetSettings { Id = "my-theme", Field = "preview", Value = "#111,#222,#333" };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("Invalid preview colors", result.Message);
+    }
+
+    [Fact]
+    public void VaultThemeSetSettings_AcceptsValidColorToken()
+    {
+        var settings = new VaultThemeSetSettings { Id = "my-theme", Field = "light.primary", Value = "#ff0000" };
+        var result = settings.Validate();
+        Assert.True(result.Successful);
+    }
+
+    [Fact]
+    public void VaultThemeDeleteSettings_RejectsEmptyThemeId()
+    {
+        var settings = new VaultThemeDeleteSettings { ThemeId = "" };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+    }
+
+    [Fact]
+    public void VaultThemeApplySettings_RejectsEmptyThemeId()
+    {
+        var settings = new VaultThemeApplySettings { ThemeId = "" };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+    }
+}
+
+[Collection("TendrilHome")]
+public class VaultThemeCommandsExecutionTests : IDisposable
+{
+    public void Dispose()
+    {
+        CliOutput.PlainOverride = null;
+    }
+
+    private static string CaptureCommandOutput(Action<CommandApp, FakeVaultService> action)
+    {
+        lock (TestLocks.ConsoleLock)
+        {
+            var writer = new StringWriter();
+            var ansiConsole = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Ansi = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Out = new AnsiConsoleOutput(writer)
+            });
+            ansiConsole.Profile.Width = 240;
+
+            var originalAnsiConsole = AnsiConsole.Console;
+            var originalOut = Console.Out;
+            var originalPlainOverride = CliOutput.PlainOverride;
+
+            AnsiConsole.Console = ansiConsole;
+            Console.SetOut(writer);
+            CliOutput.PlainOverride = true;
+
+            try
+            {
+                var (app, fakeVault) = CreateTestApp(ansiConsole);
+                action(app, fakeVault);
+            }
+            finally
+            {
+                CliOutput.PlainOverride = originalPlainOverride;
+                Console.SetOut(originalOut);
+                AnsiConsole.Console = originalAnsiConsole;
+            }
+
+            return writer.ToString();
+        }
+    }
+
+    private static (CommandApp App, FakeVaultService VaultService) CreateTestApp(IAnsiConsole console, ConfigService? configService = null)
+    {
+        var fakeVault = new FakeVaultService();
+        var services = new ServiceCollection();
+        services.AddSingleton<IVaultService>(fakeVault);
+        configService ??= new ConfigService(NullLogger<ConfigService>.Instance);
+        services.AddSingleton<IConfigService>(configService);
+        services.AddSingleton<ConfigService>(configService);
+
+        var app = Program.ConfigureCliCommands(services, console);
+        return (app, fakeVault);
+    }
+
+    private static VaultThemeManifest CreateSampleTheme(string id = "cyber-neon", string name = "Cyber Neon", bool isDark = true)
+    {
+        return new VaultThemeManifest
+        {
+            Id = id,
+            Name = name,
+            Description = "A neon futuristic theme",
+            IsDark = isDark,
+            PreviewColors = ["#ff007f", "#00f0ff", "#ffe600", "#0a0a14"],
+            UpdatedAt = new DateTimeOffset(2026, 9, 7, 12, 0, 0, TimeSpan.Zero),
+            UpdatedBy = "tester@example.com",
+            IvyTheme = new Ivy.Theme
+            {
+                Name = name,
+                FontFamily = "Fira Code",
+                FontSize = "15px",
+                BorderRadiusBoxes = "10px",
+                BorderRadiusFields = "8px",
+                BorderRadiusSelectors = "6px",
+                ShadowBoxes = true,
+                ShadowFields = false,
+                ShadowSelectors = true,
+                Colors = new Ivy.ThemeColorScheme
+                {
+                    Light = new Ivy.ThemeColors
+                    {
+                        Primary = "#0055ff",
+                        Secondary = "#64748b",
+                        Accent = "#f59e0b",
+                        Background = "#ffffff",
+                        Foreground = "#0f172a"
+                    },
+                    Dark = new Ivy.ThemeColors
+                    {
+                        Primary = "#ff007f",
+                        Secondary = "#00f0ff",
+                        Accent = "#ffe600",
+                        Background = "#0a0a14",
+                        Foreground = "#f8fafc"
+                    }
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public void VaultThemeList_WithoutJson_RendersTableWithModeAndId()
+    {
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [CreateSampleTheme()];
+            exit = app.Run(["vault", "theme", "list"]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.Contains("cyber-neon", output);
+        Assert.Contains("Cyber Neon", output);
+        Assert.Contains("Dark", output);
+    }
+
+    [Fact]
+    public void VaultThemeList_WithJson_OutputsJsonWithId()
+    {
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [CreateSampleTheme()];
+            exit = app.Run(["vault", "theme", "list", "--json"]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.Contains("cyber-neon", output);
+        Assert.Contains("\"id\": \"cyber-neon\"", output);
+    }
+
+    [Fact]
+    public void VaultThemeList_Empty_PrintsNoThemesFound()
+    {
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [];
+            exit = app.Run(["vault", "theme", "list"]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.Contains("No themes found", output);
+    }
+
+    [Fact]
+    public void VaultThemeGet_WithoutJson_RendersDetailsAndColorTable()
+    {
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [CreateSampleTheme()];
+            exit = app.Run(["vault", "theme", "get", "cyber-neon"]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Cyber Neon", output);
+        Assert.Contains("#ff007f", output);
+        Assert.Contains("#0055ff", output);
+    }
+
+    [Fact]
+    public void VaultThemeGet_WithJson_EmitsCamelCaseIvyTheme()
+    {
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [CreateSampleTheme()];
+            exit = app.Run(["vault", "theme", "get", "cyber-neon", "--json"]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.Contains("\"ivyTheme\":", output);
+        Assert.Contains("\"previewColors\":", output);
+    }
+
+    [Fact]
+    public void VaultThemeGet_UnknownId_Exits1AndListsAvailable()
+    {
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [CreateSampleTheme(id: "alpha-theme")];
+            exit = app.Run(["vault", "theme", "get", "unknown-theme"]);
+        });
+
+        Assert.Equal(1, exit);
+        Assert.Contains("not found in vault", output);
+        Assert.Contains("alpha-theme", output);
+    }
+
+    [Fact]
+    public void VaultThemeAdd_WithManifestFile_SavesThemeToVault()
+    {
+        using var tempDir = new TempDirectoryFixture("vault-theme-add-test");
+        var filePath = Path.Combine(tempDir.Path, "manifest.json");
+        var manifest = CreateSampleTheme(id: "my-imported-theme", name: "Imported Theme");
+        File.WriteAllText(filePath, JsonSerializer.Serialize(manifest, VaultThemeCommandHelpers.ManifestJsonOptions));
+
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            exit = app.Run(["vault", "theme", "add", "--file", filePath]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.Contains("added to vault successfully", output);
+    }
+
+    [Fact]
+    public void VaultThemeAdd_ThemeShapedJsonFallback_ImportsSuccessfully()
+    {
+        using var tempDir = new TempDirectoryFixture("vault-theme-add-fallback-test");
+        var filePath = Path.Combine(tempDir.Path, "theme.json");
+        var theme = new Ivy.Theme
+        {
+            Name = "Standalone Theme",
+            Colors = new Ivy.ThemeColorScheme
+            {
+                Light = new Ivy.ThemeColors { Primary = "#123456", Background = "#ffffff" }
+            }
+        };
+        File.WriteAllText(filePath, JsonSerializer.Serialize(theme, VaultThemeCommandHelpers.ManifestJsonOptions));
+
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            exit = app.Run(["vault", "theme", "add", "--file", filePath, "--id", "custom-id"]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.Contains("custom-id", output);
+    }
+
+    [Fact]
+    public void VaultThemeAdd_BlankName_Exits1WithoutCallingService()
+    {
+        using var tempDir = new TempDirectoryFixture("vault-theme-add-blank-test");
+        var filePath = Path.Combine(tempDir.Path, "manifest.json");
+        var manifest = new VaultThemeManifest
+        {
+            Id = "blank-name-theme",
+            Name = "",
+            IvyTheme = new Ivy.Theme
+            {
+                Colors = new Ivy.ThemeColorScheme
+                {
+                    Light = new Ivy.ThemeColors { Primary = "#123456" }
+                }
+            }
+        };
+        File.WriteAllText(filePath, JsonSerializer.Serialize(manifest, VaultThemeCommandHelpers.ManifestJsonOptions));
+
+        var exit = -1;
+        FakeVaultService? capturedVault = null;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            capturedVault = fakeVault;
+            exit = app.Run(["vault", "theme", "add", "--file", filePath]);
+        });
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Theme name cannot be empty", output);
+        Assert.Null(capturedVault?.LastSavedTheme);
+    }
+
+    [Fact]
+    public void VaultThemeAdd_ServiceFailure_Exits1WithError()
+    {
+        using var tempDir = new TempDirectoryFixture("vault-theme-add-fail-test");
+        var filePath = Path.Combine(tempDir.Path, "manifest.json");
+        var manifest = CreateSampleTheme();
+        File.WriteAllText(filePath, JsonSerializer.Serialize(manifest, VaultThemeCommandHelpers.ManifestJsonOptions));
+
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.SaveThemeResultToReturn = new VaultResult(false, "Vault permission denied.");
+            exit = app.Run(["vault", "theme", "add", "--file", filePath]);
+        });
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Error:", output);
+        Assert.Contains("Vault permission denied.", output);
+    }
+
+    [Fact]
+    public void VaultThemeCreate_FromPreset_ProducesExpectedManifestAndPreview()
+    {
+        var exit = -1;
+        FakeVaultService? capturedVault = null;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            capturedVault = fakeVault;
+            exit = app.Run([
+                "vault", "theme", "create", "custom-dracula",
+                "--name", "Custom Dracula",
+                "--base", "dracula",
+                "--dark",
+                "--primary", "#ff0000",
+                "--color", "ring=#00ff00"
+            ]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(capturedVault?.LastSavedTheme);
+        var saved = capturedVault.LastSavedTheme!;
+        Assert.Equal("custom-dracula", saved.Id);
+        Assert.Equal("Custom Dracula", saved.Name);
+        Assert.True(saved.IsDark);
+        Assert.Equal("#ff0000", saved.IvyTheme.Colors.Dark.Primary);
+        Assert.Equal("#00ff00", saved.IvyTheme.Colors.Dark.Ring);
+        Assert.Equal("#ff0000", saved.PreviewColors[0]);
+    }
+
+    [Fact]
+    public void VaultThemeCreate_BuiltInCollisionWithoutForce_FailsValidation()
+    {
+        var settings = new VaultThemeCreateSettings
+        {
+            Id = "dracula",
+            Name = "Colliding Dracula",
+            Force = false
+        };
+        var result = settings.Validate();
+        Assert.False(result.Successful);
+        Assert.Contains("collides with a built-in theme", result.Message);
+
+        CaptureCommandOutput((app, fakeVault) =>
+        {
+            var ex = Assert.Throws<CommandRuntimeException>(() =>
+                app.Run(["vault", "theme", "create", "dracula", "--name", "Colliding Dracula"]));
+            Assert.Contains("collides with a built-in theme", ex.Message);
+        });
+    }
+
+    [Fact]
+    public void VaultThemeSet_MutatesExpectedFields()
+    {
+        var theme = CreateSampleTheme(id: "mutating-theme");
+
+        // 1. name
+        CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [theme];
+            var exit = app.Run(["vault", "theme", "set", "mutating-theme", "name", "Renamed Theme"]);
+            Assert.Equal(0, exit);
+            Assert.Equal("Renamed Theme", fakeVault.LastSavedTheme?.Name);
+        });
+
+        // 2. mode dark
+        CaptureCommandOutput((app, fakeVault) =>
+        {
+            theme.IsDark = false;
+            fakeVault.ThemesToReturn = [theme];
+            var exit = app.Run(["vault", "theme", "set", "mutating-theme", "mode", "dark"]);
+            Assert.Equal(0, exit);
+            Assert.True(fakeVault.LastSavedTheme?.IsDark);
+        });
+
+        // 3. light.primary
+        CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [theme];
+            var exit = app.Run(["vault", "theme", "set", "mutating-theme", "light.primary", "#112233"]);
+            Assert.Equal(0, exit);
+            Assert.Equal("#112233", fakeVault.LastSavedTheme?.IvyTheme.Colors.Light.Primary);
+        });
+
+        // 4. preview
+        CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [theme];
+            var exit = app.Run(["vault", "theme", "set", "mutating-theme", "preview", "#111111,#222222,#333333,#444444"]);
+            Assert.Equal(0, exit);
+            Assert.Equal(new[] { "#111111", "#222222", "#333333", "#444444" }, fakeVault.LastSavedTheme?.PreviewColors ?? []);
+        });
+    }
+
+    [Fact]
+    public void VaultThemeSet_UnknownThemeId_Exits1()
+    {
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [];
+            exit = app.Run(["vault", "theme", "set", "non-existent", "name", "New Name"]);
+        });
+
+        Assert.Equal(1, exit);
+        Assert.Contains("not found in vault", output);
+    }
+
+    [Fact]
+    public void VaultThemeDelete_KnownId_CallsDeleteOnService()
+    {
+        var exit = -1;
+        FakeVaultService? capturedVault = null;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [CreateSampleTheme(id: "to-delete")];
+            capturedVault = fakeVault;
+            exit = app.Run(["vault", "theme", "delete", "to-delete"]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.Equal("to-delete", capturedVault?.LastDeletedThemeId);
+        Assert.Contains("deleted from vault successfully", output);
+    }
+
+    [Fact]
+    public void VaultThemeDelete_UnknownId_Exits1AndDoesNotCallService()
+    {
+        var exit = -1;
+        FakeVaultService? capturedVault = null;
+        var output = CaptureCommandOutput((app, fakeVault) =>
+        {
+            fakeVault.ThemesToReturn = [];
+            capturedVault = fakeVault;
+            exit = app.Run(["vault", "theme", "delete", "unknown-theme"]);
+        });
+
+        Assert.Equal(1, exit);
+        Assert.Null(capturedVault?.LastDeletedThemeId);
+        Assert.Contains("not found in vault", output);
+    }
+}
+
+[Collection("TendrilHome")]
+public class VaultThemeApplyCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-vault-apply-test");
+    private readonly string _originalTendrilHome;
+
+    public VaultThemeApplyCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+
+        var yaml = @"
+settings:
+  beta: false
+  theme: default
+projects: []
+verifications: []
+";
+        File.WriteAllText(Path.Combine(_tempDir.Path, "config.yaml"), yaml);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+        TendrilThemes.ClearVaultThemes();
+    }
+
+    private static string CaptureCommandOutput(Action<CommandApp, FakeVaultService, ConfigService> action)
+    {
+        lock (TestLocks.ConsoleLock)
+        {
+            var writer = new StringWriter();
+            var ansiConsole = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Ansi = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Out = new AnsiConsoleOutput(writer)
+            });
+            ansiConsole.Profile.Width = 240;
+
+            var originalAnsiConsole = AnsiConsole.Console;
+            var originalOut = Console.Out;
+            var originalPlainOverride = CliOutput.PlainOverride;
+
+            AnsiConsole.Console = ansiConsole;
+            Console.SetOut(writer);
+            CliOutput.PlainOverride = true;
+
+            try
+            {
+                var fakeVault = new FakeVaultService();
+                var services = new ServiceCollection();
+                services.AddSingleton<IVaultService>(fakeVault);
+                var configService = new ConfigService(NullLogger<ConfigService>.Instance);
+                services.AddSingleton<IConfigService>(configService);
+                services.AddSingleton<ConfigService>(configService);
+
+                var app = Program.ConfigureCliCommands(services, ansiConsole);
+                action(app, fakeVault, configService);
+            }
+            finally
+            {
+                CliOutput.PlainOverride = originalPlainOverride;
+                Console.SetOut(originalOut);
+                AnsiConsole.Console = originalAnsiConsole;
+            }
+
+            return writer.ToString();
+        }
+    }
+
+    [Fact]
+    public void VaultThemeApply_CallsLoadThemesAndUpdatesConfig()
+    {
+        var exit = -1;
+        FakeVaultService? capturedVault = null;
+        ConfigService? capturedConfig = null;
+
+        var output = CaptureCommandOutput((app, fakeVault, configService) =>
+        {
+            capturedVault = fakeVault;
+            capturedConfig = configService;
+
+            // Register a vault theme so LoadThemes simulation has it registered
+            TendrilThemes.RegisterVaultTheme(new VaultThemeManifest
+            {
+                Id = "custom-vault-theme",
+                Name = "Custom Vault Theme",
+                IvyTheme = new Ivy.Theme { Name = "Custom Vault Theme" }
+            }, "vault-1", "Main Vault");
+
+            exit = app.Run(["vault", "theme", "apply", "custom-vault-theme"]);
+        });
+
+        Assert.Equal(0, exit);
+        Assert.NotNull(capturedVault);
+        Assert.True(capturedVault.LoadThemesCallCount > 0);
+        Assert.NotNull(capturedConfig);
+        Assert.Equal("custom-vault-theme", capturedConfig.Settings.Theme);
+        Assert.Contains("Active theme set to 'custom-vault-theme'", output);
+    }
+
+    [Fact]
+    public void VaultThemeApply_UnknownThemeId_Exits1WithError()
+    {
+        var exit = -1;
+        var output = CaptureCommandOutput((app, fakeVault, configService) =>
+        {
+            exit = app.Run(["vault", "theme", "apply", "totally-unknown-theme"]);
+        });
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Error:", output);
+        Assert.Contains("Unknown theme 'totally-unknown-theme'", output);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/VaultThemesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/VaultThemesDialog.cs
@@ -1137,58 +1137,9 @@ var server = new Server()
         }
     };
 
-    private static Theme CloneTheme(Theme source)
-    {
-        return new Theme
-        {
-            Name = source.Name,
-            FontFamily = source.FontFamily,
-            FontSize = source.FontSize,
-            BorderRadiusBoxes = source.BorderRadiusBoxes,
-            BorderRadiusFields = source.BorderRadiusFields,
-            BorderRadiusSelectors = source.BorderRadiusSelectors,
-            ShadowBoxes = source.ShadowBoxes,
-            ShadowFields = source.ShadowFields,
-            ShadowSelectors = source.ShadowSelectors,
-            Colors = new ThemeColorScheme
-            {
-                Light = CloneThemeColors(source.Colors?.Light ?? ThemeColors.DefaultLight),
-                Dark = CloneThemeColors(source.Colors?.Dark ?? ThemeColors.DefaultDark)
-            }
-        };
-    }
+    private static Theme CloneTheme(Theme source) => TendrilThemes.CloneTheme(source);
 
-    private static ThemeColors CloneThemeColors(ThemeColors source)
-    {
-        return new ThemeColors
-        {
-            Primary = source.Primary,
-            PrimaryForeground = source.PrimaryForeground,
-            Secondary = source.Secondary,
-            SecondaryForeground = source.SecondaryForeground,
-            Background = source.Background,
-            Foreground = source.Foreground,
-            Destructive = source.Destructive,
-            DestructiveForeground = source.DestructiveForeground,
-            Success = source.Success,
-            SuccessForeground = source.SuccessForeground,
-            Warning = source.Warning,
-            WarningForeground = source.WarningForeground,
-            Info = source.Info,
-            InfoForeground = source.InfoForeground,
-            Border = source.Border,
-            Input = source.Input,
-            Ring = source.Ring,
-            Muted = source.Muted,
-            MutedForeground = source.MutedForeground,
-            Accent = source.Accent,
-            AccentForeground = source.AccentForeground,
-            Card = source.Card,
-            CardForeground = source.CardForeground,
-            Popover = source.Popover,
-            PopoverForeground = source.PopoverForeground
-        };
-    }
+    private static ThemeColors CloneThemeColors(ThemeColors source) => TendrilThemes.CloneThemeColors(source);
 
     public static bool TryImportTheme(string raw, out Theme importedTheme, out string? errorMessage)
     {

--- a/src/Ivy.Tendril/Commands/VaultThemeCommand.cs
+++ b/src/Ivy.Tendril/Commands/VaultThemeCommand.cs
@@ -1,0 +1,824 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Apps.Settings.Dialogs;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Vault;
+using Ivy.Tendril.Themes;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using SpectreValidation = Spectre.Console.ValidationResult;
+
+namespace Ivy.Tendril.Commands;
+
+internal static class VaultThemeCommandHelpers
+{
+    internal static readonly Dictionary<string, (Func<ThemeColors, string?> Get, Action<ThemeColors, string?> Set)> ColorTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["primary"] = (c => c.Primary, (c, v) => c.Primary = v),
+        ["primaryForeground"] = (c => c.PrimaryForeground, (c, v) => c.PrimaryForeground = v),
+        ["secondary"] = (c => c.Secondary, (c, v) => c.Secondary = v),
+        ["secondaryForeground"] = (c => c.SecondaryForeground, (c, v) => c.SecondaryForeground = v),
+        ["background"] = (c => c.Background, (c, v) => c.Background = v),
+        ["foreground"] = (c => c.Foreground, (c, v) => c.Foreground = v),
+        ["destructive"] = (c => c.Destructive, (c, v) => c.Destructive = v),
+        ["destructiveForeground"] = (c => c.DestructiveForeground, (c, v) => c.DestructiveForeground = v),
+        ["success"] = (c => c.Success, (c, v) => c.Success = v),
+        ["successForeground"] = (c => c.SuccessForeground, (c, v) => c.SuccessForeground = v),
+        ["warning"] = (c => c.Warning, (c, v) => c.Warning = v),
+        ["warningForeground"] = (c => c.WarningForeground, (c, v) => c.WarningForeground = v),
+        ["info"] = (c => c.Info, (c, v) => c.Info = v),
+        ["infoForeground"] = (c => c.InfoForeground, (c, v) => c.InfoForeground = v),
+        ["border"] = (c => c.Border, (c, v) => c.Border = v),
+        ["input"] = (c => c.Input, (c, v) => c.Input = v),
+        ["ring"] = (c => c.Ring, (c, v) => c.Ring = v),
+        ["muted"] = (c => c.Muted, (c, v) => c.Muted = v),
+        ["mutedForeground"] = (c => c.MutedForeground, (c, v) => c.MutedForeground = v),
+        ["accent"] = (c => c.Accent, (c, v) => c.Accent = v),
+        ["accentForeground"] = (c => c.AccentForeground, (c, v) => c.AccentForeground = v),
+        ["card"] = (c => c.Card, (c, v) => c.Card = v),
+        ["cardForeground"] = (c => c.CardForeground, (c, v) => c.CardForeground = v),
+        ["popover"] = (c => c.Popover, (c, v) => c.Popover = v),
+        ["popoverForeground"] = (c => c.PopoverForeground, (c, v) => c.PopoverForeground = v),
+    };
+
+    internal static bool IsHexColor(string? hex) =>
+        !string.IsNullOrWhiteSpace(hex) && Regex.IsMatch(hex.Trim(), @"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$");
+
+    internal static string NormalizeId(string id) =>
+        Regex.Replace(id.ToLowerInvariant(), @"[^a-z0-9_-]", "-").Trim('-');
+
+    internal static VaultThemeManifest? FindTheme(List<VaultThemeManifest> themes, string id) =>
+        themes.FirstOrDefault(t => string.Equals(t.Id, id, StringComparison.OrdinalIgnoreCase));
+
+    internal static int WriteNotFound(string id, List<VaultThemeManifest> themes)
+    {
+        AnsiConsole.MarkupLine($"[red]Error:[/] Theme '{id.EscapeMarkup()}' not found in vault.");
+        if (themes.Count > 0)
+        {
+            AnsiConsole.MarkupLine($"Available: {string.Join(", ", themes.Select(t => t.Id))}");
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("Vault contains no themes.");
+        }
+        return 1;
+    }
+
+    internal static readonly JsonSerializerOptions ManifestJsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+}
+
+// --- Settings ---
+
+public class VaultThemeListSettings : CommandSettings
+{
+    [Description("Target vault ID")]
+    [CommandOption("--vault")]
+    public string? VaultId { get; init; }
+
+    [Description("Output as JSON")]
+    [CommandOption("--json")]
+    public bool Json { get; init; }
+}
+
+public class VaultThemeGetSettings : CommandSettings
+{
+    [Description("Theme ID to retrieve")]
+    [CommandArgument(0, "<theme-id>")]
+    public string ThemeId { get; init; } = "";
+
+    [Description("Target vault ID")]
+    [CommandOption("--vault")]
+    public string? VaultId { get; init; }
+
+    [Description("Output as JSON")]
+    [CommandOption("--json")]
+    public bool Json { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(ThemeId, "theme-id");
+    }
+}
+
+public class VaultThemeAddSettings : CommandSettings
+{
+    [Description("File path containing theme manifest or theme JSON")]
+    [CommandOption("-f|--file")]
+    public string? FilePath { get; init; }
+
+    [Description("Read theme JSON from stdin")]
+    [CommandOption("--stdin")]
+    public bool Stdin { get; init; }
+
+    [Description("Optional theme ID override")]
+    [CommandOption("--id")]
+    public string? Id { get; init; }
+
+    [Description("Optional theme name override")]
+    [CommandOption("-n|--name")]
+    public string? Name { get; init; }
+
+    [Description("Target vault ID")]
+    [CommandOption("--vault")]
+    public string? VaultId { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var count = CliValidation.CountSources(Stdin, FilePath, "");
+        if (count == 0)
+            return SpectreValidation.Error("Provide theme JSON via --file or --stdin.");
+        return CliValidation.ValidateSingleSource(count, "--file or --stdin");
+    }
+}
+
+public class VaultThemeCreateSettings : CommandSettings
+{
+    [Description("Theme ID")]
+    [CommandArgument(0, "<id>")]
+    public string Id { get; init; } = "";
+
+    [Description("Display name for the theme")]
+    [CommandOption("-n|--name")]
+    public string Name { get; init; } = "";
+
+    [Description("Theme description")]
+    [CommandOption("-d|--description")]
+    public string? Description { get; init; }
+
+    [Description("Base preset theme ID")]
+    [CommandOption("-b|--base")]
+    public string? BasePreset { get; init; }
+
+    [Description("Create as dark mode theme")]
+    [CommandOption("--dark")]
+    public bool Dark { get; init; }
+
+    [Description("Create as light mode theme")]
+    [CommandOption("--light")]
+    public bool Light { get; init; }
+
+    [Description("Primary color hex")]
+    [CommandOption("--primary")]
+    public string? Primary { get; init; }
+
+    [Description("Secondary color hex")]
+    [CommandOption("--secondary")]
+    public string? Secondary { get; init; }
+
+    [Description("Accent color hex")]
+    [CommandOption("--accent")]
+    public string? Accent { get; init; }
+
+    [Description("Background color hex")]
+    [CommandOption("--background")]
+    public string? Background { get; init; }
+
+    [Description("Foreground color hex")]
+    [CommandOption("--foreground")]
+    public string? Foreground { get; init; }
+
+    [Description("Color token override (<token>=<hex>)")]
+    [CommandOption("--color")]
+    public string[]? Colors { get; init; }
+
+    [Description("Font family")]
+    [CommandOption("--font")]
+    public string? Font { get; init; }
+
+    [Description("Font size")]
+    [CommandOption("--font-size")]
+    public string? FontSize { get; init; }
+
+    [Description("Border radius for boxes, fields, and selectors")]
+    [CommandOption("--radius")]
+    public string? Radius { get; init; }
+
+    [Description("Apply overrides to mode: light, dark, or both")]
+    [CommandOption("--apply-to")]
+    public string? ApplyTo { get; init; }
+
+    [Description("Force creation even if ID collides with built-in theme")]
+    [CommandOption("--force")]
+    public bool Force { get; init; }
+
+    [Description("Target vault ID")]
+    [CommandOption("--vault")]
+    public string? VaultId { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var idValidation = CliValidation.RequireNonEmpty(Id, "id");
+        if (!idValidation.Successful)
+            return idValidation;
+
+        var normalizedId = VaultThemeCommandHelpers.NormalizeId(Id);
+        if (string.IsNullOrWhiteSpace(normalizedId))
+            return SpectreValidation.Error("<id> normalized to empty. Provide a valid alphanumeric identifier.");
+
+        if (!Force && TendrilThemes.BuiltInThemes.Any(t => string.Equals(t.Id, normalizedId, StringComparison.OrdinalIgnoreCase)))
+            return SpectreValidation.Error($"Theme id '{Id}' collides with a built-in theme. Use --force to override.");
+
+        var nameValidation = CliValidation.RequireNonEmpty(Name, "name");
+        if (!nameValidation.Successful)
+            return nameValidation;
+
+        if (!string.IsNullOrWhiteSpace(BasePreset) && !TendrilThemes.BuiltInThemes.Any(t => string.Equals(t.Id, BasePreset, StringComparison.OrdinalIgnoreCase)))
+            return SpectreValidation.Error($"Unknown base preset '{BasePreset}'. Valid presets: {string.Join(", ", TendrilThemes.BuiltInThemes.Select(t => t.Id))}");
+
+        if (Dark && Light)
+            return SpectreValidation.Error("Cannot specify both --dark and --light.");
+
+        if (!string.IsNullOrWhiteSpace(ApplyTo))
+        {
+            var applyValidation = CliValidation.ValidateOneOf(ApplyTo, "--apply-to", ["light", "dark", "both"]);
+            if (!applyValidation.Successful)
+                return applyValidation;
+        }
+
+        if (Primary != null && !VaultThemeCommandHelpers.IsHexColor(Primary))
+            return SpectreValidation.Error($"Invalid hex color '{Primary}' for --primary.");
+        if (Secondary != null && !VaultThemeCommandHelpers.IsHexColor(Secondary))
+            return SpectreValidation.Error($"Invalid hex color '{Secondary}' for --secondary.");
+        if (Accent != null && !VaultThemeCommandHelpers.IsHexColor(Accent))
+            return SpectreValidation.Error($"Invalid hex color '{Accent}' for --accent.");
+        if (Background != null && !VaultThemeCommandHelpers.IsHexColor(Background))
+            return SpectreValidation.Error($"Invalid hex color '{Background}' for --background.");
+        if (Foreground != null && !VaultThemeCommandHelpers.IsHexColor(Foreground))
+            return SpectreValidation.Error($"Invalid hex color '{Foreground}' for --foreground.");
+
+        if (Colors != null)
+        {
+            foreach (var c in Colors)
+            {
+                var eq = c.IndexOf('=');
+                if (eq <= 0 || eq >= c.Length - 1)
+                    return SpectreValidation.Error($"Invalid color override '{c}'. Expected '<token>=<hex>'.");
+                var token = c[..eq].Trim();
+                var hex = c[(eq + 1)..].Trim();
+                if (!VaultThemeCommandHelpers.ColorTokens.ContainsKey(token))
+                    return SpectreValidation.Error($"Unknown color token '{token}' in --color '{c}'.");
+                if (!VaultThemeCommandHelpers.IsHexColor(hex))
+                    return SpectreValidation.Error($"Invalid hex color '{hex}' in --color '{c}'.");
+            }
+        }
+
+        return SpectreValidation.Success();
+    }
+}
+
+public class VaultThemeSetSettings : CommandSettings
+{
+    public static readonly string[] ValidStandardFields =
+    [
+        "name", "description", "mode", "font", "font-size",
+        "radius-boxes", "radius-fields", "radius-selectors",
+        "shadow-boxes", "shadow-fields", "shadow-selectors", "preview"
+    ];
+
+    [Description("Theme ID")]
+    [CommandArgument(0, "<id>")]
+    public string Id { get; init; } = "";
+
+    [Description("Field or color token to update")]
+    [CommandArgument(1, "<field>")]
+    public string Field { get; init; } = "";
+
+    [Description("New value")]
+    [CommandArgument(2, "<value>")]
+    public string Value { get; init; } = "";
+
+    [Description("Target vault ID")]
+    [CommandOption("--vault")]
+    public string? VaultId { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var idValidation = CliValidation.RequireNonEmpty(Id, "id");
+        if (!idValidation.Successful)
+            return idValidation;
+
+        if (string.IsNullOrWhiteSpace(Field))
+            return SpectreValidation.Error($"<field> is required and cannot be empty. Valid fields: {string.Join(", ", ValidStandardFields)}");
+
+        var isStandard = ValidStandardFields.Contains(Field, StringComparer.OrdinalIgnoreCase);
+        var isColor = false;
+        if (!isStandard)
+        {
+            var token = Field;
+            if (token.StartsWith("light.", StringComparison.OrdinalIgnoreCase))
+                token = token[6..];
+            else if (token.StartsWith("dark.", StringComparison.OrdinalIgnoreCase))
+                token = token[5..];
+
+            isColor = VaultThemeCommandHelpers.ColorTokens.ContainsKey(token);
+        }
+
+        if (!isStandard && !isColor)
+            return SpectreValidation.Error($"Unknown field '{Field}'. Valid fields: {string.Join(", ", ValidStandardFields)}");
+
+        if (isColor && !VaultThemeCommandHelpers.IsHexColor(Value))
+            return SpectreValidation.Error($"Invalid hex color '{Value}' for color field '{Field}'. Expected format: #RGB, #RRGGBB, or #RRGGBBAA.");
+
+        if (Field.Equals("preview", StringComparison.OrdinalIgnoreCase))
+        {
+            var parts = Value.Split(',', StringSplitOptions.TrimEntries);
+            if (parts.Length != 4 || parts.Any(p => !VaultThemeCommandHelpers.IsHexColor(p)))
+                return SpectreValidation.Error($"Invalid preview colors '{Value}'. Expected four comma-separated hex colors (e.g. '#111,#222,#333,#444').");
+        }
+
+        if (Field.Equals("mode", StringComparison.OrdinalIgnoreCase))
+        {
+            var modeValidation = CliValidation.ValidateOneOf(Value, "mode", ["light", "dark"]);
+            if (!modeValidation.Successful)
+                return modeValidation;
+        }
+
+        if (Field.Equals("shadow-boxes", StringComparison.OrdinalIgnoreCase) ||
+            Field.Equals("shadow-fields", StringComparison.OrdinalIgnoreCase) ||
+            Field.Equals("shadow-selectors", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!VaultCommandHelpers.TryParseBool(Value, out _))
+                return SpectreValidation.Error($"Invalid boolean value '{Value}' for '{Field}'. Expected true, false, yes, or no.");
+        }
+
+        return SpectreValidation.Success();
+    }
+}
+
+public class VaultThemeDeleteSettings : CommandSettings
+{
+    [Description("Theme ID to delete")]
+    [CommandArgument(0, "<theme-id>")]
+    public string ThemeId { get; init; } = "";
+
+    [Description("Target vault ID")]
+    [CommandOption("--vault")]
+    public string? VaultId { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(ThemeId, "theme-id");
+    }
+}
+
+public class VaultThemeApplySettings : CommandSettings
+{
+    [Description("Theme ID to apply")]
+    [CommandArgument(0, "<theme-id>")]
+    public string ThemeId { get; init; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(ThemeId, "theme-id");
+    }
+}
+
+// --- Commands ---
+
+public class VaultThemeListCommand(IVaultService vaultService) : AsyncCommand<VaultThemeListSettings>
+{
+    protected override async Task<int> ExecuteAsync(CommandContext context, VaultThemeListSettings settings, CancellationToken cancellationToken)
+    {
+        var themes = await vaultService.GetThemesAsync(settings.VaultId);
+
+        if (settings.Json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(themes, VaultThemeCommandHelpers.ManifestJsonOptions));
+            return 0;
+        }
+
+        if (themes.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No themes found in vault.[/]");
+            return 0;
+        }
+
+        var rows = themes.Select(t => (IReadOnlyList<string>)new[]
+        {
+            t.Id,
+            t.Name,
+            t.IsDark ? "Dark" : "Light",
+            t.Description,
+            string.Join(", ", t.PreviewColors ?? []),
+            t.UpdatedAt.ToString("yyyy-MM-dd HH:mm:ss"),
+            t.UpdatedBy ?? "-"
+        });
+
+        CliOutput.WriteTable(["Id", "Name", "Mode", "Description", "Preview", "Updated", "Updated By"], rows);
+        return 0;
+    }
+}
+
+public class VaultThemeGetCommand(IVaultService vaultService) : AsyncCommand<VaultThemeGetSettings>
+{
+    protected override async Task<int> ExecuteAsync(CommandContext context, VaultThemeGetSettings settings, CancellationToken cancellationToken)
+    {
+        var themes = await vaultService.GetThemesAsync(settings.VaultId);
+        var theme = VaultThemeCommandHelpers.FindTheme(themes, settings.ThemeId);
+        if (theme == null)
+        {
+            return VaultThemeCommandHelpers.WriteNotFound(settings.ThemeId, themes);
+        }
+
+        if (settings.Json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(theme, VaultThemeCommandHelpers.ManifestJsonOptions));
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine($"[bold]Id:[/] {theme.Id.EscapeMarkup()}");
+        AnsiConsole.MarkupLine($"[bold]Name:[/] {theme.Name.EscapeMarkup()}");
+        AnsiConsole.MarkupLine($"[bold]Description:[/] {(string.IsNullOrWhiteSpace(theme.Description) ? "-" : theme.Description.EscapeMarkup())}");
+        AnsiConsole.MarkupLine($"[bold]Mode:[/] {(theme.IsDark ? "Dark" : "Light")}");
+        AnsiConsole.MarkupLine($"[bold]Preview:[/] {string.Join(", ", theme.PreviewColors ?? [])}");
+        AnsiConsole.MarkupLine($"[bold]Font:[/] {(string.IsNullOrWhiteSpace(theme.IvyTheme.FontFamily) ? "-" : theme.IvyTheme.FontFamily.EscapeMarkup())}");
+        AnsiConsole.MarkupLine($"[bold]Font Size:[/] {(string.IsNullOrWhiteSpace(theme.IvyTheme.FontSize) ? "-" : theme.IvyTheme.FontSize.EscapeMarkup())}");
+        AnsiConsole.MarkupLine($"[bold]Border radii:[/] Boxes={theme.IvyTheme.BorderRadiusBoxes ?? "-"}, Fields={theme.IvyTheme.BorderRadiusFields ?? "-"}, Selectors={theme.IvyTheme.BorderRadiusSelectors ?? "-"}");
+        AnsiConsole.MarkupLine($"[bold]Shadows:[/] Boxes={theme.IvyTheme.ShadowBoxes}, Fields={theme.IvyTheme.ShadowFields}, Selectors={theme.IvyTheme.ShadowSelectors}");
+        AnsiConsole.MarkupLine($"[bold]Updated:[/] {theme.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
+        AnsiConsole.MarkupLine($"[bold]Updated By:[/] {(string.IsNullOrWhiteSpace(theme.UpdatedBy) ? "-" : theme.UpdatedBy.EscapeMarkup())}");
+
+        var lightColors = theme.IvyTheme.Colors?.Light ?? ThemeColors.DefaultLight;
+        var darkColors = theme.IvyTheme.Colors?.Dark ?? ThemeColors.DefaultDark;
+
+        var colorRows = VaultThemeCommandHelpers.ColorTokens.Select(kvp => (IReadOnlyList<string>)new[]
+        {
+            kvp.Key,
+            kvp.Value.Get(lightColors) ?? "-",
+            kvp.Value.Get(darkColors) ?? "-"
+        });
+
+        CliOutput.WriteTable(["Token", "Light", "Dark"], colorRows);
+        return 0;
+    }
+}
+
+public class VaultThemeAddCommand(IVaultService vaultService) : AsyncCommand<VaultThemeAddSettings>
+{
+    protected override async Task<int> ExecuteAsync(CommandContext context, VaultThemeAddSettings settings, CancellationToken cancellationToken)
+    {
+        var content = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, "");
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] Theme content cannot be empty.");
+            return 1;
+        }
+
+        VaultThemeManifest? manifest = null;
+        var deserializeOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip
+        };
+
+        try
+        {
+            manifest = JsonSerializer.Deserialize<VaultThemeManifest>(content, deserializeOptions);
+        }
+        catch
+        {
+            // Fall through to TryImportTheme
+        }
+
+        if (manifest?.IvyTheme?.Colors == null || (manifest.IvyTheme.Colors.Light == null && manifest.IvyTheme.Colors.Dark == null))
+        {
+            if (VaultThemesDialog.TryImportTheme(content, out var importedTheme, out var importError))
+            {
+                manifest = new VaultThemeManifest
+                {
+                    Id = settings.Id ?? "",
+                    Name = settings.Name ?? importedTheme.Name,
+                    Description = "",
+                    IsDark = false,
+                    PreviewColors = TendrilThemes.ExtractPreviewColors(importedTheme, false),
+                    IvyTheme = importedTheme
+                };
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] Failed to parse theme: {(importError ?? "Invalid theme format").EscapeMarkup()}");
+                return 1;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.Id))
+            manifest.Id = settings.Id;
+        if (!string.IsNullOrWhiteSpace(settings.Name))
+        {
+            manifest.Name = settings.Name;
+            manifest.IvyTheme.Name = settings.Name;
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Name))
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] Theme name cannot be empty.");
+            return 1;
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Id))
+        {
+            manifest.Id = VaultThemeCommandHelpers.NormalizeId(manifest.Name);
+        }
+        else
+        {
+            manifest.Id = VaultThemeCommandHelpers.NormalizeId(manifest.Id);
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Id))
+        {
+            AnsiConsole.MarkupLine("[red]Error:[/] Theme id cannot be empty.");
+            return 1;
+        }
+
+        var result = await vaultService.SaveThemeToVaultAsync(manifest, settings.VaultId);
+        if (result.Success)
+        {
+            AnsiConsole.MarkupLine($"[green]Theme '{manifest.Id.EscapeMarkup()}' added to vault successfully.[/]");
+            return 0;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {result.Message.EscapeMarkup()}{(result.ErrorMessage != null ? $": {result.ErrorMessage.EscapeMarkup()}" : "")}");
+            return 1;
+        }
+    }
+}
+
+public class VaultThemeCreateCommand(IVaultService vaultService) : AsyncCommand<VaultThemeCreateSettings>
+{
+    protected override async Task<int> ExecuteAsync(CommandContext context, VaultThemeCreateSettings settings, CancellationToken cancellationToken)
+    {
+        Theme theme;
+        bool isDark;
+
+        if (!string.IsNullOrWhiteSpace(settings.BasePreset))
+        {
+            var basePreset = TendrilThemes.GetTheme(settings.BasePreset);
+            theme = TendrilThemes.CloneTheme(basePreset.IvyTheme);
+            isDark = basePreset.IsDark;
+        }
+        else
+        {
+            theme = TendrilThemes.CloneTheme(Theme.Default);
+            isDark = false;
+        }
+
+        if (settings.Dark) isDark = true;
+        if (settings.Light) isDark = false;
+
+        theme.Colors ??= new ThemeColorScheme();
+        theme.Colors.Light ??= TendrilThemes.CloneThemeColors(ThemeColors.DefaultLight);
+        theme.Colors.Dark ??= TendrilThemes.CloneThemeColors(ThemeColors.DefaultDark);
+
+        var targetModes = new List<ThemeColors>();
+        var applyTo = settings.ApplyTo?.ToLowerInvariant();
+        if (applyTo == "both")
+        {
+            targetModes.Add(theme.Colors.Light);
+            targetModes.Add(theme.Colors.Dark);
+        }
+        else if (applyTo == "light")
+        {
+            targetModes.Add(theme.Colors.Light);
+        }
+        else if (applyTo == "dark")
+        {
+            targetModes.Add(theme.Colors.Dark);
+        }
+        else
+        {
+            targetModes.Add(isDark ? theme.Colors.Dark : theme.Colors.Light);
+        }
+
+        foreach (var target in targetModes)
+        {
+            if (settings.Primary != null) target.Primary = settings.Primary;
+            if (settings.Secondary != null) target.Secondary = settings.Secondary;
+            if (settings.Accent != null) target.Accent = settings.Accent;
+            if (settings.Background != null) target.Background = settings.Background;
+            if (settings.Foreground != null) target.Foreground = settings.Foreground;
+
+            if (settings.Colors != null)
+            {
+                foreach (var c in settings.Colors)
+                {
+                    var eq = c.IndexOf('=');
+                    if (eq > 0)
+                    {
+                        var token = c[..eq].Trim();
+                        var hex = c[(eq + 1)..].Trim();
+                        if (VaultThemeCommandHelpers.ColorTokens.TryGetValue(token, out var accessor))
+                        {
+                            accessor.Set(target, hex);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.Font)) theme.FontFamily = settings.Font;
+        if (!string.IsNullOrWhiteSpace(settings.FontSize)) theme.FontSize = settings.FontSize;
+        if (!string.IsNullOrWhiteSpace(settings.Radius))
+        {
+            theme.BorderRadiusBoxes = settings.Radius;
+            theme.BorderRadiusFields = settings.Radius;
+            theme.BorderRadiusSelectors = settings.Radius;
+        }
+        theme.Name = settings.Name;
+
+        var curColors = isDark ? theme.Colors.Dark : theme.Colors.Light;
+        string[] previewColors =
+        [
+            curColors.Primary ?? "#18181b",
+            curColors.Secondary ?? "#71717a",
+            curColors.Accent ?? "#27272a",
+            curColors.Background ?? "#ffffff"
+        ];
+
+        var normalizedId = VaultThemeCommandHelpers.NormalizeId(settings.Id);
+        var manifest = new VaultThemeManifest
+        {
+            Id = normalizedId,
+            Name = settings.Name,
+            Description = settings.Description ?? "",
+            IsDark = isDark,
+            PreviewColors = previewColors,
+            IvyTheme = theme
+        };
+
+        var result = await vaultService.SaveThemeToVaultAsync(manifest, settings.VaultId);
+        if (result.Success)
+        {
+            AnsiConsole.MarkupLine($"[green]Theme '{manifest.Id.EscapeMarkup()}' created and saved to vault.[/]");
+            return 0;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {result.Message.EscapeMarkup()}");
+            return 1;
+        }
+    }
+}
+
+public class VaultThemeSetCommand(IVaultService vaultService) : AsyncCommand<VaultThemeSetSettings>
+{
+    protected override async Task<int> ExecuteAsync(CommandContext context, VaultThemeSetSettings settings, CancellationToken cancellationToken)
+    {
+        var themes = await vaultService.GetThemesAsync(settings.VaultId);
+        var theme = VaultThemeCommandHelpers.FindTheme(themes, settings.Id);
+        if (theme == null)
+        {
+            return VaultThemeCommandHelpers.WriteNotFound(settings.Id, themes);
+        }
+
+        var field = settings.Field;
+        if (field.Equals("name", StringComparison.OrdinalIgnoreCase))
+        {
+            theme.Name = settings.Value;
+            theme.IvyTheme.Name = settings.Value;
+        }
+        else if (field.Equals("description", StringComparison.OrdinalIgnoreCase))
+        {
+            theme.Description = settings.Value;
+        }
+        else if (field.Equals("mode", StringComparison.OrdinalIgnoreCase))
+        {
+            theme.IsDark = settings.Value.Equals("dark", StringComparison.OrdinalIgnoreCase);
+        }
+        else if (field.Equals("font", StringComparison.OrdinalIgnoreCase))
+        {
+            theme.IvyTheme.FontFamily = settings.Value;
+        }
+        else if (field.Equals("font-size", StringComparison.OrdinalIgnoreCase))
+        {
+            theme.IvyTheme.FontSize = settings.Value;
+        }
+        else if (field.Equals("radius-boxes", StringComparison.OrdinalIgnoreCase))
+        {
+            theme.IvyTheme.BorderRadiusBoxes = settings.Value;
+        }
+        else if (field.Equals("radius-fields", StringComparison.OrdinalIgnoreCase))
+        {
+            theme.IvyTheme.BorderRadiusFields = settings.Value;
+        }
+        else if (field.Equals("radius-selectors", StringComparison.OrdinalIgnoreCase))
+        {
+            theme.IvyTheme.BorderRadiusSelectors = settings.Value;
+        }
+        else if (field.Equals("shadow-boxes", StringComparison.OrdinalIgnoreCase))
+        {
+            if (VaultCommandHelpers.TryParseBool(settings.Value, out var val))
+                theme.IvyTheme.ShadowBoxes = val;
+        }
+        else if (field.Equals("shadow-fields", StringComparison.OrdinalIgnoreCase))
+        {
+            if (VaultCommandHelpers.TryParseBool(settings.Value, out var val))
+                theme.IvyTheme.ShadowFields = val;
+        }
+        else if (field.Equals("shadow-selectors", StringComparison.OrdinalIgnoreCase))
+        {
+            if (VaultCommandHelpers.TryParseBool(settings.Value, out var val))
+                theme.IvyTheme.ShadowSelectors = val;
+        }
+        else if (field.Equals("preview", StringComparison.OrdinalIgnoreCase))
+        {
+            theme.PreviewColors = settings.Value.Split(',', StringSplitOptions.TrimEntries);
+        }
+        else
+        {
+            theme.IvyTheme.Colors ??= new ThemeColorScheme();
+            theme.IvyTheme.Colors.Light ??= TendrilThemes.CloneThemeColors(ThemeColors.DefaultLight);
+            theme.IvyTheme.Colors.Dark ??= TendrilThemes.CloneThemeColors(ThemeColors.DefaultDark);
+
+            ThemeColors target;
+            string token;
+            if (field.StartsWith("light.", StringComparison.OrdinalIgnoreCase))
+            {
+                target = theme.IvyTheme.Colors.Light;
+                token = field[6..];
+            }
+            else if (field.StartsWith("dark.", StringComparison.OrdinalIgnoreCase))
+            {
+                target = theme.IvyTheme.Colors.Dark;
+                token = field[5..];
+            }
+            else
+            {
+                target = theme.IsDark ? theme.IvyTheme.Colors.Dark : theme.IvyTheme.Colors.Light;
+                token = field;
+            }
+
+            if (VaultThemeCommandHelpers.ColorTokens.TryGetValue(token, out var accessor))
+            {
+                accessor.Set(target, settings.Value);
+            }
+        }
+
+        var result = await vaultService.SaveThemeToVaultAsync(theme, settings.VaultId);
+        if (result.Success)
+        {
+            AnsiConsole.MarkupLine($"Updated {settings.Field} on theme '{theme.Id.EscapeMarkup()}'.");
+            return 0;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {result.Message.EscapeMarkup()}");
+            return 1;
+        }
+    }
+}
+
+public class VaultThemeDeleteCommand(IVaultService vaultService) : AsyncCommand<VaultThemeDeleteSettings>
+{
+    protected override async Task<int> ExecuteAsync(CommandContext context, VaultThemeDeleteSettings settings, CancellationToken cancellationToken)
+    {
+        var themes = await vaultService.GetThemesAsync(settings.VaultId);
+        var theme = VaultThemeCommandHelpers.FindTheme(themes, settings.ThemeId);
+        if (theme == null)
+        {
+            return VaultThemeCommandHelpers.WriteNotFound(settings.ThemeId, themes);
+        }
+
+        var result = await vaultService.DeleteThemeFromVaultAsync(theme.Id, settings.VaultId);
+        if (result.Success)
+        {
+            AnsiConsole.MarkupLine($"[green]Theme '{theme.Id.EscapeMarkup()}' deleted from vault successfully.[/]");
+            return 0;
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {result.Message.EscapeMarkup()}");
+            return 1;
+        }
+    }
+}
+
+public class VaultThemeApplyCommand(IVaultService vaultService, ConfigService config) : AsyncCommand<VaultThemeApplySettings>
+{
+    protected override Task<int> ExecuteAsync(CommandContext context, VaultThemeApplySettings settings, CancellationToken cancellationToken)
+    {
+        vaultService.LoadThemesIntoRegistry();
+
+        string resolvedId;
+        try
+        {
+            resolvedId = ConfigSetCommand.ValidateTheme(settings.ThemeId);
+        }
+        catch (ArgumentException ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message.EscapeMarkup()}");
+            return Task.FromResult(1);
+        }
+
+        config.MutateAndSave(s => s.Theme = resolvedId);
+        AnsiConsole.MarkupLine($"Active theme set to '{resolvedId.EscapeMarkup()}'.");
+        return Task.FromResult(0);
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -889,6 +889,24 @@ public class Program
                     .WithDescription("Export project(s) and create a pull request to the vault repository");
                 vault.AddCommand<VaultDeleteCommand>("delete")
                     .WithDescription("Delete a project from the vault repository and create a pull request");
+
+                vault.AddBranch("theme", theme =>
+                {
+                    theme.AddCommand<VaultThemeListCommand>("list")
+                        .WithDescription("List team themes available in the vault");
+                    theme.AddCommand<VaultThemeGetCommand>("get")
+                        .WithDescription("Get details of a vault theme");
+                    theme.AddCommand<VaultThemeAddCommand>("add")
+                        .WithDescription("Add or import a theme into the vault");
+                    theme.AddCommand<VaultThemeCreateCommand>("create")
+                        .WithDescription("Create a new theme and save it to the vault");
+                    theme.AddCommand<VaultThemeSetCommand>("set")
+                        .WithDescription("Update a property or color token on a vault theme");
+                    theme.AddCommand<VaultThemeDeleteCommand>("delete")
+                        .WithDescription("Delete a theme from the vault");
+                    theme.AddCommand<VaultThemeApplyCommand>("apply")
+                        .WithDescription("Apply a theme as the active Tendril theme");
+                });
             });
         });
         return app;

--- a/src/Ivy.Tendril/Themes/TendrilThemes.cs
+++ b/src/Ivy.Tendril/Themes/TendrilThemes.cs
@@ -1338,4 +1338,57 @@ public static class TendrilThemes
     {
         client.SetThemeMode(ParseThemeMode(mode));
     }
+
+    public static Theme CloneTheme(Theme source)
+    {
+        return new Theme
+        {
+            Name = source.Name,
+            FontFamily = source.FontFamily,
+            FontSize = source.FontSize,
+            BorderRadiusBoxes = source.BorderRadiusBoxes,
+            BorderRadiusFields = source.BorderRadiusFields,
+            BorderRadiusSelectors = source.BorderRadiusSelectors,
+            ShadowBoxes = source.ShadowBoxes,
+            ShadowFields = source.ShadowFields,
+            ShadowSelectors = source.ShadowSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = CloneThemeColors(source.Colors?.Light ?? ThemeColors.DefaultLight),
+                Dark = CloneThemeColors(source.Colors?.Dark ?? ThemeColors.DefaultDark)
+            }
+        };
+    }
+
+    public static ThemeColors CloneThemeColors(ThemeColors source)
+    {
+        return new ThemeColors
+        {
+            Primary = source.Primary,
+            PrimaryForeground = source.PrimaryForeground,
+            Secondary = source.Secondary,
+            SecondaryForeground = source.SecondaryForeground,
+            Background = source.Background,
+            Foreground = source.Foreground,
+            Destructive = source.Destructive,
+            DestructiveForeground = source.DestructiveForeground,
+            Success = source.Success,
+            SuccessForeground = source.SuccessForeground,
+            Warning = source.Warning,
+            WarningForeground = source.WarningForeground,
+            Info = source.Info,
+            InfoForeground = source.InfoForeground,
+            Border = source.Border,
+            Input = source.Input,
+            Ring = source.Ring,
+            Muted = source.Muted,
+            MutedForeground = source.MutedForeground,
+            Accent = source.Accent,
+            AccentForeground = source.AccentForeground,
+            Card = source.Card,
+            CardForeground = source.CardForeground,
+            Popover = source.Popover,
+            PopoverForeground = source.PopoverForeground
+        };
+    }
 }


### PR DESCRIPTION
# Summary

## Changes

Implemented the `tendril vault theme` CLI command branch in Spectre.Console.Cli, providing headless management of team vault themes. This allows users to list, get, add, create, set, delete, and apply vault themes directly from the command line.

## API Changes

- Added CLI command branch `tendril vault theme` with seven commands: `list`, `get`, `add`, `create`, `set`, `delete`, and `apply`.
- Added public static methods `TendrilThemes.CloneTheme(Theme source)` and `TendrilThemes.CloneThemeColors(ThemeColors source)`.
- Added public command and settings classes in `Ivy.Tendril.Commands`: `VaultThemeListCommand`, `VaultThemeGetCommand`, `VaultThemeAddCommand`, `VaultThemeCreateCommand`, `VaultThemeSetCommand`, `VaultThemeDeleteCommand`, `VaultThemeApplyCommand`, and corresponding settings types.

## Files Modified

- `src/Ivy.Tendril/Themes/TendrilThemes.cs`: Added `CloneTheme` and `CloneThemeColors` helper methods.
- `src/Ivy.Tendril/Apps/Settings/Dialogs/VaultThemesDialog.cs`: Delegated internal cloning methods to `TendrilThemes`.
- `src/Ivy.Tendril/Commands/VaultThemeCommand.cs`: Implemented command classes, settings models, validation logic, and token mapping.
- `src/Ivy.Tendril/Program.cs`: Registered `vault.AddBranch("theme", ...)` with the seven commands.
- `src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/07_Vault.md`: Documented command signatures, option descriptions, and examples.
- `src/Ivy.Tendril.Test/Commands/VaultCommandTests.cs`: Extended `FakeVaultService` with theme inspection and mock properties.
- `src/Ivy.Tendril.Test/Commands/VaultThemeCommandTests.cs`: Added comprehensive unit test suite covering all commands and settings validation.

## Manual Testing

1. Ensure Tendril is running with a connected vault, or run with a simulated environment.
2. Run `tendril vault theme list` to view all vault themes in tabular format, or `tendril vault theme list --json` for raw JSON.
3. Run `tendril vault theme create test-theme --name "Test Theme" --base dracula --dark --primary "#00ffcc"` to create a new theme in the vault.
4. Run `tendril vault theme get test-theme` to inspect details and verify that the primary color token is `#00ffcc`.
5. Run `tendril vault theme apply test-theme` to activate the theme. Observe the confirmation message and check that `config.yaml` has `theme: test-theme`.
6. Run `tendril vault theme delete test-theme` to clean up the theme.

---

## Commits

- 44d6f90a Move theme cloning helpers to TendrilThemes (Plan 00064)
- e51de3a0 Add vault theme CLI command branch (Plan 00064)
- a3ce28a5 Add tests for vault theme CLI commands (Plan 00064)

---

Created using [Ivy Tendril](https://ivy.app).