### PR TITLE
[00079] Add Attachment Previews in Chat History

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -557,6 +557,129 @@ describe("ChatWidget File Uploads and Attachments", () => {
     expect(screen.queryByText("[Attached Files]:")).not.toBeInTheDocument();
   });
 
+  it("renders image preview elements pointing to the /ivy/local-file endpoint for image attachments in chat history", () => {
+    const session: ChatSessionDto = {
+      id: "sess-img",
+      title: "Image Preview Test",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [
+        {
+          id: "m-img",
+          role: "user" as const,
+          content: "Here is a screenshot\n\n[Attached Files]:\n- /path/to/screenshot.png\n- /path/to/photo.jpg",
+          timestamp: "12:00",
+        },
+      ],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-img"
+        sessions={[session]}
+      />
+    );
+
+    expect(screen.getByText("Here is a screenshot")).toBeInTheDocument();
+    expect(screen.getByText("screenshot.png")).toBeInTheDocument();
+    expect(screen.getByText("PNG")).toBeInTheDocument();
+    expect(screen.getByText("photo.jpg")).toBeInTheDocument();
+    expect(screen.getByText("JPG")).toBeInTheDocument();
+
+    const imgElements = screen.getAllByRole("img");
+    const previewImgs = imgElements.filter((img) =>
+      img.getAttribute("src")?.includes("/ivy/local-file?path=")
+    );
+    expect(previewImgs.length).toBe(2);
+    expect(previewImgs[0].getAttribute("src")).toContain("/ivy/local-file?path=%2Fpath%2Fto%2Fscreenshot.png");
+    expect(previewImgs[1].getAttribute("src")).toContain("/ivy/local-file?path=%2Fpath%2Fto%2Fphoto.jpg");
+  });
+
+  it("opens lightbox modal with full image view on click, and closes via Escape or close button", () => {
+    const session: ChatSessionDto = {
+      id: "sess-lightbox",
+      title: "Lightbox Test",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [
+        {
+          id: "m-lb",
+          role: "user" as const,
+          content: "Check this out\n\n[Attached Files]:\n- /path/to/preview.png",
+          timestamp: "12:00",
+        },
+      ],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-lightbox"
+        sessions={[session]}
+      />
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    const thumbnailCard = screen.getByText("preview.png").closest(".chat-user-attachment-card");
+    expect(thumbnailCard).toBeInTheDocument();
+    fireEvent.click(thumbnailCard!);
+
+    const modal = screen.getByRole("dialog");
+    expect(modal).toBeInTheDocument();
+    const closeBtn = screen.getByRole("button", { name: /Close preview/i });
+    expect(closeBtn).toBeInTheDocument();
+
+    // Close via close button
+    fireEvent.click(closeBtn);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // Reopen and close via Escape
+    fireEvent.click(thumbnailCard!);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders PDF preview cards with PdfThumbnail for PDF attachments in chat history", () => {
+    const session: ChatSessionDto = {
+      id: "sess-pdf",
+      title: "PDF Preview Test",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [
+        {
+          id: "m-pdf",
+          role: "user" as const,
+          content: "Here is the report\n\n[Attached Files]:\n- /docs/specification.pdf",
+          timestamp: "12:00",
+        },
+      ],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-pdf"
+        sessions={[session]}
+      />
+    );
+
+    expect(screen.getByText("Here is the report")).toBeInTheDocument();
+    expect(screen.getByText("specification.pdf")).toBeInTheDocument();
+    expect(screen.getByText("PDF")).toBeInTheDocument();
+
+    const pdfCard = screen.getByText("specification.pdf").closest(".chat-user-attachment-card-pdf");
+    expect(pdfCard).toBeInTheDocument();
+  });
+
   it("submitting a message with an attached file and empty text prompt emits OnSendMessage with empty prompt", async () => {
     const handleEvent = vi.fn();
     render(

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -8,6 +8,7 @@ import { BlockMarkdown } from "../BlockMarkdown";
 import { QuestionsDraftContext, QuestionsSubmitContext } from "../PlanMarkdown/questionsContext";
 import type { QuestionSubmitCallback, QuestionsDraftState, QuestionsDraftStore } from "../PlanMarkdown/questionsContext";
 import { isImageFile, processImageFile } from "../imageUtils";
+import { getIvyHost } from "../PlanMarkdown/localFiles";
 import "./chat-widget.css";
 
 if (typeof window !== "undefined") {
@@ -87,6 +88,13 @@ const PdfThumbnail: React.FC<{ url: string }> = ({ url }) => {
 const isPdfFile = (nameOrType: string) => {
   const lower = nameOrType.toLowerCase();
   return lower === "application/pdf" || lower.endsWith(".pdf");
+};
+
+const getAttachmentUrl = (filePath: string): string => {
+  if (filePath.startsWith("http://") || filePath.startsWith("https://") || filePath.startsWith("data:") || filePath.startsWith("blob:")) {
+    return filePath;
+  }
+  return `${getIvyHost()}/ivy/local-file?path=${encodeURIComponent(filePath)}`;
 };
 
 const getFileExtBadge = (name: string): string => {
@@ -408,6 +416,21 @@ export function ChatWidget({
       return () => document.removeEventListener("mousedown", handleClickOutside);
     }
   }, [jobsDropdownOpen]);
+
+  const [activeLightboxImage, setActiveLightboxImage] = useState<{ url: string; title: string } | null>(null);
+
+  useEffect(() => {
+    if (!activeLightboxImage) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setActiveLightboxImage(null);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeLightboxImage]);
 
   const sessionSpawnedJobs = activeSession?.spawnedJobs || [];
   const otherRunningJobs = (runningJobs || []).filter(
@@ -1374,6 +1397,61 @@ export function ChatWidget({
                               {attachedPaths.map((filePath, idx) => {
                                 const fileName = filePath.split(/[/\\]/).pop() || filePath;
                                 const ext = fileName.split(".").pop()?.toUpperCase() || "FILE";
+                                const isImage = isImageFile(filePath);
+                                const isPdf = isPdfFile(filePath);
+                                const fileUrl = getAttachmentUrl(filePath);
+
+                                if (isImage) {
+                                  return (
+                                    <div
+                                      key={idx}
+                                      className="chat-user-attachment-card chat-user-attachment-card-clickable"
+                                      title={filePath}
+                                      onClick={() => setActiveLightboxImage({ url: fileUrl, title: fileName })}
+                                      role="button"
+                                      tabIndex={0}
+                                      onKeyDown={(e) => {
+                                        if (e.key === "Enter" || e.key === " ") {
+                                          e.preventDefault();
+                                          setActiveLightboxImage({ url: fileUrl, title: fileName });
+                                        }
+                                      }}
+                                    >
+                                      <div className="chat-user-attachment-preview-container">
+                                        <img
+                                          src={fileUrl}
+                                          alt={fileName}
+                                          className="chat-user-attachment-card-image"
+                                        />
+                                        <div className="chat-user-attachment-preview-overlay" />
+                                      </div>
+                                      <div className="chat-user-attachment-content">
+                                        <span className="chat-user-attachment-name" title={fileName}>{fileName}</span>
+                                        <span className="chat-user-attachment-ext">{ext}</span>
+                                      </div>
+                                    </div>
+                                  );
+                                }
+
+                                if (isPdf) {
+                                  return (
+                                    <div
+                                      key={idx}
+                                      className="chat-user-attachment-card chat-user-attachment-card-pdf"
+                                      title={filePath}
+                                    >
+                                      <div className="chat-user-attachment-preview-container">
+                                        <PdfThumbnail url={fileUrl} />
+                                        <div className="chat-user-attachment-preview-overlay" />
+                                      </div>
+                                      <div className="chat-user-attachment-content">
+                                        <span className="chat-user-attachment-name" title={fileName}>{fileName}</span>
+                                        <span className="chat-user-attachment-ext">PDF</span>
+                                      </div>
+                                    </div>
+                                  );
+                                }
+
                                 return (
                                   <div key={idx} className="chat-user-attachment-badge" title={filePath}>
                                     <Paperclip size={12} className="chat-user-attachment-icon" />
@@ -1739,6 +1817,40 @@ export function ChatWidget({
           </div>
         </div>
       </div>
+      {activeLightboxImage && (
+        <div
+          className="chat-image-lightbox-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label={activeLightboxImage.title || "Image preview"}
+        >
+          <div
+            className="chat-image-lightbox-backdrop"
+            onClick={() => setActiveLightboxImage(null)}
+          />
+          <div className="chat-image-lightbox-container">
+            <button
+              type="button"
+              className="chat-image-lightbox-close"
+              aria-label="Close preview"
+              onClick={() => setActiveLightboxImage(null)}
+            >
+              <X size={18} />
+            </button>
+            <img
+              src={activeLightboxImage.url}
+              alt={activeLightboxImage.title || "Preview"}
+              className="chat-image-lightbox-img"
+              onClick={(e) => e.stopPropagation()}
+            />
+            {activeLightboxImage.title && (
+              <div className="chat-image-lightbox-caption">
+                {activeLightboxImage.title}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -775,11 +775,103 @@
   word-break: break-word;
 }
 
+
 .chat-user-message-attachments {
   display: flex;
   flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.375rem;
+  align-items: flex-start;
+}
+
+.chat-user-attachment-card {
+  position: relative;
+  width: 140px;
+  height: 105px;
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 8px);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  flex-shrink: 0;
+  overflow: hidden;
+  box-sizing: border-box;
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.chat-user-attachment-card-clickable {
+  cursor: pointer;
+}
+
+.chat-user-attachment-card-clickable:hover {
+  border-color: var(--ring);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+.chat-user-attachment-card-clickable:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.chat-user-attachment-preview-container {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: var(--radius, 8px);
+  overflow: hidden;
+}
+
+.chat-user-attachment-card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.chat-user-attachment-preview-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.2) 50%, rgba(0, 0, 0, 0.75) 100%);
+  pointer-events: none;
+}
+
+.chat-user-attachment-content {
+  position: relative;
+  z-index: 3;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.375rem;
-  margin-top: 0.25rem;
+}
+
+.chat-user-attachment-content .chat-user-attachment-name {
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.85);
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-user-attachment-content .chat-user-attachment-ext {
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  background-color: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 3px;
+  padding: 1px 4px;
+  color: #fff;
+  flex-shrink: 0;
 }
 
 .chat-user-attachment-badge {
@@ -817,6 +909,80 @@
   border-radius: 3px;
   padding: 0 4px;
   color: var(--muted-foreground);
+}
+
+/* Lightbox Modal */
+.chat-image-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-image-lightbox-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+}
+
+.chat-image-lightbox-container {
+  position: relative;
+  z-index: 100000;
+  max-width: 90vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-image-lightbox-img {
+  max-width: 90vw;
+  max-height: 85vh;
+  object-fit: contain;
+  border-radius: var(--radius, 8px);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 10px 10px -5px rgba(0, 0, 0, 0.3);
+  user-select: none;
+}
+
+.chat-image-lightbox-close {
+  position: absolute;
+  top: -40px;
+  right: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.chat-image-lightbox-close:hover {
+  background: rgba(255, 255, 255, 0.4);
+  color: #fff;
+}
+
+.chat-image-lightbox-caption {
+  margin-top: 0.75rem;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: center;
+  max-width: 80vw;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
 }
 
 .chat-action-btn {


### PR DESCRIPTION
# Summary

## Changes

Added rich visual preview cards for images and PDF attachments in chat message history, replacing the plain text badges for visual media. Implemented an interactive full-size image lightbox modal dialog with backdrop dismissal, close button, and Escape key navigation.

## API Changes

None.

## Files Modified

- **Frontend Widgets:**
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx`: Added image preview cards, PDF thumbnail rendering using `PdfThumbnail`, lightbox state, and modal dialog overlay with Escape key listener.
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css`: Added responsive flex styling for attachment cards, thumbnail image overlays, and lightbox modal dialog styles.
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Added unit test coverage for image preview URLs, lightbox modal opening and dismissal, and PDF preview cards.

## Manual Testing

1. Launch the Tendril desktop application:
   ```bash
   dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port
   ```
2. Navigate to the Chat view.
3. Attach an image file (PNG, JPG, or WebP) and a PDF file to the composer input, then send the message.
4. Observe the user message bubble:
   - The image attachment renders as a visual thumbnail preview card with filename and format badge.
   - The PDF attachment renders a first-page preview card with filename and "PDF" badge.
   - Any attached non-image, non-PDF file (e.g. `.log`, `.txt`) continues to render as a compact badge with a paperclip icon.
5. Click on the image preview card:
   - A dark translucent lightbox modal opens displaying the image in full size.
   - Press the Escape key or click the "X" close button to dismiss the lightbox.

---

### Commits
- 1553264d: Plan 00079: Add attachment previews in chat history and lightbox modal

---
Created using [Ivy Tendril](https://ivy.app).
