### PR TITLE
[00097] Normalize File Encodings to UTF-8 to Resolve Dotnet Format Errors

### DIFF
--- a/src/Ivy.Tendril.Test/FormatHelperTests.cs
+++ b/src/Ivy.Tendril.Test/FormatHelperTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Globalization;
+using System.Globalization;
+using System.IO;
+using System.Linq;
 using Ivy.Tendril.Helpers;
 using Xunit;
 
@@ -92,5 +94,53 @@ public class FormatHelperTests
     public void FormatExecutionProfile(string? profile, string? expected)
     {
         Assert.Equal(expected, FormatHelper.FormatExecutionProfile(profile));
+    }
+
+    [Fact]
+    public void SourceFiles_DoNotContainUtf8Bom()
+    {
+        var repoRoot = FindRepoRoot();
+        var targetDirs = new[]
+        {
+            Path.Combine(repoRoot, "src", "Ivy.Tendril"),
+            Path.Combine(repoRoot, "src", "Ivy.Tendril.Test")
+        };
+
+        var utf8Bom = new byte[] { 0xEF, 0xBB, 0xBF };
+        var violatingFiles = new List<string>();
+
+        foreach (var dir in targetDirs)
+        {
+            var csFiles = Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories)
+                .Where(f => !f.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar) &&
+                            !f.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar));
+
+            foreach (var file in csFiles)
+            {
+                using var stream = File.OpenRead(file);
+                var header = new byte[3];
+                var bytesRead = stream.Read(header, 0, 3);
+                if (bytesRead == 3 && header.SequenceEqual(utf8Bom))
+                {
+                    violatingFiles.Add(Path.GetRelativePath(repoRoot, file));
+                }
+            }
+        }
+
+        Assert.Empty(violatingFiles);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "src", "Ivy.Tendril", "Ivy.Tendril.slnx")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate repository root from BaseDirectory: " + AppDomain.CurrentDomain.BaseDirectory);
     }
 }

--- a/src/Ivy.Tendril.Test/Services/TelemetryPlanUuidTests.cs
+++ b/src/Ivy.Tendril.Test/Services/TelemetryPlanUuidTests.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Models;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services.Telemetry;
 using Xunit;
 

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Telemetry;
 using Ivy.Tendril.Services.Jobs;

--- a/src/Ivy.Tendril/Apps/Settings/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AddProjectDialog.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Apps.Onboarding;
+using Ivy.Tendril.Apps.Onboarding;
 using Ivy.Tendril.Apps.Onboarding.Models;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/Settings/AddProjectView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AddProjectView.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Apps.Onboarding;
+using Ivy.Tendril.Apps.Onboarding;
 using Ivy.Tendril.Apps.Onboarding.Models;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services.Plans;

--- a/src/Ivy.Tendril/Helpers/FormatHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FormatHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace Ivy.Tendril.Helpers;
 

--- a/src/Ivy.Tendril/Services/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/AgentProviderFactory.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Abstractions;
 
 namespace Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Services/Telemetry/ITelemetryService.cs
+++ b/src/Ivy.Tendril/Services/Telemetry/ITelemetryService.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services.Telemetry;

--- a/src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs
+++ b/src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Text;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Apps.Jobs;

--- a/src/experiments/JobCostSheet/JobCostSheetApp.cs
+++ b/src/experiments/JobCostSheet/JobCostSheetApp.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Apps.Views.Sheets;
+using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services.Jobs;


### PR DESCRIPTION
# Summary

## Changes

Normalized file encodings across the repository by stripping UTF-8 byte-order marks (BOM) from 11 C# source files in `Ivy.Tendril`, `Ivy.Tendril.Test`, and `experiments`. Added an automated regression unit test ensuring that all C# source files in `Ivy.Tendril` and `Ivy.Tendril.Test` remain free of UTF-8 BOM preambles to prevent future `dotnet format` CHARSET diagnostics.

## API Changes

None.

## Files Modified

- **Source File Normalization (BOM Stripped)**:
  - `src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs`
  - `src/Ivy.Tendril/Apps/Settings/AddProjectDialog.cs`
  - `src/Ivy.Tendril/Apps/Settings/AddProjectView.cs`
  - `src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs`
  - `src/Ivy.Tendril/Helpers/FormatHelper.cs`
  - `src/Ivy.Tendril/Services/AgentProviderFactory.cs`
  - `src/Ivy.Tendril/Services/Telemetry/ITelemetryService.cs`
  - `src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs`
  - `src/experiments/JobCostSheet/JobCostSheetApp.cs`
  - `src/Ivy.Tendril.Test/Services/TelemetryPlanUuidTests.cs`
- **Tests**:
  - `src/Ivy.Tendril.Test/FormatHelperTests.cs`: Stripped BOM and added `SourceFiles_DoNotContainUtf8Bom` regression unit test.

## Manual Testing

N/A: internal change with no user-facing behavior. Verification can be confirmed by running:
1. `dotnet format src/Ivy.Tendril/Ivy.Tendril.slnx --verify-no-changes` (no CHARSET errors)
2. `dotnet test src/Ivy.Tendril/Ivy.Tendril.slnx --filter "FullyQualifiedName~FormatHelperTests"` (regression test passes)

---
- `bbff10ee` Add regression unit test for UTF-8 encoding without BOM in source files (Plan 00097)
- `e3e9b435` Normalize file encodings to UTF-8 without BOM across source files (Plan 00097)

---
Created using [Ivy Tendril](https://ivy.app).