### PR TITLE
[00095] Auto Accept Assigned Issues in Inbox

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -2220,5 +2220,42 @@ projects:
         Assert.Equal("InheritGeneral", project.SandboxMode);
         Assert.Equal("AutoImplementPlans", project.AutoImplementPlans);
     }
+
+    [Fact]
+    public void InboxConfig_DefaultValues_AreCorrect()
+    {
+        var config = new InboxConfig();
+        Assert.False(config.AutoAcceptAssignedIssues);
+        Assert.Equal(15, config.CheckIntervalMinutes);
+
+        var settings = new TendrilSettings();
+        Assert.NotNull(settings.Inbox);
+        Assert.False(settings.Inbox.AutoAcceptAssignedIssues);
+        Assert.Equal(15, settings.Inbox.CheckIntervalMinutes);
+    }
+
+    [Fact]
+    public void InboxConfig_RoundTripsThroughYaml()
+    {
+        var settings = new TendrilSettings
+        {
+            Inbox = new InboxConfig
+            {
+                AutoAcceptAssignedIssues = true,
+                CheckIntervalMinutes = 30
+            }
+        };
+
+        var yaml = YamlHelper.Serializer.Serialize(settings);
+        Assert.Contains("inbox:", yaml);
+        Assert.Contains("autoAcceptAssignedIssues: true", yaml);
+        Assert.Contains("checkIntervalMinutes: 30", yaml);
+
+        var deserialized = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml);
+        Assert.NotNull(deserialized);
+        Assert.NotNull(deserialized.Inbox);
+        Assert.True(deserialized.Inbox.AutoAcceptAssignedIssues);
+        Assert.Equal(30, deserialized.Inbox.CheckIntervalMinutes);
+    }
 }
 

--- a/src/Ivy.Tendril.Test/FakePlanReaderService.cs
+++ b/src/Ivy.Tendril.Test/FakePlanReaderService.cs
@@ -19,9 +19,10 @@ internal class FakePlanReaderService : IPlanReaderService
     {
     }
 
+    public List<PlanFile> Plans { get; set; } = [];
     public List<PlanFile> GetPlans(PlanStatus? statusFilter = null)
     {
-        return [];
+        return Plans;
     }
 
     public PlanFile? GetPlanByFolder(string folderPath)

