### PR TITLE
[00069] Standardize Dashboard Trend on 4-Week View with Dashed Expanding Average

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -358,9 +358,11 @@ public class DashboardAppViewModelTests
         Assert.Equal(12.50, trend.PrevCost[^1]);
         Assert.Equal(2.0, trend.PrevPlans[^1]);
 
-        // Records begin Aug 9 (the fallback for a mock with no DailyDataStart), so the window clears it
-        // on Aug 15 and every day after that has a mean.
-        Assert.Null(trend.RollingCost[trend.Dates.IndexOf("2026-08-14")]);
+        // Records begin Aug 9 (the fallback for a mock with no DailyDataStart).
+        // Leading dates have expanding averages rather than null.
+        Assert.NotNull(trend.RollingCost[trend.Dates.IndexOf("2026-08-10")]);
+        Assert.Equal(6.25d, trend.RollingCost[trend.Dates.IndexOf("2026-08-10")]!.Value);
+        Assert.NotNull(trend.RollingCost[trend.Dates.IndexOf("2026-08-14")]);
         Assert.NotNull(trend.RollingCost[trend.Dates.IndexOf("2026-08-15")]);
         Assert.True(trend.RollingCost.Distinct().Count() > 1, "the rolling series is flat");
     }

--- a/src/Ivy.Tendril.Test/Models/RollingAverageCalculatorTests.cs
+++ b/src/Ivy.Tendril.Test/Models/RollingAverageCalculatorTests.cs
@@ -73,18 +73,27 @@ public class RollingAverageCalculatorTests
     }
 
     [Fact]
-    public void Compute_IsNullUntilTheWindowClearsTheDataStart()
+    public void Compute_CalculatesExpandingAverageForHistoryUnderSevenDays()
     {
-        // Records begin on day 4, so day 10 is the first date whose window (days 4..10) sits entirely
-        // inside recorded history.
+        // Records begin on day 4 (index 3). Days 1..3 before dataStart are null.
+        // Days 4..9 (indices 3..8) have 1 to 6 days of history and compute an expanding average.
+        // Day 10 (index 9) is the first full 7-day window.
         var dataStart = Day1.AddDays(3);
 
         var rolling = RollingAverageCalculator.Compute(Days(12), Ramp, dataStart);
 
-        Assert.All(rolling.Take(9), value => Assert.Null(value));
-        Assert.NotNull(rolling[9]);
+        Assert.Null(rolling[0]);
+        Assert.Null(rolling[1]);
+        Assert.Null(rolling[2]);
+
+        Assert.Equal(4d, rolling[3]);
+        Assert.Equal(4.5d, rolling[4]);
+        Assert.Equal(5d, rolling[5]);
+        Assert.Equal(5.5d, rolling[6]);
+        Assert.Equal(6d, rolling[7]);
+        Assert.Equal(6.5d, rolling[8]);
+
         Assert.Equal(7d, rolling[9]);
-        Assert.NotNull(rolling[11]);
     }
 
     [Fact]
@@ -109,6 +118,6 @@ public class RollingAverageCalculatorTests
         // different and worse claim.
         var rolling = RollingAverageCalculator.Compute(Days(10), _ => 0d, Day1);
 
-        Assert.All(rolling.Skip(RollingAverageCalculator.WindowDays - 1), value => Assert.Equal(0d, value));
+        Assert.All(rolling, value => Assert.Equal(0d, value));
     }
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
@@ -69,23 +69,15 @@ describe("TendrilDashboard trend legend", () => {
     renderDashboard(trendOf(30, 100, 4));
 
     expect(screen.getByText("7-day average")).toBeInTheDocument();
-    expect(screen.getByText("Last 12 months")).toBeInTheDocument();
-    expect(screen.getByText("Previous year")).toBeInTheDocument();
+    expect(screen.getByText("Last 4 weeks")).toBeInTheDocument();
+    expect(screen.getByText("Previous 4 weeks")).toBeInTheDocument();
     expect(screen.queryByText(/^Avg /)).not.toBeInTheDocument();
   });
 
