### PR TITLE
[00089] Fix Flaky Option Selection in Chat UI Question Blocks

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { fireEvent, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { PlanMarkdown as DraftMarkdown } from "./PlanMarkdown";
 import { QuestionsCallout } from "./QuestionsCallout";
 
@@ -502,6 +502,82 @@ describe("DraftMarkdown interactive questions", () => {
     expect(copy).not.toBeNull();
     expect(copy!.closest("label")).toBeNull();
     expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("selects an option when clicking the card container element", () => {
+    const { container, eventHandler } = renderInteractive(SINGLE);
+
+    const card = container.querySelector<HTMLElement>(".pmv-question-option");
+    expect(card).not.toBeNull();
+    fireEvent.click(card!);
+
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+    expect(eventHandler).toHaveBeenCalledWith("OnAnswersChange", "w1", [
+      { questionId: "budget", answer: ["per-request"] },
+    ]);
+  });
+
+  it("selects an option when clicking inside the option description markdown", () => {
+    const { container, eventHandler } = renderInteractive(RICH_DESCRIPTION);
+
+    const description = container.querySelector<HTMLElement>(".pmv-question-option-description");
+    expect(description).not.toBeNull();
+    const strong = description!.querySelector("strong");
+    expect(strong).not.toBeNull();
+    fireEvent.click(strong!);
+
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+    expect(eventHandler).toHaveBeenCalledWith("OnAnswersChange", "w1", [
+      { questionId: "budget", answer: ["per-request"] },
+    ]);
+  });
+
+  it("ignores card click when clicking interactive elements such as code copy buttons", async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    const { container, eventHandler } = renderInteractive(RICH_DESCRIPTION);
+
+    const copy = container.querySelector<HTMLButtonElement>(
+      ".pmv-question-option-description .pmv-code-copy",
+    );
+    expect(copy).not.toBeNull();
+    await act(async () => {
+      fireEvent.click(copy!);
+    });
+
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("ignores card click when user has an active text selection", () => {
+    const { container, eventHandler } = renderInteractive(SINGLE);
+
+    const selectionSpy = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "selected text",
+    } as Selection);
+
+    const card = container.querySelector<HTMLElement>(".pmv-question-option");
+    expect(card).not.toBeNull();
+    fireEvent.click(card!);
+
+    expect(eventHandler).not.toHaveBeenCalled();
+    selectionSpy.mockRestore();
+  });
+
+  it("toggles other input when clicking the Other card container", () => {
+    const { container } = renderInteractive(SINGLE);
+
+    const otherCard = container.querySelector<HTMLElement>(".pmv-question-option--other");
+    expect(otherCard).not.toBeNull();
+    expect(container.querySelector(".pmv-question-other-input")).toBeNull();
+
+    fireEvent.click(otherCard!);
+
+    const input = container.querySelector<HTMLInputElement>(".pmv-question-other-input");
+    expect(input).not.toBeNull();
   });
 
   it("renders a GFM table in a description", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useState } from "react";
+import React, { useContext, useId, useMemo, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CodeBlock } from "../CodeBlock";
@@ -95,7 +95,8 @@ const QuestionView: React.FC<QuestionViewProps> = ({
     setOtherOpen(typed !== undefined);
   }
 
-  const groupName = `pmv-q-${blockIndex}-${question.id}`;
+  const reactId = useId();
+  const groupName = `pmv-q-${reactId}-${blockIndex}-${question.id}`;
   const otherActive = typed !== undefined;
 
   /**
@@ -195,6 +196,11 @@ const QuestionView: React.FC<QuestionViewProps> = ({
             <div
               key={option.value}
               className={`pmv-question-option${selected ? " pmv-question-option--selected" : ""}`}
+              onClick={(e) => {
+                if ((e.target as HTMLElement).closest("label, input, textarea, button, a")) return;
+                if (window.getSelection()?.toString()) return;
+                selectOption(option);
+              }}
             >
               <label className="pmv-question-option-main">
                 <input
@@ -223,6 +229,11 @@ const QuestionView: React.FC<QuestionViewProps> = ({
         {hasOptions && question.other && (
           <div
             className={`pmv-question-option pmv-question-option--other${otherActive ? " pmv-question-option--selected" : ""}`}
+            onClick={(e) => {
+              if ((e.target as HTMLElement).closest("label, input, textarea, button, a")) return;
+              if (window.getSelection()?.toString()) return;
+              toggleOther();
+            }}
           >
             <label className="pmv-question-other-label">
               <input
@@ -324,30 +335,37 @@ const ChatQuestionsBlock: React.FC<ChatQuestionsBlockProps> = ({ questions, bloc
   );
   const localAnswers = draftState.answers;
 
-  const writeDraft = (next: QuestionsDraftState) => {
-    setDraftState(next);
-    store?.write(blockKey, next);
-  };
-
   const handleLocalAnswer = (questionId: string, answer: string | string[] | null | undefined) => {
-    const next = { ...localAnswers };
-    if (answer === undefined || answer === null || answer === "" || (Array.isArray(answer) && answer.length === 0)) {
-      delete next[questionId];
-    } else if (Array.isArray(answer)) {
-      next[questionId] = answer;
-    } else {
-      next[questionId] = [answer];
-    }
-    writeDraft({ ...draftState, answers: next });
+    setDraftState((prev) => {
+      const nextAnswers = { ...prev.answers };
+      if (answer === undefined || answer === null || answer === "" || (Array.isArray(answer) && answer.length === 0)) {
+        delete nextAnswers[questionId];
+      } else if (Array.isArray(answer)) {
+        nextAnswers[questionId] = answer;
+      } else {
+        nextAnswers[questionId] = [answer];
+      }
+      const nextState = { ...prev, answers: nextAnswers };
+      store?.write(blockKey, nextState);
+      return nextState;
+    });
   };
 
   const handleOtherOpenChange = (questionId: string, open: boolean) => {
-    writeDraft({ ...draftState, otherOpen: { ...draftState.otherOpen, [questionId]: open } });
+    setDraftState((prev) => {
+      const nextState = { ...prev, otherOpen: { ...prev.otherOpen, [questionId]: open } };
+      store?.write(blockKey, nextState);
+      return nextState;
+    });
   };
 
   const hasAnyAnswers = Object.keys(localAnswers).length > 0;
   const clearAll = () => {
-    writeDraft({ answers: {}, otherOpen: {} });
+    setDraftState(() => {
+      const nextState = { answers: {}, otherOpen: {} };
+      store?.write(blockKey, nextState);
+      return nextState;
+    });
   };
 
   const canSubmit = questions.every((q) => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/plan-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/plan-markdown.css
@@ -983,6 +983,7 @@
   border: 1px solid hsl(199 89% 48% / 0.25);
   border-radius: 0.375rem;
   background: var(--background, hsl(0 0% 100% / 0.5));
+  cursor: pointer;
 }
 
 /* Only the radio and title are the label. The description sits outside it so a code block's


### PR DESCRIPTION
# Summary

## Changes

Fixed flaky option selection in Chat UI and Plan Markdown question blocks by expanding the clickable region from the tiny inner label to the full option card and its description. Added click filtering to ignore clicks on nested interactive controls (buttons, links, text inputs) or during active text selection, scoped radio input group names using `useId` to prevent cross-message interference in chat streams, and made draft state updates functional and atomic.

## API Changes

None.

## Files Modified

- **UI Components & Styles**:
  - `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx`: Added card click handlers on standard and Other option containers with interactive/selection filters, generated scoped radio group names with `useId`, and converted `ChatQuestionsBlock` state updates to functional forms.
  - `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/plan-markdown.css`: Added `cursor: pointer` to `.pmv-question-option`.
- **Tests**:
  - `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx`: Added 5 unit tests covering card container clicks, description markdown clicks, interactive element click ignoring, text selection click ignoring, and Other card toggling.

## Manual Testing

1. Launch Tendril or run the widget sample app (`vp dev` in `src/Ivy.Tendril.Widgets/frontend` or start the Tendril desktop application).
2. Open a chat session or a plan revision that renders a question block with options and markdown descriptions.
3. Click anywhere on an option card (including padding or description text outside the radio button and title text): verify the option immediately becomes selected.
4. Try highlighting and selecting text in a description: verify that dragging to select text does not toggle or select the option upon release.
5. If the description has a code snippet with a copy button, click the copy button: verify the code is copied without toggling option selection.
6. Click the Other option card padding: verify the text input opens cleanly.

---
- 39e30123 Fix flaky option selection in Chat UI question blocks (#00089)

---
Created using [Ivy Tendril](https://ivy.app).
