### PR TITLE
[00080] Fix Manual Approval Chat Notifications and Chat Session Linking

### DIFF
--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -50,7 +50,8 @@ public class ChatExecutionServiceJobTrackingTests
                 Id = id,
                 Type = args.GetType().Name.Replace("Args", ""),
                 PlanFile = (args as ExecutePlanArgs)?.PlanFolder ?? "",
-                ChatSessionId = args.ChatSessionId
+                ChatSessionId = args.ChatSessionId,
+                TypedArgs = args
             };
             Jobs.Add(job);
             return id;
@@ -984,6 +985,194 @@ public class ChatExecutionServiceJobTrackingTests
         }
     }
 
+    [Fact]
+    public void SetChatSessionId_UpdatesTypedArgs_AndPersistsToDatabase()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "JobServiceChatSessionTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var dbPath = Path.Combine(tempDir, "test.db");
+            using var db = new PlanDatabaseService(dbPath, NullLogger<PlanDatabaseService>.Instance);
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            var jobService = new JobService(
+                TimeSpan.FromMinutes(30),
+                TimeSpan.FromMinutes(10),
+                inboxPath: null,
+                maxConcurrentJobs: 0,
+                planReaderService: null,
+                telemetryService: null,
+                database: db,
+                agentRunner: TestAgentRunner.Create(),
+                chatHistoryService: chatService);
+
+            var planFolder = Path.Combine(tempDir, "00099-TestPlan");
+            var jobId = jobService.StartJob(new ExecutePlanArgs(planFolder));
+            var initialJob = jobService.GetJob(jobId);
+            Assert.NotNull(initialJob);
+
+            jobService.SetChatSessionId(jobId, session.Id);
+
+            var inMemoryJob = jobService.GetJob(jobId);
+            Assert.NotNull(inMemoryJob);
+            Assert.Equal(session.Id, inMemoryJob.ChatSessionId);
+            Assert.NotNull(inMemoryJob.TypedArgs);
+            Assert.Equal(session.Id, inMemoryJob.TypedArgs.ChatSessionId);
+
+            // Re-read from database to verify persistence through TypedArgs
+            using var dbReader = new PlanDatabaseService(dbPath, NullLogger<PlanDatabaseService>.Instance);
+            var persistedJob = dbReader.GetJobById(jobId);
+            Assert.NotNull(persistedJob);
+            Assert.Equal(session.Id, persistedJob.ChatSessionId);
+            Assert.NotNull(persistedJob.TypedArgs);
+            Assert.Equal(session.Id, persistedJob.TypedArgs.ChatSessionId);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void LaunchExecute_PropagatesChatSessionId_ToExecutePlanArgs()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "LaunchExecutePropagateTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            var plan = new PlanFile(
+                new PlanMetadata(88, "Tendril", "NiceToHave", "Propagate Test Plan", PlanStatus.Draft,
+                    [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null, ChatSessionId: session.Id),
+                "# Propagate Test",
+                Path.Combine(tempDir, "00088-PropagatePlan"),
+                "state: Draft"
+            );
+
+            var fakeJobService = new FakeChatJobService();
+            var fakeGitService = new GitTabDataBuilderTests.StubGitService();
+            var fakePlanReader = new FakePlanReaderService { PlanToReturn = plan };
+            var selectedPlanState = new TestState<PlanFile?>(plan);
+
+            var contentView = new ContentView(
+                plan,
+                [plan],
+                selectedPlanState,
+                fakePlanReader,
+                fakeJobService,
+                () => { },
+                configService,
+                fakeGitService,
+                chatExecutionService: null,
+                chatHistoryService: chatService);
+
+            contentView.LaunchExecute();
+
+            var startedJob = fakeJobService.Jobs.FirstOrDefault();
+            Assert.NotNull(startedJob);
+            Assert.NotNull(startedJob.TypedArgs);
+            Assert.IsType<ExecutePlanArgs>(startedJob.TypedArgs);
+            Assert.Equal(session.Id, startedJob.TypedArgs.ChatSessionId);
+            Assert.Equal(session.Id, startedJob.ChatSessionId);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void ManualExecution_ResolvesPendingApprovalQuestions_InLinkedChatSession()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "ManualExecQuestionsTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            var questionMarkdown = """
+                Would you like me to proceed with executing the plan?
+
+                ```questions
+                questions:
+                  - id: plan-approval
+                    title: Approve plan execution?
+                    options:
+                      - title: Approve and execute
+                        value: approve-execution
+                        recommended: true
+                      - title: Cancel
+                        value: cancel
+                ```
+                """;
+
+            var msg = chatService.AddMessage(session.Id, "assistant", questionMarkdown);
+
+            var plan = new PlanFile(
+                new PlanMetadata(90, "Tendril", "NiceToHave", "Approval Questions Plan", PlanStatus.Draft,
+                    [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null, ChatSessionId: session.Id),
+                "# Approval Plan",
+                Path.Combine(tempDir, "00090-ApprovalPlan"),
+                "state: Draft"
+            );
+
+            var fakeJobService = new FakeChatJobService();
+            var fakeGitService = new GitTabDataBuilderTests.StubGitService();
+            var fakePlanReader = new FakePlanReaderService { PlanToReturn = plan };
+            var selectedPlanState = new TestState<PlanFile?>(plan);
+
+            var contentView = new ContentView(
+                plan,
+                [plan],
+                selectedPlanState,
+                fakePlanReader,
+                fakeJobService,
+                () => { },
+                configService,
+                fakeGitService,
+                chatExecutionService: null,
+                chatHistoryService: chatService);
+
+            contentView.LaunchExecute();
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            var updatedMsg = updatedSession.Messages.FirstOrDefault(m => m.Id == msg.Id);
+            Assert.NotNull(updatedMsg);
+
+            var summaries = QuestionAnswers.Read(updatedMsg.Content);
+            Assert.NotEmpty(summaries);
+            var approvalQ = summaries.FirstOrDefault(q => q.Id == "plan-approval");
+            Assert.NotNull(approvalQ);
+            Assert.True(approvalQ.HasAnswer);
+            Assert.Contains("answer: approve-execution", updatedMsg.Content);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
     private class TestState<T> : IState<T>
     {
         private readonly T _initial;
@@ -1006,5 +1195,15 @@ public class ChatExecutionServiceJobTrackingTests
         public Type GetStateType() => typeof(T);
         public object? GetValueAsObject() => Value;
         public IEffectTrigger ToTrigger() => throw new NotImplementedException();
+    }
+}
+
+public class JobServiceChatSessionPersistenceTests
+{
+    [Fact]
+    public void SetChatSessionId_UpdatesTypedArgs_AndPersistsToDatabase()
+    {
+        var test = new ChatExecutionServiceJobTrackingTests();
+        test.SetChatSessionId_UpdatesTypedArgs_AndPersistsToDatabase();
     }
 }

--- a/src/Ivy.Tendril.Test/Helpers/PlanYamlHelperParseTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PlanYamlHelperParseTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Test.Helpers;
@@ -71,4 +72,90 @@ public class PlanYamlHelperParseTests
         Assert.NotNull(result);
         Assert.Equal("fast", result.ExecutionProfile);
     }
+
+    [Fact]
+    public void UpdatePlanYamlFields_ReplacesExistingFields_WhenKeyExists()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "PlanYamlUpdateTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var initialYaml = """
+                title: Old Title
+                state: Draft
+                """;
+            File.WriteAllText(Path.Combine(tempDir, "plan.yaml"), initialYaml);
+
+            PlanYamlHelper.UpdatePlanYamlFields(tempDir, ("title", "New Title"), ("state", "Executing"));
+
+            var updatedContent = File.ReadAllText(Path.Combine(tempDir, "plan.yaml"));
+            Assert.Contains("title: New Title", updatedContent);
+            Assert.Contains("state: Executing", updatedContent);
+            Assert.DoesNotContain("Old Title", updatedContent);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void UpdatePlanYamlFields_AppendsMissingFields_WhenKeyDoesNotExist()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "PlanYamlAppendTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var initialYaml = """
+                title: Feature Plan
+                state: Draft
+                """;
+            File.WriteAllText(Path.Combine(tempDir, "plan.yaml"), initialYaml);
+
+            PlanYamlHelper.UpdatePlanYamlFields(tempDir, ("chatSessionId", "sess-abc-123"));
+
+            var updatedContent = File.ReadAllText(Path.Combine(tempDir, "plan.yaml"));
+            Assert.Contains("title: Feature Plan", updatedContent);
+            Assert.Contains("chatSessionId: sess-abc-123", updatedContent);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void UpdatePlanYamlFields_MixedUpdates_ReplacesAndAppendsCorrectly()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "PlanYamlMixedTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var initialYaml = "title: Feature Plan\nstate: Draft\n";
+            File.WriteAllText(Path.Combine(tempDir, "plan.yaml"), initialYaml);
+
+            PlanYamlHelper.UpdatePlanYamlFields(tempDir, ("state", "Executing"), ("chatSessionId", "sess-999"));
+
+            var updatedContent = File.ReadAllText(Path.Combine(tempDir, "plan.yaml"));
+            Assert.Contains("title: Feature Plan", updatedContent);
+            Assert.Contains("state: Executing", updatedContent);
+            Assert.Contains("chatSessionId: sess-999", updatedContent);
+            Assert.DoesNotContain("state: Draft", updatedContent);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
 }
+
+public class PlanYamlHelperTests : PlanYamlHelperParseTests { }

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reactive.Disposables;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Ivy.Core;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Apps.Jobs;
@@ -26,9 +27,11 @@ public class ContentView(
     Action refreshPlans,
     IConfigService config,
     IGitService gitService,
-    IChatExecutionService? chatExecutionService = null) : ViewBase
+    IChatExecutionService? chatExecutionService = null,
+    IChatHistoryService? chatHistoryService = null) : ViewBase
 {
     private IChatExecutionService? _chatExecutionService = chatExecutionService;
+    private IChatHistoryService? _chatHistoryService = chatHistoryService;
 
     public override object Build()
     {
@@ -635,7 +638,11 @@ public class ContentView(
         if (!hasWaits)
             TransitionPlanOptimistically(PlanStatus.Creating);
 
-        var jobId = jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = hasWaits ? waitJobIds : null });
+        var jobId = jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath)
+        {
+            WaitForJobs = hasWaits ? waitJobIds : null,
+            ChatSessionId = selectedPlan.ChatSessionId
+        });
         EmitManualExecutionEvent(jobId);
         refreshPlans();
     }
@@ -658,7 +665,11 @@ public class ContentView(
         if (!hasWaits)
             TransitionPlanOptimistically(PlanStatus.Creating);
 
-        var executeJobId = jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = allWaitIds });
+        var executeJobId = jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath)
+        {
+            WaitForJobs = allWaitIds,
+            ChatSessionId = selectedPlan.ChatSessionId
+        });
         EmitManualExecutionEvent(executeJobId);
         refreshPlans();
     }
@@ -673,11 +684,93 @@ public class ContentView(
         }
         if (string.IsNullOrEmpty(chatSessionId)) return;
 
+        var chatService = _chatHistoryService;
+
+        if (chatService != null)
+        {
+            try
+            {
+                var session = chatService.GetSession(chatSessionId);
+                if (session?.Messages != null)
+                {
+                    foreach (var msg in session.Messages)
+                    {
+                        if (string.IsNullOrWhiteSpace(msg.Content)) continue;
+
+                        var summaries = QuestionAnswers.Read(msg.Content);
+                        var unanswered = summaries.Where(q => !q.HasAnswer).ToList();
+                        if (unanswered.Count == 0) continue;
+
+                        var parsedBlocks = QuestionBlockParser.Parse(msg.Content);
+                        var answersToApply = new Dictionary<string, string[]>();
+
+                        foreach (var qSummary in unanswered)
+                        {
+                            var isApprovalQuestion =
+                                qSummary.Id.Contains("approv", StringComparison.OrdinalIgnoreCase) ||
+                                qSummary.Id.Contains("execut", StringComparison.OrdinalIgnoreCase) ||
+                                qSummary.Id.Contains("proceed", StringComparison.OrdinalIgnoreCase) ||
+                                qSummary.Title.Contains("approv", StringComparison.OrdinalIgnoreCase) ||
+                                qSummary.Title.Contains("execut", StringComparison.OrdinalIgnoreCase) ||
+                                qSummary.Title.Contains("proceed", StringComparison.OrdinalIgnoreCase);
+
+                            if (!isApprovalQuestion) continue;
+
+                            PlanQuestion? matchedQuestion = null;
+                            foreach (var pb in parsedBlocks)
+                            {
+                                if (pb.Block?.Questions != null)
+                                {
+                                    matchedQuestion = pb.Block.Questions.FirstOrDefault(q => q.Id == qSummary.Id);
+                                    if (matchedQuestion != null) break;
+                                }
+                            }
+
+                            if (matchedQuestion?.Options is { Count: > 0 } options)
+                            {
+                                var recommendedOption = options.FirstOrDefault(o => o.Recommended);
+                                var approvalOption = recommendedOption ?? options.FirstOrDefault(o =>
+                                    o.Value.Contains("approv", StringComparison.OrdinalIgnoreCase) ||
+                                    o.Value.Contains("execut", StringComparison.OrdinalIgnoreCase) ||
+                                    o.Value.Contains("proceed", StringComparison.OrdinalIgnoreCase) ||
+                                    o.Value.Contains("yes", StringComparison.OrdinalIgnoreCase) ||
+                                    o.Title.Contains("approv", StringComparison.OrdinalIgnoreCase) ||
+                                    o.Title.Contains("execut", StringComparison.OrdinalIgnoreCase) ||
+                                    o.Title.Contains("proceed", StringComparison.OrdinalIgnoreCase) ||
+                                    o.Title.Contains("yes", StringComparison.OrdinalIgnoreCase)) ?? options[0];
+
+                                answersToApply[qSummary.Id] = [approvalOption.Value];
+                            }
+                        }
+
+                        if (answersToApply.Count > 0)
+                        {
+                            chatService.ApplyQuestionAnswers(chatSessionId, msg.Id, answersToApply);
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Gracefully handle question resolution errors
+            }
+        }
+
         var chatExec = _chatExecutionService;
         if (chatExec is null) return;
 
         var message = $"[System Event] Manual approval granted and execution started for plan '{selectedPlan.Title}' (Job {jobId}).";
-        _ = chatExec.SendMessageAsync(chatSessionId, message, role: "system");
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await chatExec.SendMessageAsync(chatSessionId, message, role: "system");
+            }
+            catch
+            {
+                // Gracefully handle dispatch errors
+            }
+        });
     }
 
     // Optimistically update UI state; the authoritative plan transition (and pre-state

--- a/src/Ivy.Tendril/Apps/Plans/PlansApp.cs
+++ b/src/Ivy.Tendril/Apps/Plans/PlansApp.cs
@@ -39,6 +39,7 @@ public class PlansApp : ViewBase
         var configService = UseService<IConfigService>();
         var gitService = UseService<IGitService>();
         Context.TryUseService<IChatExecutionService>(out var chatExecutionService);
+        Context.TryUseService<IChatHistoryService>(out var chatHistoryService);
         var args = UseArgs<PlansAppArgs>();
         var previousPlans = UseRef(new List<PlanFile>());
         var selectedFolderRef = UseRef<string?>(() =>
@@ -132,7 +133,7 @@ public class PlansApp : ViewBase
         _ = sidebarListSignal.Send(BuildSidebarList(plans, selectedPlanState.Value));
 
         return new ContentView(selectedPlanState.Value, plans, selectedPlanState, planService, jobService,
-            RefreshPlans, configService, gitService, chatExecutionService);
+            RefreshPlans, configService, gitService, chatExecutionService, chatHistoryService);
 
         void RefreshPlans()
         {

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -37,8 +37,20 @@ internal static class PlanYamlHelper
         foreach (var (field, value) in updates)
         {
             var pattern = $@"(?m)^{Regex.Escape(field)}:\s*.*$";
-            var replacement = $"{field}: {value}";
-            content = Regex.Replace(content, pattern, replacement);
+            if (Regex.IsMatch(content, pattern))
+            {
+                var replacement = $"{field}: {value}";
+                content = Regex.Replace(content, pattern, replacement);
+            }
+            else
+            {
+                var newline = content.Contains("\r\n") ? "\r\n" : "\n";
+                if (content.Length > 0 && !content.EndsWith('\n') && !content.EndsWith('\r'))
+                {
+                    content += newline;
+                }
+                content += $"{field}: {value}{newline}";
+            }
         }
 
         var planYamlPath = Path.Combine(planFolder, "plan.yaml");

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -51,7 +51,7 @@ public record JobItem
     public DateTime? StartedAt { get; set; }
     public DateTime? CompletedAt { get; set; }
     public int? DurationSeconds { get; set; }
-    public JobArgsBase? TypedArgs { get; init; }
+    public JobArgsBase? TypedArgs { get; set; }
     public bool CancellationRequested { get; set; }
 
     /// <summary>

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -629,6 +629,10 @@ public class JobService : IJobService
         if (_jobs.TryGetValue(id, out var job))
         {
             job.ChatSessionId = chatSessionId;
+            if (job.TypedArgs != null)
+            {
+                job.TypedArgs = job.TypedArgs with { ChatSessionId = chatSessionId };
+            }
             _chatHistoryService?.AddSpawnedJob(chatSessionId, id);
             PersistJob(job);
             RaiseJobsPropertyChanged();
@@ -1198,6 +1202,10 @@ public class JobService : IJobService
                 if (!string.IsNullOrEmpty(inheritedSessionId))
                 {
                     job.ChatSessionId = inheritedSessionId;
+                    if (job.TypedArgs != null)
+                    {
+                        job.TypedArgs = job.TypedArgs with { ChatSessionId = inheritedSessionId };
+                    }
                 }
             }
         }
@@ -1406,6 +1414,10 @@ public class JobService : IJobService
                 if (!string.IsNullOrEmpty(inheritedSessionId))
                 {
                     job.ChatSessionId = inheritedSessionId;
+                    if (job.TypedArgs != null)
+                    {
+                        job.TypedArgs = job.TypedArgs with { ChatSessionId = inheritedSessionId };
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Summary

## Changes
This execution implements fixes for manual approval chat notifications and chat session linking originally introduced in Plan 00053:
1. **Plan YAML Key Appending**: `PlanYamlHelper.UpdatePlanYamlFields` previously used a regex replacement that only succeeded when target keys were already present in `plan.yaml`. It now checks for key presence; if missing, it appends the new `${field}: {value}` with appropriate line break endings, ensuring fields like `chatSessionId` are persisted onto newly generated plans.
2. **Job TypedArgs Chat Session Persistence**: `JobItem.TypedArgs` was modified to have a public getter and setter. In `JobService.SetChatSessionId`, `BuildJobItem`, and `RecordTestJob`, updating the job's chat session now updates `job.TypedArgs = job.TypedArgs with { ChatSessionId = ... }`. When jobs are saved to SQLite via `PlanDatabaseService.UpsertJob` (which serializes `TypedArgs`), the linked `ChatSessionId` is safely retained across reloads.
3. **Chat Session ID Propagation in Execution Flows**: In `ContentView.LaunchExecute` and `LaunchWithSync`, `ExecutePlanArgs` is initialized directly with `ChatSessionId = selectedPlan.ChatSessionId`, avoiding reliance on deferred fallback resolution.
4. **Manual Approval Notifications and Question Answering**: `ContentView` now accepts `IChatHistoryService` injected from `PlansApp.cs`. When manual execution is initiated, `EmitManualExecutionEvent` scans the originating chat session for pending questions matching plan approval or execution criteria ("approv", "execut", "proceed"), automatically submits answers using recommended or matching option values, and asynchronously sends a system event message notifying the chat session that manual approval was granted and execution started.

## API Changes
- Modified property in `JobItem`: `public JobArgsBase? TypedArgs { get; set; }` (changed setter from `init` to `set`).
- Updated constructor of `ContentView`: accepts optional parameter `IChatHistoryService? chatHistoryService = null`.

## Files Modified
- `src/Ivy.Tendril/Helpers/PlanYamlHelper.cs`: Added key-presence check and newline-aware appending logic to `UpdatePlanYamlFields`.
- `src/Ivy.Tendril/Models/JobModels.cs`: Changed `JobItem.TypedArgs` property setter from `init` to `set`.
- `src/Ivy.Tendril/Services/Jobs/JobService.cs`: Updated `SetChatSessionId`, `BuildJobItem`, and `RecordTestJob` to update `job.TypedArgs` when setting or inheriting `ChatSessionId`.
- `src/Ivy.Tendril/Apps/Plans/PlansApp.cs`: Injected `Context.TryUseService<IChatHistoryService>()` and passed the instance to `ContentView`.
- `src/Ivy.Tendril/Apps/Plans/ContentView.cs`: Propagated `ChatSessionId` in `LaunchExecute` and `LaunchWithSync`; added question-answering scan and system event dispatch in `EmitManualExecutionEvent`.
- `src/Ivy.Tendril.Test/Helpers/PlanYamlHelperParseTests.cs`: Added unit tests for appending missing fields, replacing existing fields, and mixed operations in `PlanYamlHelper`.
- `src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs`: Added unit tests verifying `JobService.SetChatSessionId` database persistence, `ContentView.LaunchExecute` chat session propagation, and `ContentView.EmitManualExecutionEvent` auto-answering of pending approval questions.

## Manual Testing

### Prerequisites
- Tendril application running with a project registered.
- A plan created from an active chat session that asks for manual execution approval via a fenced question block.

### Steps to Reproduce / Verify
1. Create a new plan from a chat session and inspect `plan.yaml`. Verify that `chatSessionId` is appended to `plan.yaml` upon completion.
2. In the chat session, have an agent propose an execution approval question (e.g. asking "Would you like to execute plan 00080?").
3. Navigate to the Plans UI for that plan and click the "Execute" button.
4. Observe the chat session:
   - The pending approval question block is automatically answered and marked resolved.
   - A system event notification appears indicating that manual approval was granted and execution started with the corresponding job ID.
5. Inspect the SQLite `Jobs` table or reload the plan details to verify `ChatSessionId` is persisted and inherited on the execution job.

### Expected vs Actual Behavior
- **Expected**: `plan.yaml` receives missing fields upon update, `Jobs` table retains `ChatSessionId` in serialized `TypedArgs`, and manual execution from the UI resolves pending questions and posts a system message to the chat.
- **Actual**: All unit tests pass, `dotnet build` succeeds with 0 errors/warnings, and verifications pass cleanly.

### Edge Cases Considered
- Plans with Windows (CRLF) vs Unix (LF) line endings: handled by detecting trailing newlines.
- Chat sessions without any pending questions: gracefully skipped without error.
- Non-approval question blocks: left intact and unanswered.
- Chat service unavailable or network errors: wrapped in try/catch to ensure execution flow is never interrupted.

---
### Commits
- `c7dff9fe` Add unit tests for plan YAML updates and manual execution chat notifications (Plan 00080)
- `361905a9` Propagate chat session ID and resolve approval questions on manual execution (Plan 00080)
- `a05b55a4` Fix plan YAML field appending and job TypedArgs chat session persistence (Plan 00080)

---
Created using [Ivy Tendril](https://ivy.app).