--- a/src/Ivy.Tendril.Test/Services/Inbox/AssignedIssuesAutoImportServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/Inbox/AssignedIssuesAutoImportServiceTests.cs
@@ -1,0 +1,358 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
+using Ivy.Tendril.Services.Inbox;
+using Ivy.Tendril.Services.Jobs;
+using Ivy.Tendril.Services.Plans;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test.Services.Inbox;
+
+[Collection("TendrilHome")]
+public class AssignedIssuesAutoImportServiceTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("auto-import-tests");
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    private ConfigService CreateConfigService(bool autoAccept = true, int interval = 15)
+    {
+        var settings = new TendrilSettings
+        {
+            Inbox = new InboxConfig
+            {
+                AutoAcceptAssignedIssues = autoAccept,
+                CheckIntervalMinutes = interval
+            }
+        };
+
+        var config = new ConfigService(settings);
+        config.SetTendrilHome(_tempDir.Path);
+        return config;
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_WhenDisabled_DoesNotFetchOrImport()
+    {
+        var config = CreateConfigService(autoAccept: false);
+        var github = new TestGithubService
+        {
+            IssuesToReturn =
+            [
+                new GitHubIssue(101, "Fix login", "Login issue description", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/101")
+            ]
+        };
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+
+        await service.RunSyncAsync();
+
+        Assert.Equal(0, github.CallCount);
+        var inboxPath = Path.Combine(_tempDir.Path, "Inbox");
+        if (Directory.Exists(inboxPath))
+        {
+            Assert.Empty(Directory.GetFiles(inboxPath));
+        }
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_WhenEnabled_ImportsNewAssignedIssues()
+    {
+        var config = CreateConfigService(autoAccept: true);
+        var github = new TestGithubService
+        {
+            IssuesToReturn =
+            [
+                new GitHubIssue(101, "Fix login bug", "Login fails with 500 error", ["bug"], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/101")
+            ]
+        };
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+
+        await service.RunSyncAsync();
+
+        Assert.Equal(1, github.CallCount);
+        var inboxPath = Path.Combine(_tempDir.Path, "Inbox");
+        Assert.True(Directory.Exists(inboxPath));
+
+        var files = Directory.GetFiles(inboxPath, "101-*.md");
+        Assert.Single(files);
+
+        var content = await File.ReadAllTextAsync(files[0]);
+        Assert.Contains("project: Auto", content);
+        Assert.Contains("[GitHub Issue #101](https://github.com/owner/repo/issues/101)", content);
+        Assert.Contains("Login fails with 500 error", content);
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_ResolvesProjectOrDefaultsToAuto()
+    {
+        var config = CreateConfigService(autoAccept: true);
+        var frontendProject = new ProjectConfig { Name = "FrontendProject" };
+
+        var github = new TestGithubService
+        {
+            ProjectMap = new Dictionary<string, ProjectConfig>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["org/frontend"] = frontendProject
+            },
+            IssuesToReturn =
+            [
+                new GitHubIssue(201, "Frontend issue", "UI bug", [], ["user1"], "org/frontend", "https://github.com/org/frontend/issues/201"),
+                new GitHubIssue(202, "Backend issue", "API bug", [], ["user1"], "org/unmapped", "https://github.com/org/unmapped/issues/202")
+            ]
+        };
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+
+        await service.RunSyncAsync();
+
+        var inboxPath = Path.Combine(_tempDir.Path, "Inbox");
+        var frontendFiles = Directory.GetFiles(inboxPath, "201-*.md");
+        Assert.Single(frontendFiles);
+        var frontendContent = await File.ReadAllTextAsync(frontendFiles[0]);
+        Assert.Contains("project: FrontendProject", frontendContent);
+
+        var backendFiles = Directory.GetFiles(inboxPath, "202-*.md");
+        Assert.Single(backendFiles);
+        var backendContent = await File.ReadAllTextAsync(backendFiles[0]);
+        Assert.Contains("project: Auto", backendContent);
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_SkipsExistingInboxFiles()
+    {
+        var config = CreateConfigService(autoAccept: true);
+        var inboxPath = Path.Combine(_tempDir.Path, "Inbox");
+        Directory.CreateDirectory(inboxPath);
+
+        // Pre-create .md and .md.processing files
+        await File.WriteAllTextAsync(Path.Combine(inboxPath, "301-existing.md"), "original 301");
+        await File.WriteAllTextAsync(Path.Combine(inboxPath, "302-processing.md.processing"), "original 302");
+
+        var github = new TestGithubService
+        {
+            IssuesToReturn =
+            [
+                new GitHubIssue(301, "Existing issue", "Body 301", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/301"),
+                new GitHubIssue(302, "Processing issue", "Body 302", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/302"),
+                new GitHubIssue(303, "New issue", "Body 303", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/303")
+            ]
+        };
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+
+        await service.RunSyncAsync();
+
+        // 301 and 302 should be untouched
+        var content301 = await File.ReadAllTextAsync(Path.Combine(inboxPath, "301-existing.md"));
+        Assert.Equal("original 301", content301);
+
+        Assert.True(File.Exists(Path.Combine(inboxPath, "302-processing.md.processing")));
+        Assert.False(File.Exists(Path.Combine(inboxPath, "302-processing.md")));
+
+        // 303 should be imported
+        var files303 = Directory.GetFiles(inboxPath, "303-*.md");
+        Assert.Single(files303);
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_SkipsExistingPlans()
+    {
+        var config = CreateConfigService(autoAccept: true);
+
+        var existingPlan = new PlanFile(
+            new PlanMetadata(
+                Id: 1,
+                Project: "Test",
+                Level: "Feature",
+                Title: "Already Planned",
+                State: PlanStatus.Draft,
+                Repos: [],
+                Commits: [],
+                Prs: [],
+                Verifications: [],
+                RelatedPlans: [],
+                DependsOn: [],
+                Created: DateTime.UtcNow,
+                Updated: DateTime.UtcNow,
+                InitialPrompt: null,
+                SourceUrl: "https://github.com/owner/repo/issues/401"
+            ),
+            "",
+            Path.Combine(_tempDir.Path, "Plans", "00001-AlreadyPlanned"),
+            ""
+        );
+
+        var planReader = new FakePlanReaderService
+        {
+            Plans = [existingPlan]
+        };
+
+        var github = new TestGithubService
+        {
+            IssuesToReturn =
+            [
+                new GitHubIssue(401, "Planned issue", "Body 401", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/401"),
+                new GitHubIssue(402, "Unplanned issue", "Body 402", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/402")
+            ]
+        };
+
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+
+        await service.RunSyncAsync();
+
+        var inboxPath = Path.Combine(_tempDir.Path, "Inbox");
+        var files401 = Directory.GetFiles(inboxPath, "401-*.md");
+        Assert.Empty(files401);
+
+        var files402 = Directory.GetFiles(inboxPath, "402-*.md");
+        Assert.Single(files402);
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_SkipsActiveJobs()
+    {
+        var config = CreateConfigService(autoAccept: true);
+
+        var activeJob = new JobItem
+        {
+            Id = "00001",
+            Status = JobStatus.Running,
+            TypedArgs = new CreatePlanArgs("Implement changes for issue #501", "Auto")
+        };
+
+        var jobService = new TestJobService
+        {
+            Jobs = [activeJob]
+        };
+
+        var github = new TestGithubService
+        {
+            IssuesToReturn =
+            [
+                new GitHubIssue(501, "Active job issue", "Body 501", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/501"),
+                new GitHubIssue(502, "No job issue", "Body 502", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/502")
+            ]
+        };
+
+        var planReader = new FakePlanReaderService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+
+        await service.RunSyncAsync();
+
+        var inboxPath = Path.Combine(_tempDir.Path, "Inbox");
+        var files501 = Directory.GetFiles(inboxPath, "501-*.md");
+        Assert.Empty(files501);
+
+        var files502 = Directory.GetFiles(inboxPath, "502-*.md");
+        Assert.Single(files502);
+    }
+
+    [Fact]
+    public async Task TriggerManualCheckAsync_RunsImportImmediately()
+    {
+        // AutoAccept is disabled in config, but manual trigger must still run
+        var config = CreateConfigService(autoAccept: false);
+        var github = new TestGithubService
+        {
+            IssuesToReturn =
+            [
+                new GitHubIssue(601, "Manual check issue", "Body 601", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/601")
+            ]
+        };
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+
+        await service.TriggerManualCheckAsync();
+
+        Assert.Equal(1, github.CallCount);
+        var inboxPath = Path.Combine(_tempDir.Path, "Inbox");
+        var files601 = Directory.GetFiles(inboxPath, "601-*.md");
+        Assert.Single(files601);
+    }
+
+    private sealed class TestGithubService : IGithubService
+    {
+        public List<GitHubIssue> IssuesToReturn { get; set; } = [];
+        public int CallCount { get; private set; }
+        public Dictionary<string, ProjectConfig> ProjectMap { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public List<RepoConfig> GetRepos() => [];
+        public RepoConfig? GetRepoConfigFromPathCached(string repoPath) => null;
+        public ProjectConfig? FindProjectForGithubRepo(string ownerRepo) =>
+            ProjectMap.TryGetValue(ownerRepo, out var proj) ? proj : null;
+
+        public IReadOnlyList<string> GetResolvedGithubRepos(ProjectConfig project) => [];
+        public Task<(List<string> assignees, string? error)> GetAssigneesAsync(string owner, string repo) =>
+            Task.FromResult((new List<string>(), (string?)null));
+        public Task<(List<string> labels, string? error)> GetLabelsAsync(string owner, string repo) =>
+            Task.FromResult((new List<string>(), (string?)null));
+        public Task<(Dictionary<string, PrInfo> statuses, string? error)> GetPrStatusesAsync(string owner, string repo) =>
+            Task.FromResult((new Dictionary<string, PrInfo>(), (string?)null));
+        public Task<(List<GitHubIssue> issues, string? error)> SearchIssuesAsync(IssueSearchRequest request) =>
+            Task.FromResult((new List<GitHubIssue>(), (string?)null));
+        public Task<(List<GitHubIssue> issues, string? error)> GetMyAssignedIssuesAsync()
+        {
+            CallCount++;
+            return Task.FromResult((IssuesToReturn, (string?)null));
+        }
+        public Task<(List<GitHubReviewItem> prs, string? error)> GetReviewRequestsAsync() =>
+            Task.FromResult((new List<GitHubReviewItem>(), (string?)null));
+    }
+
+    private sealed class TestJobService : IJobService
+    {
+        public List<JobItem> Jobs { get; set; } = [];
+
+#pragma warning disable CS0067
+        public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
+        public event Action<JobNotification>? NotificationReady;
+        public event Action<JobItem>? JobFinished;
+#pragma warning restore CS0067
+
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null) => "job-id";
+        public void ForceStartJob(string id) { }
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
+        public void StopJob(string id) { }
+        public int StopAllJobs() => 0;
+        public void DeleteJob(string id) { }
+        public void ClearCompletedJobs() { }
+        public void ClearFailedJobs() { }
+        public void ClearAllJobs() { }
+        public int StopQueuedJobs() => 0;
+        public List<JobItem> GetJobs() => Jobs;
+        public List<JobItem> GetJobsForPlan(string planFile) => [];
+        public JobItem? GetJob(string id) => null;
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => true;
+        public void SetChatSessionId(string id, string chatSessionId) { }
+        public bool ReportJobFailure(string id, string message) => true;
+        public bool IsInboxFileTracked(string filePath) => false;
+        public void Dispose() { }
+    }
+}

--- a/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
@@ -1,9 +1,11 @@
+using Ivy.Tendril.Apps.Inbox.Dialogs;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Git;
+using Ivy.Tendril.Services.Inbox;
 
 namespace Ivy.Tendril.Apps.Inbox;
 
@@ -43,12 +45,14 @@ public class ContentView(
     IGithubService githubService,
     RefreshToken refreshToken,
     Func<Task> onRefresh,
-    Func<IReadOnlyList<GitHubIssue>, Task> onFireOffIssues) : ViewBase
+    Func<IReadOnlyList<GitHubIssue>, Task> onFireOffIssues,
+    AssignedIssuesAutoImportService? autoImportService = null) : ViewBase
 {
     public override object Build()
     {
         var client = UseService<IClientProvider>();
         var openFile = UseState<string?>(null);
+        var isAutoAcceptSettingsOpen = UseState(false);
 
         var (issueSheet, showIssueSheet) = UseTrigger<GitHubIssue>((isOpen, issue) =>
         {
@@ -153,7 +157,9 @@ public class ContentView(
                 allIssues: myIssues,
                 showRepoBadge: true,
                 client: client,
-                showIssueSheet: showIssueSheet
+                showIssueSheet: showIssueSheet,
+                isMyIssues: true,
+                openAutoAcceptSettings: () => isAutoAcceptSettingsOpen.Set(true)
             );
         }
         else // Project
@@ -167,11 +173,19 @@ public class ContentView(
                 allIssues: projectIssues,
                 showRepoBadge: false,
                 client: client,
-                showIssueSheet: showIssueSheet
+                showIssueSheet: showIssueSheet,
+                isMyIssues: false
             );
         }
 
-        return new Fragment(mainView, issueSheet, reviewSheet, new FileSheet(openFile, config));
+        var autoAcceptDialog = new AutoAcceptSettingsDialog(
+            isAutoAcceptSettingsOpen,
+            config,
+            autoImportService,
+            refreshToken,
+            onRefresh);
+
+        return new Fragment(mainView, issueSheet, reviewSheet, new FileSheet(openFile, config), autoAcceptDialog);
     }
 
     private object BuildReviewsView(IClientProvider client, Action<GitHubReviewItem> showReviewSheet)
@@ -300,7 +314,9 @@ public class ContentView(
         IReadOnlyList<GitHubIssue> allIssues,
         bool showRepoBadge,
         IClientProvider client,
-        Action<GitHubIssue> showIssueSheet)
+        Action<GitHubIssue> showIssueSheet,
+        bool isMyIssues = false,
+        Action? openAutoAcceptSettings = null)
     {
         var refreshButton = new Button()
             .Icon(Icons.RefreshCw)
@@ -330,10 +346,28 @@ public class ContentView(
             refreshToken.Refresh();
         }
 
+        var isAutoAcceptOn = config.Settings.Inbox.AutoAcceptAssignedIssues;
+
+        var autoAcceptControls = isMyIssues
+            ? (Layout.Horizontal().Height(Size.Auto()).Width(Size.Auto()).AlignContent(Align.Left)
+                | new Badge(isAutoAcceptOn ? "Auto-Accept: On" : "Auto-Accept: Off")
+                    .Variant(isAutoAcceptOn ? BadgeVariant.Primary : BadgeVariant.Secondary)
+                    .Small()
+                | (openAutoAcceptSettings != null
+                    ? new Button()
+                        .Icon(Icons.Settings)
+                        .Ghost()
+                        .Small()
+                        .Tooltip("Auto-Accept Settings")
+                        .OnClick(openAutoAcceptSettings)
+                    : null))
+            : null;
+
         var header = Layout.Horizontal().Height(Size.Auto()).AlignContent(Align.SpaceBetween).Width(Size.Full())
             | (Layout.Horizontal().Height(Size.Auto()).Width(Size.Auto()).AlignContent(Align.Left)
                 | Text.H3(title).Bold()
-                | refreshButton)
+                | refreshButton
+                | autoAcceptControls)
             | (Layout.Horizontal().Height(Size.Auto()).Width(Size.Auto()).AlignContent(Align.Right)
                 | new Button("Select All").Ghost().Small().OnClick(SelectAll)
                 | new Button("Deselect All").Ghost().Small().Disabled(selectedCount == 0).OnClick(DeselectAll)

--- a/src/Ivy.Tendril/Apps/Inbox/Dialogs/AutoAcceptSettingsDialog.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/Dialogs/AutoAcceptSettingsDialog.cs
@@ -1,0 +1,81 @@
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Inbox;
+
+namespace Ivy.Tendril.Apps.Inbox.Dialogs;
+
+public class AutoAcceptSettingsDialog(
+    IState<bool> isOpen,
+    IConfigService config,
+    AssignedIssuesAutoImportService? autoImportService,
+    RefreshToken refreshToken,
+    Func<Task> onRefresh) : ViewBase
+{
+    public override object? Build()
+    {
+        var client = UseService<IClientProvider>();
+        var autoAccept = UseState(config.Settings.Inbox.AutoAcceptAssignedIssues);
+        var checkInterval = UseState(config.Settings.Inbox.CheckIntervalMinutes);
+        var isCheckingNow = UseState(false);
+
+        if (!isOpen.Value) return null;
+
+        var intervalOptions = new[]
+        {
+            new Option<int>("5 minutes", 5),
+            new Option<int>("10 minutes", 10),
+            new Option<int>("15 minutes", 15),
+            new Option<int>("30 minutes", 30),
+            new Option<int>("60 minutes", 60),
+        };
+
+        var dialogBody = Layout.Vertical().Gap(4)
+            | Text.P("Automatically import newly assigned GitHub issues into Tendril plans at regular intervals.").Muted().Small()
+            | autoAccept.ToSwitchInput().WithField().Label("Auto-Accept Assigned Issues")
+            | checkInterval.ToSelectInput(intervalOptions).WithField().Label("Check Interval")
+            | (Layout.Horizontal().AlignContent(Align.Left)
+                | new Button("Check Now")
+                    .Icon(Icons.RefreshCw)
+                    .Outline()
+                    .Small()
+                    .Loading(isCheckingNow.Value)
+                    .OnClick(async () =>
+                    {
+                        if (autoImportService != null)
+                        {
+                            isCheckingNow.Set(true);
+                            try
+                            {
+                                await autoImportService.TriggerManualCheckAsync();
+                                client.Toast("Checked for assigned issues", "Auto-Accept");
+                                await onRefresh();
+                            }
+                            catch (Exception ex)
+                            {
+                                client.Toast($"Check failed: {ex.Message}", "Error");
+                            }
+                            finally
+                            {
+                                isCheckingNow.Set(false);
+                            }
+                        }
+                    }));
+
+        return new Dialog(
+            _ => isOpen.Set(false),
+            new DialogHeader("Auto-Accept Settings"),
+            new DialogBody(dialogBody),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() => isOpen.Set(false)),
+                new Button("Save").Primary().OnClick(() =>
+                {
+                    config.Settings.Inbox.AutoAcceptAssignedIssues = autoAccept.Value;
+                    config.Settings.Inbox.CheckIntervalMinutes = checkInterval.Value;
+                    config.SaveSettings();
+                    client.Toast("Auto-accept settings saved", "Saved");
+                    isOpen.Set(false);
+                    refreshToken.Refresh();
+                })
+            )
+        );
+    }
+}

--- a/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
@@ -3,6 +3,7 @@ using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Git;
+using Ivy.Tendril.Services.Inbox;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Apps.Inbox;
@@ -16,6 +17,7 @@ public class InboxApp : ViewBase
         var config = UseService<IConfigService>();
         var client = UseService<IClientProvider>();
         var logger = UseService<ILogger<InboxApp>>();
+        var autoImportService = UseService<AssignedIssuesAutoImportService>();
 
         var selectedCategory = UseState(InboxCategory.MyIssues);
         var selectedProject = UseState<string?>(() => config.Settings.Projects.FirstOrDefault()?.Name);
@@ -281,7 +283,8 @@ public class InboxApp : ViewBase
             githubService,
             refreshToken,
             onRefresh: FetchCurrentDataAsync,
-            onFireOffIssues: FireOffIssues
+            onFireOffIssues: FireOffIssues,
+            autoImportService: autoImportService
         );
 
         return new SidebarLayout(

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -247,6 +247,8 @@ internal static class ServiceRegistration
             return new InboxWatcherService(config, jobService, sp.GetRequiredService<ILogger<InboxWatcherService>>());
         });
         server.Services.AddSingleton<IInboxWatcherService>(sp => sp.GetRequiredService<InboxWatcherService>());
+        server.Services.AddSingleton<Services.Inbox.AssignedIssuesAutoImportService>();
+        server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<Services.Inbox.AssignedIssuesAutoImportService>());
         server.Services.AddSingleton<WorktreeCleanupService>(sp =>
         {
             var config = sp.GetRequiredService<IConfigService>();

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -201,6 +201,12 @@ public record ApiSettings
     public string? ApiKey { get; set; }
 }
 
+public class InboxConfig
+{
+    public bool AutoAcceptAssignedIssues { get; set; } = false;
+    public int CheckIntervalMinutes { get; set; } = 15;
+}
+
 public class TendrilSettings
 {
     public string CodingAgent { get; set; } = "claude";
@@ -216,6 +222,12 @@ public class TendrilSettings
     public LlmConfig? Llm { get; set; }
     public AuthConfig? Auth { get; set; }
     public ApiSettings? Api { get; set; }
+    private InboxConfig _inbox = new();
+    public InboxConfig Inbox
+    {
+        get => _inbox;
+        set => _inbox = value ?? new InboxConfig();
+    }
     public Dictionary<string, PromptwareConfig> Promptwares { get; set; } = new();
     public List<AgentConfig> CodingAgents { get; set; } = new();
     public Tunnel.TunnelConfig? Tunnel { get; set; }

--- a/src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs
+++ b/src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs
@@ -1,0 +1,184 @@
+using Ivy.Tendril.Apps.Inbox;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Git;
+using Ivy.Tendril.Services.Jobs;
+using Ivy.Tendril.Services.Plans;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Inbox;
+
+public class AssignedIssuesAutoImportService : IStartable, IDisposable
+{
+    private readonly IConfigService _config;
+    private readonly IGithubService _githubService;
+    private readonly IPlanReaderService _planReader;
+    private readonly IJobService _jobService;
+    private readonly ILogger<AssignedIssuesAutoImportService> _logger;
+    private readonly SemaphoreSlim _syncLock = new(1, 1);
+    private Timer? _timer;
+
+    public AssignedIssuesAutoImportService(
+        IConfigService config,
+        IGithubService githubService,
+        IPlanReaderService planReader,
+        IJobService jobService,
+        ILogger<AssignedIssuesAutoImportService> logger)
+    {
+        _config = config;
+        _githubService = githubService;
+        _planReader = planReader;
+        _jobService = jobService;
+        _logger = logger;
+    }
+
+    public void Start()
+    {
+        var intervalMinutes = Math.Max(1, _config.Settings.Inbox.CheckIntervalMinutes);
+        var interval = TimeSpan.FromMinutes(intervalMinutes);
+        _timer = new Timer(_ => _ = RunSyncAsync(), null, TimeSpan.FromSeconds(15), interval);
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+        _syncLock.Dispose();
+    }
+
+    public Task TriggerManualCheckAsync()
+    {
+        return RunSyncAsync(force: true);
+    }
+
+    public async Task RunSyncAsync(bool force = false)
+    {
+        if (Environment.GetEnvironmentVariable("TENDRIL_NOT_MASTER") == "1")
+        {
+            _logger.LogDebug("Skipping assigned issues auto-import: node is not master.");
+            return;
+        }
+
+        if (!force && !_config.Settings.Inbox.AutoAcceptAssignedIssues)
+        {
+            _logger.LogDebug("Skipping assigned issues auto-import: auto-accept is disabled.");
+            return;
+        }
+
+        if (!await _syncLock.WaitAsync(0))
+        {
+            _logger.LogDebug("Assigned issues auto-import is already in progress.");
+            return;
+        }
+
+        try
+        {
+            var (issues, error) = await _githubService.GetMyAssignedIssuesAsync();
+            if (error != null)
+            {
+                _logger.LogWarning("Failed to fetch assigned GitHub issues: {Error}", error);
+                return;
+            }
+
+            if (issues == null || issues.Count == 0)
+                return;
+
+            var inboxPath = Path.Combine(_config.TendrilHome, "Inbox");
+            if (!Directory.Exists(inboxPath))
+                Directory.CreateDirectory(inboxPath);
+
+            var activeJobs = _jobService.GetJobs()
+                .Where(j => j.Status is not (JobStatus.Completed or JobStatus.Failed or JobStatus.Timeout or JobStatus.Stopped))
+                .ToList();
+
+            var existingPlans = _planReader.GetPlans();
+
+            foreach (var issue in issues)
+            {
+                // 1. Check if an inbox file already exists for this issue
+                var hasMatchingInboxFile = Directory.GetFiles(inboxPath, $"{issue.Number}-*.md*")
+                    .Any(f => f.EndsWith(".md", StringComparison.OrdinalIgnoreCase) ||
+                              f.EndsWith(".md.processing", StringComparison.OrdinalIgnoreCase));
+
+                if (hasMatchingInboxFile)
+                {
+                    _logger.LogDebug("Issue #{Number} already exists in Inbox, skipping.", issue.Number);
+                    continue;
+                }
+
+                // 2. Check if an active job is processing this issue
+                var hasActiveJob = activeJobs.Any(j =>
+                    j.TypedArgs is CreatePlanArgs cp &&
+                    cp.Description != null &&
+                    cp.Description.Contains($"#{issue.Number}"));
+
+                if (hasActiveJob)
+                {
+                    _logger.LogDebug("Issue #{Number} is currently being processed by an active job, skipping.", issue.Number);
+                    continue;
+                }
+
+                // 3. Check if an existing plan already references this issue URL or issue
+                var issueUrl = issue.Url ?? (issue.Repository != null
+                    ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
+                    : null);
+
+                var hasExistingPlan = existingPlans.Any(p =>
+                {
+                    if (p.Metadata == null) return false;
+
+                    if (!string.IsNullOrEmpty(issueUrl))
+                    {
+                        if (string.Equals(p.Metadata.SourceUrl?.TrimEnd('/'), issueUrl.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
+                            return true;
+
+                        if (p.Metadata.InitialPrompt != null &&
+                            p.Metadata.InitialPrompt.Contains(issueUrl, StringComparison.OrdinalIgnoreCase))
+                            return true;
+                    }
+
+                    return false;
+                });
+
+                if (hasExistingPlan)
+                {
+                    _logger.LogDebug("Issue #{Number} is already tracked by an existing plan, skipping.", issue.Number);
+                    continue;
+                }
+
+                // 4. Resolve the target project
+                var targetProject = (issue.Repository != null
+                    ? _githubService.FindProjectForGithubRepo(issue.Repository)?.Name
+                    : null) ?? "Auto";
+
+                // 5. Write new inbox file
+                var safeName = InboxApp.SanitizeFileName(issue.Title ?? $"issue-{issue.Number}");
+                var fileName = $"{issue.Number}-{safeName}.md";
+                var filePath = Path.Combine(inboxPath, fileName);
+
+                var resolvedUrl = issue.Url ?? (issue.Repository != null
+                    ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
+                    : "");
+
+                var content = $"""
+                               ---
+                               project: {targetProject}
+                               ---
+                               {(string.IsNullOrEmpty(resolvedUrl) ? $"# Issue #{issue.Number}: {issue.Title}" : $"[GitHub Issue #{issue.Number}]({resolvedUrl})")}
+
+                               {issue.Body}
+                               """;
+
+                await FileHelper.WriteAllTextAsync(filePath, content);
+                _logger.LogInformation("Auto-imported assigned issue #{Number} into Inbox for project {Project}.", issue.Number, targetProject);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during assigned issues auto-import.");
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Implemented automatic import and implementation plan triggering for GitHub issues assigned to the user. Background polling periodically checks for newly assigned issues, guards against duplicate imports or plans, and creates inbox items that trigger CreatePlan jobs.

## API Changes

- Added `InboxConfig` class and `TendrilSettings.Inbox` property in `Ivy.Tendril.Services.ConfigService`.
- Added `AssignedIssuesAutoImportService` in `Ivy.Tendril.Services.Inbox` implementing `IStartable` and `IDisposable`.
- Added `AutoAcceptSettingsDialog` in `Ivy.Tendril.Apps.Inbox.Dialogs`.

## Files Modified

- `src/Ivy.Tendril/Services/ConfigService.cs`: Added InboxConfig and Inbox settings property.
- `src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs`: Background polling service for auto-importing assigned issues.
- `src/Ivy.Tendril/ServiceRegistration.cs`: Registered AssignedIssuesAutoImportService as singleton and IStartable.
- `src/Ivy.Tendril/Apps/Inbox/Dialogs/AutoAcceptSettingsDialog.cs`: Dialog for toggling auto-accept, setting interval, and triggering manual check.
- `src/Ivy.Tendril/Apps/Inbox/ContentView.cs`: Added auto-accept badge, settings button, and dialog rendering.
- `src/Ivy.Tendril/Apps/Inbox/InboxApp.cs`: Injected AssignedIssuesAutoImportService and passed to ContentView.
- `src/Ivy.Tendril.Test/ConfigServiceTests.cs`: Unit tests for InboxConfig defaults and YAML round-trip.
- `src/Ivy.Tendril.Test/Services/Inbox/AssignedIssuesAutoImportServiceTests.cs`: Unit tests for auto-import service behavior.

## Manual Testing

1. Launch Tendril and open the Inbox app.
2. Select the "My Issues" tab.
3. Observe the "Auto-Accept: Off" badge and the settings gear button in the header.
4. Click the settings button to open the Auto-Accept Settings dialog.
5. Toggle "Auto-Accept Assigned Issues" to On, select an interval (e.g. 15 minutes), or click "Check Now".
6. Click Save and observe the badge changes to "Auto-Accept: On".

---
## Commits

- 08bed791 Add InboxConfig and AssignedIssuesAutoImportService background polling (Plan 00095)
- d3afa30c Add Auto-Accept settings dialog and header controls to Inbox app (Plan 00095)
- 083a23ea Add unit tests for AssignedIssuesAutoImportService and InboxConfig (Plan 00095)

---
Created using [Ivy Tendril](https://ivy.app).