-  it("explains the missing curve when no day has a full window yet", () => {
-    const { container } = renderDashboard(trendOf(4, 100, 4, false));
-
-    expect(screen.getByText("7-day average (needs 7 days of history)")).toBeInTheDocument();
-    expect(container.querySelector(".tdb-legend-item-empty")).toBeInTheDocument();
-    expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(0);
-  });
-
-  it("keeps the item unmuted once the curve can be drawn", () => {
+  it("renders the 7-day average legend item and curve", () => {
     const { container } = renderDashboard(trendOf(30, 100, 4));
 
-    expect(container.querySelector(".tdb-legend-item-empty")).not.toBeInTheDocument();
+    expect(screen.getByText("7-day average")).toBeInTheDocument();
     expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(1);
   });
 });
@@ -102,35 +94,13 @@ describe("TendrilDashboard range and metric combinations", () => {
     } as unknown as typeof ResizeObserver;
   });
 
-  // Month and week carry different figures so a toggle that read the wrong payload would show it.
+  // Monthly and weekly carry different figures: activeTrend standardizes on weekly when available, or trend.
   const monthly = trendOf(365, 120, 6);
   const weekly = trendOf(28, 45, 4);
 
-  it("shows the yearly cost series in dollars", () => {
+  it("shows the 4 week cost series in dollars by default", () => {
     const { container } = renderDashboard(monthly, weekly);
 
-    hoverLastPoint(container);
-
-    expect(screen.getByText("Last 12 months: $120.00")).toBeInTheDocument();
-    expect(screen.getByText("7-day average: $120.00")).toBeInTheDocument();
-    expect(screen.getByText("Previous year: $60.00")).toBeInTheDocument();
-  });
-
-  it("shows the yearly plan series counted in plans", () => {
-    const { container } = renderDashboard(monthly, weekly);
-
-    fireEvent.click(screen.getByText("Total Plans"));
-    hoverLastPoint(container);
-
-    expect(screen.getByText("Last 12 months: 6 plans")).toBeInTheDocument();
-    expect(screen.getByText("7-day average: 6 plans")).toBeInTheDocument();
-    expect(screen.getByText("Previous year: 3 plans")).toBeInTheDocument();
-  });
-
-  it("shows the 4 week cost series in dollars", () => {
-    const { container } = renderDashboard(monthly, weekly);
-
-    fireEvent.click(screen.getByText("Week"));
     hoverLastPoint(container);
 
     expect(screen.getByText("Last 4 weeks: $45.00")).toBeInTheDocument();
@@ -141,13 +111,22 @@ describe("TendrilDashboard range and metric combinations", () => {
   it("shows the 4 week plan series counted in plans", () => {
     const { container } = renderDashboard(monthly, weekly);
 
-    fireEvent.click(screen.getByText("Week"));
     fireEvent.click(screen.getByText("Total Plans"));
     hoverLastPoint(container);
 
     expect(screen.getByText("Last 4 weeks: 4 plans")).toBeInTheDocument();
     expect(screen.getByText("7-day average: 4 plans")).toBeInTheDocument();
     expect(screen.getByText("Previous 4 weeks: 2 plans")).toBeInTheDocument();
+  });
+
+  it("falls back to monthly trend if weekly trend is not provided", () => {
+    const { container } = renderDashboard(monthly, null);
+
+    hoverLastPoint(container);
+
+    expect(screen.getByText("Last 4 weeks: $120.00")).toBeInTheDocument();
+    expect(screen.getByText("7-day average: $120.00")).toBeInTheDocument();
+    expect(screen.getByText("Previous 4 weeks: $60.00")).toBeInTheDocument();
   });
 
   it("hides the trend card entirely when there is no series", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -65,7 +65,6 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
 }) => {
   const [tab, setTab] = useState<"cost" | "plans">("cost");
   const [sideTab, setSideTab] = useState<"git" | "prs">("git");
-  const [trendPeriod, setTrendPeriod] = useState<"month" | "week">("month");
 
   const fireEvent = (eventName: string) => {
     if (events.includes(eventName)) {
@@ -87,9 +86,9 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
     { icon: <MessageSquareWarning size={16} />, count: failedCount, label: "Failed", event: "OnJobs" },
   ];
 
-  const activeTrend = trendPeriod === "week" && trendWeekly ? trendWeekly : trend;
-  const currentTrendName = trendPeriod === "week" ? "Last 4 weeks" : "Last 12 months";
-  const previousTrendName = trendPeriod === "week" ? "Previous 4 weeks" : "Previous year";
+  const activeTrend = trendWeekly ?? trend;
+  const currentTrendName = "Last 4 weeks";
+  const previousTrendName = "Previous 4 weeks";
 
   const trendData =
     activeTrend == null
@@ -109,9 +108,6 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
             formatTick: formatCountTick,
             formatValue: formatPlansValue,
           };
-
-  const rolling = trendData?.rolling ?? [];
-  const hasRolling = rolling.some((value) => value != null);
 
   return (
     <div className="tdb-root remove-parent-padding">
@@ -183,29 +179,6 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
                       Total Plans
                     </button>
                   </div>
-                  {trendWeekly && (
-                    <>
-                      <div className="tdb-trend-sep" />
-                      <div className="tdb-granularity-toggle">
-                        <button
-                          type="button"
-                          className="tdb-granularity-btn"
-                          data-active={trendPeriod === "month"}
-                          onClick={() => setTrendPeriod("month")}
-                        >
-                          Month
-                        </button>
-                        <button
-                          type="button"
-                          className="tdb-granularity-btn"
-                          data-active={trendPeriod === "week"}
-                          onClick={() => setTrendPeriod("week")}
-                        >
-                          Week
-                        </button>
-                      </div>
-                    </>
-                  )}
                   <div className="tdb-trend-sep" />
                   <div className="tdb-legend">
                     <span className="tdb-legend-item">
@@ -216,15 +189,9 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
                       <span className="tdb-legend-dash" />
                       {previousTrendName}
                     </span>
-                    {/* Named even when it cannot be drawn: a fresh install should read why the curve
-                        is missing rather than not know it was meant to be there. */}
-                    <span
-                      className={
-                        "tdb-legend-item" + (hasRolling ? "" : " tdb-legend-item-empty")
-                      }
-                    >
+                    <span className="tdb-legend-item">
                       <span className="tdb-legend-line-avg" />
-                      {hasRolling ? "7-day average" : "7-day average (needs 7 days of history)"}
+                      7-day average
                     </span>
                   </div>
                 </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx
@@ -25,8 +25,8 @@ const renderChart = (props: Partial<React.ComponentProps<typeof TrendChart>> = {
       values={props.values ?? dates.map((_, i) => 100 + i * 10)}
       previous={props.previous}
       rolling={props.rolling}
-      currentName={props.currentName ?? "Last 12 months"}
-      previousName={props.previousName ?? "Previous year"}
+      currentName={props.currentName ?? "Last 4 weeks"}
+      previousName={props.previousName ?? "Previous 4 weeks"}
       formatTick={props.formatTick ?? ((v) => `$${v}`)}
       formatValue={props.formatValue ?? formatCurrencyValue}
     />,
@@ -56,6 +56,15 @@ describe("TrendChart rolling average curve", () => {
 
     expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(1);
     expect(container.querySelectorAll(".tdb-trend-avg-line")).toHaveLength(0);
+  });
+
+  it("draws an expanding average curve when rolling series is omitted", () => {
+    const dates = days(14);
+    const values = dates.map((_, i) => 100 + i * 10);
+
+    const { container } = renderChart({ dates, values, rolling: undefined });
+
+    expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(1);
   });
 
   it("breaks the curve into a segment per contiguous run of history", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -312,39 +312,6 @@
   background: var(--tdb-divider);
 }
 
-.tdb-granularity-toggle {
-  display: inline-flex;
-  align-items: center;
-  background: var(--tdb-pill-bg);
-  border-radius: 6px;
-  padding: 2px;
-  gap: 2px;
-}
-
-.tdb-granularity-btn {
-  border: none;
-  background: transparent;
-  font: inherit;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--tdb-muted);
-  padding: 3px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  line-height: 14px;
-  transition: background 0.15s ease, color 0.15s ease;
-}
-
-.tdb-granularity-btn:hover {
-  color: var(--tdb-fg);
-}
-
-.tdb-granularity-btn[data-active="true"] {
-  background: var(--tdb-bg);
-  color: var(--tdb-fg);
-  box-shadow: 0 1px 3px color-mix(in srgb, var(--tdb-fg) 8%, transparent);
-}
-
 .tdb-legend {
   display: flex;
   align-items: center;
@@ -377,14 +344,9 @@
 .tdb-legend-line-avg {
   width: 10px;
   height: 0;
-  border-top: 1.5px solid var(--tdb-muted);
+  border-top: 1.5px dashed var(--tdb-muted);
   opacity: 0.8;
   flex-shrink: 0;
-}
-
-/* The 7-day average legend item when there is not enough history to draw its curve. */
-.tdb-legend-item-empty {
-  opacity: 0.6;
 }
 
 .tdb-trend-chart {
@@ -436,11 +398,12 @@
   stroke-linejoin: round;
 }
 
-/* Solid, so the three series read apart: current solid dark, comparison dashed, this one solid muted. */
+/* Dashed curve for 7-day average to distinguish from solid current usage. */
 .tdb-trend-avg-curve {
   fill: none;
   stroke: var(--tdb-muted);
   stroke-width: 1.5;
+  stroke-dasharray: 4 4;
   stroke-linecap: round;
   stroke-linejoin: round;
   opacity: 0.8;

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -55,21 +55,25 @@ describe("dashboard.css side block and git activity layout", () => {
 });
 
 describe("dashboard.css rolling average curve and legend", () => {
-  it("defines the solid muted average legend indicator", () => {
+  it("defines the dashed muted average legend indicator", () => {
     expect(css).toContain(".tdb-legend-line-avg {");
-    expect(css).toMatch(/\.tdb-legend-line-avg\s*\{[^}]*border-top:\s*1\.5px solid var\(--tdb-muted\)/);
+    expect(css).toMatch(/\.tdb-legend-line-avg\s*\{[^}]*border-top:\s*1\.5px dashed var\(--tdb-muted\)/);
   });
 
-  it("strokes the rolling curve without filling it", () => {
+  it("strokes the rolling curve with dashed pattern without filling it", () => {
     expect(css).toContain(".tdb-trend-avg-curve {");
     expect(css).toMatch(/\.tdb-trend-avg-curve\s*\{[^}]*fill:\s*none;/);
     expect(css).toMatch(/\.tdb-trend-avg-curve\s*\{[^}]*stroke:\s*var\(--tdb-muted\);/);
-    // A dash pattern here would put it back in the comparison line's visual language.
-    expect(css).not.toMatch(/\.tdb-trend-avg-curve\s*\{[^}]*stroke-dasharray/);
+    expect(css).toMatch(/\.tdb-trend-avg-curve\s*\{[^}]*stroke-dasharray:\s*4 4;/);
   });
 
   it("no longer carries the constant horizontal reference line", () => {
     expect(css).not.toContain(".tdb-trend-avg-line");
     expect(css).not.toContain(".tdb-legend-dash-avg");
+  });
+
+  it("no longer carries granularity toggle styles", () => {
+    expect(css).not.toContain(".tdb-granularity-toggle");
+    expect(css).not.toContain(".tdb-granularity-btn");
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
@@ -104,11 +104,12 @@ describe("computeRollingAverage", () => {
     expect(new Set(rolling).size).toBeGreaterThan(1);
   });
 
-  it("leaves the first six entries null, having no full window", () => {
+  it("computes expanding average for the first six entries", () => {
     const rolling = computeRollingAverage([1, 2, 3, 4, 5, 6, 7, 8]);
 
-    expect(rolling.slice(0, 6)).toEqual([null, null, null, null, null, null]);
-    expect(rolling[6]).not.toBeNull();
+    expect(rolling.slice(0, 6)).toEqual([1, 1.5, 2, 2.5, 3, 3.5]);
+    expect(rolling[6]).toBe(4);
+    expect(rolling[7]).toBe(5);
   });
 
   it("averages each entry with the six before it", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -137,9 +137,9 @@ export const computeAverage = (values: number[]): number | null => {
 export const ROLLING_WINDOW_DAYS = 7;
 
 /**
- * Trailing mean of each entry and the `window - 1` before it, null for the leading entries that have
- * no full window. Only a fallback: the server sends a rolling series that also sees the days before
- * the displayed range, and this one cannot.
+ * Trailing mean of each entry and up to `window - 1` before it, calculating an expanding
+ * average for leading entries with fewer days than `window`. Only a fallback: the server sends
+ * a rolling series that also sees the days before the displayed range, and this one cannot.
  */
 export const computeRollingAverage = (
   values: number[],
@@ -147,7 +147,7 @@ export const computeRollingAverage = (
 ): (number | null)[] =>
   values.map((_, index) =>
     index < window - 1
-      ? null
+      ? values.slice(0, index + 1).reduce((acc, v) => acc + v, 0) / (index + 1)
       : values
           .slice(index - window + 1, index + 1)
           .reduce((acc, value) => acc + value, 0) / window,

--- a/src/Ivy.Tendril/Models/RollingAverage.cs
+++ b/src/Ivy.Tendril/Models/RollingAverage.cs
@@ -11,9 +11,9 @@ public static class RollingAverageCalculator
     public const int WindowDays = 7;
 
     /// <summary>
-    ///     Mean of each date and the six calendar days before it. Null where the window reaches before
-    ///     <paramref name="dataStart" />, so an incomplete window is a gap in the curve rather than a
-    ///     value dragged down by days we never recorded.
+    ///     Mean of each date and up to six calendar days before it. For history under seven days,
+    ///     computes an expanding average from dataStart. Null where date is before dataStart or
+    ///     when dataStart is null.
     /// </summary>
     /// <param name="dates">The displayed days. One entry out per entry in.</param>
     /// <param name="valueAt">
@@ -32,20 +32,21 @@ public static class RollingAverageCalculator
 
         foreach (var date in dates)
         {
-            var windowStart = date.AddDays(-(WindowDays - 1));
-            if (dataStart is null || windowStart < dataStart.Value)
+            if (dataStart is null || date < dataStart.Value)
             {
                 result.Add(null);
                 continue;
             }
 
-            var sum = 0d;
-            for (var offset = 0; offset < WindowDays; offset++)
-                sum += valueAt(windowStart.AddDays(offset));
+            var windowStart = date.AddDays(-(WindowDays - 1));
+            var effectiveStart = windowStart < dataStart.Value ? dataStart.Value : windowStart;
+            var dayCount = date.DayNumber - effectiveStart.DayNumber + 1;
 
-            // Divided by the window, never by "the days that had data": that is what makes a recorded
-            // day with no activity pull the mean down, which is the honest reading of a quiet week.
-            result.Add(sum / WindowDays);
+            var sum = 0d;
+            for (var offset = 0; offset < dayCount; offset++)
+                sum += valueAt(effectiveStart.AddDays(offset));
+
+            result.Add(sum / dayCount);
         }
 
         return result;


### PR DESCRIPTION
# Summary

## Changes

Standardized the dashboard trend card on a focused 4-week daily view and eliminated the Month/Week granularity toggle. Updated the 7-day rolling average line to render as a dashed curve in both the chart and legend to avoid visual collision with the solid usage curve. Implemented expanding average calculations in both C# and TypeScript for histories under 7 days so that fresh installations display meaningful trend averages without leading null gaps.

## API Changes

None.

## Files Modified

- **Backend Logic & Tests**:
  - `src/Ivy.Tendril/Models/RollingAverage.cs`: Implemented expanding average calculation when history is fewer than 7 days.
  - `src/Ivy.Tendril.Test/Models/RollingAverageCalculatorTests.cs`: Added unit tests verifying expanding average values from Day 1 to Day 6.
  - `src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs`: Updated weekly trend tests to assert expanding average on leading days.
- **Frontend Components & Styles**:
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx`: Removed granularity toggle state and UI, locked trend view to 4 weeks, and rendered 7-day average legend unconditionally.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`: Removed toggle styles, styled average curve and legend indicators as dashed.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`: Updated fallback rolling average function to calculate expanding averages.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`: Updated CSS tests for dashed curve and removed toggle selectors.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts`: Updated unit tests for expanding rolling averages.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx`: Added expanding average fallback test and updated legend expectations.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx`: Updated dashboard tests to expect 4-week trend series by default.

## Manual Testing

1. Open the Tendril application dashboard (or run the widget sample/storybook).
2. Inspect the trend card:
   - Verify there is no Month/Week toggle.
   - Verify the legend displays "Last 4 weeks", "Previous 4 weeks", and "7-day average".
   - Verify the 7-day average curve is rendered with a dashed stroke.
   - Verify on systems with fewer than 7 days of history that the dashed average curve starts from Day 1 as an expanding average rather than showing a missing or truncated curve.

---
### Commits
- e069aeb6: Standardize dashboard trend on 4-week view with dashed average curve (Plan 00069)
- 7278cdfc: Compute expanding average for history under 7 days (Plan 00069)

---
Created using [Ivy Tendril](https://ivy.app).
