### PR TITLE
[00098] Add Interactive Calculation Breakdown Sheets for KPI Cards

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -393,4 +393,78 @@ public class DashboardAppViewModelTests
         var day6 = sep.Days.First(d => d.Date == "2026-09-06");
         Assert.Equal(3, day6.Count);
     }
+
+    [Fact]
+    public void BuildKpis_AssignsExpectedKpiIds()
+    {
+        var today = new DateTime(2026, 8, 31);
+        var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 15.5m, [], []);
+        var activity = new DashboardActivityStats([], 10m);
+
+        var kpis = DashboardApp.BuildKpis(stats, activity, [], today);
+
+        Assert.Equal(4, kpis.Count);
+        Assert.Equal("dailyPrs", kpis[0].Id);
+        Assert.Equal("avgCostMonth", kpis[1].Id);
+        Assert.Equal("forecastMonth", kpis[2].Id);
+        Assert.Equal("avgCostPlan", kpis[3].Id);
+    }
+
+    [Fact]
+    public void BuildKpis_ComputesCorrectMonthlyAndRollingPlanCalculations()
+    {
+        var today = new DateTime(2026, 8, 31);
+        var prDays = new List<(DateOnly Date, int Count)>
+        {
+            // 45 PRs in last 30 days => 45 / 30 = 1.5 daily PRs
+            (new DateOnly(2026, 8, 15), 45),
+            // 30 PRs in prior 30 days => 30 / 30 = 1.0 daily PRs (+50%)
+            (new DateOnly(2026, 7, 15), 30)
+        };
+
+        var months = new List<DashboardMonthStats>
+        {
+            new(2026, 2, 2, 0, 100m, 1000),
+            new(2026, 3, 3, 0, 200m, 2000),
+            new(2026, 4, 4, 0, 300m, 3000),
+            new(2026, 5, 5, 0, 400m, 4000),
+            new(2026, 6, 6, 0, 500m, 5000),
+            new(2026, 7, 7, 0, 600m, 6000), // last completed month (July): $600
+            new(2026, 8, 8, 0, 999m, 9000)  // in-flight month (August): must be excluded
+        };
+        // Mean of completed months: (100+200+300+400+500+600)/6 = 350. Last completed=600, prev=500 (+20%)
+        var stats = new DashboardModels(10, 0, 0, 0, 8, 2, 25.0m, [], []);
+        var activity = new DashboardActivityStats(months, 20.0m);
+
+        var kpis = DashboardApp.BuildKpis(stats, activity, prDays, today);
+
+        // 1. dailyPrs
+        Assert.Equal("dailyPrs", kpis[0].Id);
+        Assert.Equal("1.5", kpis[0].Value);
+        Assert.Equal("+50%", kpis[0].Delta);
+
+        // 2. avgCostMonth
+        Assert.Equal("avgCostMonth", kpis[1].Id);
+        Assert.Equal("$350", kpis[1].Value);
+        Assert.Equal("+20%", kpis[1].Delta);
+
+        // 3. forecastMonth
+        Assert.Equal("forecastMonth", kpis[2].Id);
+
+        // 4. avgCostPlan: $25.00 vs $20.00 (+25%)
+        Assert.Equal("avgCostPlan", kpis[3].Id);
+        Assert.Equal("$25.00", kpis[3].Value);
+        Assert.Equal("+25%", kpis[3].Delta);
+    }
+
+    [Theory]
+    [InlineData("dailyPrs", "Avg Daily PR Count")]
+    [InlineData("avgCostMonth", "Avg Cost/Month")]
+    [InlineData("forecastMonth", "Forecast This Month")]
+    [InlineData("avgCostPlan", "Avg Cost/Plan")]
+    [InlineData("other", "KPI Breakdown")]
+    public void GetKpiSheetTitle_ReturnsExpectedTitle(string key, string expected)
+    {
+        Assert.Equal(expected, DashboardApp.GetKpiSheetTitle(key));
+    }
 }

--- a/src/Ivy.Tendril.Test/FakePlanReaderService.cs
+++ b/src/Ivy.Tendril.Test/FakePlanReaderService.cs
@@ -103,6 +103,12 @@ internal class FakePlanReaderService : IPlanReaderService
         return [];
     }
 
+    public List<RecentMergedPrDto> RecentMergedPrsToReturn { get; set; } = [];
+    public List<RecentPlanCostDto> RecentPlanCostsToReturn { get; set; } = [];
+
+    public List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50) => RecentMergedPrsToReturn;
+    public List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) => RecentPlanCostsToReturn;
+
     public decimal GetPlanTotalCost(string folderPath)
     {
         return 0;

--- a/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
+++ b/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
@@ -1,0 +1,121 @@
+using Ivy.Tendril.Apps.Views.Sheets;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test.Views.Sheets;
+
+public class KpiBreakdownSheetTests
+{
+    private readonly DateTime _today = new(2026, 8, 31);
+    private readonly DashboardModels _stats = new(10, 2, 1, 1, 5, 1, 24.50m, [], []);
+    private readonly DashboardActivityStats _activity;
+    private readonly List<(DateOnly Date, int Count)> _prDays;
+    private readonly FakePlanReaderService _fakeService;
+
+    public KpiBreakdownSheetTests()
+    {
+        var dailyCosts = new List<DashboardDailyCost>
+        {
+            new(new DateOnly(2026, 8, 31), 25.00m, 2500),
+            new(new DateOnly(2026, 8, 25), 15.50m, 1500),
+            new(new DateOnly(2026, 8, 20), 10.00m, 1000)
+        };
+
+        var months = new List<DashboardMonthStats>
+        {
+            new(2026, 3, 5, 2, 150m, 15000),
+            new(2026, 4, 8, 4, 250m, 25000),
+            new(2026, 5, 10, 6, 350m, 35000),
+            new(2026, 6, 12, 8, 450m, 45000),
+            new(2026, 7, 15, 10, 550m, 55000),
+            new(2026, 8, 3, 1, 100m, 10000) // In-flight month
+        };
+
+        _activity = new DashboardActivityStats(months, 20.00m, dailyCosts);
+
+        _prDays =
+        [
+            (new DateOnly(2026, 8, 30), 2),
+            (new DateOnly(2026, 8, 25), 3),
+            (new DateOnly(2026, 8, 10), 1),
+            (new DateOnly(2026, 7, 25), 4),
+            (new DateOnly(2026, 7, 15), 2)
+        ];
+
+        _fakeService = new FakePlanReaderService
+        {
+            RecentMergedPrsToReturn =
+            [
+                new RecentMergedPrDto("https://github.com/org/repo/pull/1", 42, "Fix login", "/repos/app", DateTime.UtcNow),
+                new RecentMergedPrDto("https://github.com/org/repo/pull/2", 43, "Add dark mode", "/repos/app", DateTime.UtcNow.AddDays(-1))
+            ],
+            RecentPlanCostsToReturn =
+            [
+                new RecentPlanCostDto(42, "Fix login", "Completed", DateTime.UtcNow.AddDays(-2), 12.50m, 15000),
+                new RecentPlanCostDto(43, "Add dark mode", "Review", DateTime.UtcNow.AddDays(-1), null, 8000)
+            ]
+        };
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_RendersDailyPrsBreakdown()
+    {
+        var sheet = new KpiBreakdownSheet("dailyPrs", _stats, _activity, _prDays, _today, _fakeService);
+        var result = sheet.Build();
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_RendersAvgCostMonthBreakdown()
+    {
+        var sheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var result = sheet.Build();
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_RendersForecastMonthBreakdown()
+    {
+        var sheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var result = sheet.Build();
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_RendersAvgCostPlanBreakdown()
+    {
+        var sheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, _today, _fakeService);
+        var result = sheet.Build();
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_RendersUnknownKeyGracefully()
+    {
+        var sheet = new KpiBreakdownSheet("unknownMetricKey", _stats, _activity, _prDays, _today, _fakeService);
+        var result = sheet.Build();
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_HandlesEmptyDataGracefully()
+    {
+        var emptyStats = new DashboardModels(0, 0, 0, 0, 0, 0, 0m, [], []);
+        var emptyActivity = new DashboardActivityStats([], 0m);
+        var emptyService = new FakePlanReaderService();
+
+        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", emptyStats, emptyActivity, [], _today, emptyService);
+        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", emptyStats, emptyActivity, [], _today, emptyService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", emptyStats, emptyActivity, [], _today, emptyService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", emptyStats, emptyActivity, [], _today, emptyService);
+
+        Assert.NotNull(dailyPrsSheet.Build());
+        Assert.NotNull(avgCostMonthSheet.Build());
+        Assert.NotNull(forecastSheet.Build());
+        Assert.NotNull(avgCostPlanSheet.Build());
+    }
+}

--- a/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
+++ b/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
@@ -9,7 +9,8 @@ public record DashboardKpiDto(
     string Value,
     string? Delta = null,
     string? Direction = null,
-    string? Hint = null);
+    string? Hint = null,
+    string? Id = null);
 
 public record DashboardMonthValueDto(string Label, double Value);
 
@@ -100,6 +101,7 @@ public record TendrilDashboard : WidgetBase<TendrilDashboard>
     [Event] public EventHandler<Event<TendrilDashboard>>? OnReview { get; init; }
     [Event] public EventHandler<Event<TendrilDashboard>>? OnJobs { get; init; }
     [Event] public EventHandler<Event<TendrilDashboard, string>>? OnJob { get; init; }
+    [Event] public EventHandler<Event<TendrilDashboard, string>>? OnSelectKpi { get; init; }
 }
 
 public static class TendrilDashboardExtensions
@@ -157,4 +159,7 @@ public static class TendrilDashboardExtensions
 
     public static TendrilDashboard OnJob(this TendrilDashboard w, Action<string> handler) =>
         w with { OnJob = new(e => { handler(e.Value); return ValueTask.CompletedTask; }) };
+
+    public static TendrilDashboard OnSelectKpi(this TendrilDashboard w, Action<string> handler) =>
+        w with { OnSelectKpi = new(e => { handler(e.Value); return ValueTask.CompletedTask; }) };
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
@@ -136,3 +136,101 @@ describe("TendrilDashboard range and metric combinations", () => {
     expect(screen.queryByText("7-day average")).not.toBeInTheDocument();
   });
 });
+
+describe("TendrilDashboard KPI card interactions and accessibility", () => {
+  const kpis = [
+    { id: "dailyPrs", label: "Avg Daily PR count", value: "1.2", delta: "+10%" },
+    { id: "avgCostMonth", label: "Avg Cost/Month", value: "$450" },
+    { id: "forecastMonth", label: "Forecast This Month", value: "$600" },
+    { id: "avgCostPlan", label: "Avg Cost/Plan", value: "$24.50" },
+  ];
+
+  it("renders KPI cards with button accessibility attributes", () => {
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={vi.fn()}
+        events={["OnSelectKpi"]}
+        kpis={kpis}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    const kpiButtons = buttons.filter((b) => b.classList.contains("tdb-kpi"));
+    expect(kpiButtons).toHaveLength(4);
+
+    kpiButtons.forEach((btn, idx) => {
+      expect(btn).toHaveAttribute("tabindex", "0");
+      expect(btn).toHaveAttribute(
+        "aria-label",
+        `View calculation breakdown for ${kpis[idx].label}`,
+      );
+    });
+  });
+
+  it("fires OnSelectKpi event when a KPI card is clicked", () => {
+    const eventHandler = vi.fn();
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={eventHandler}
+        events={["OnSelectKpi"]}
+        kpis={kpis}
+      />,
+    );
+
+    const dailyPrsCard = screen.getByLabelText("View calculation breakdown for Avg Daily PR count");
+    fireEvent.click(dailyPrsCard);
+
+    expect(eventHandler).toHaveBeenCalledWith("OnSelectKpi", "dash", ["dailyPrs"]);
+
+    const costPlanCard = screen.getByLabelText("View calculation breakdown for Avg Cost/Plan");
+    fireEvent.click(costPlanCard);
+
+    expect(eventHandler).toHaveBeenCalledWith("OnSelectKpi", "dash", ["avgCostPlan"]);
+  });
+
+  it("fires OnSelectKpi when Enter or Space key is pressed", () => {
+    const eventHandler = vi.fn();
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={eventHandler}
+        events={["OnSelectKpi"]}
+        kpis={kpis}
+      />,
+    );
+
+    const monthCostCard = screen.getByLabelText("View calculation breakdown for Avg Cost/Month");
+    fireEvent.keyDown(monthCostCard, { key: "Enter" });
+    expect(eventHandler).toHaveBeenCalledWith("OnSelectKpi", "dash", ["avgCostMonth"]);
+
+    const forecastCard = screen.getByLabelText("View calculation breakdown for Forecast This Month");
+    fireEvent.keyDown(forecastCard, { key: " " });
+    expect(eventHandler).toHaveBeenCalledWith("OnSelectKpi", "dash", ["forecastMonth"]);
+  });
+
+  it("falls back to standard identifier keys when kpi.id is not provided", () => {
+    const eventHandler = vi.fn();
+    const kpisWithoutId = [
+      { label: "Avg Daily PR count", value: "1.2" },
+      { label: "Avg Cost/Month", value: "$450" },
+      { label: "Forecast This Month", value: "$600" },
+      { label: "Avg Cost/Plan", value: "$24.50" },
+    ];
+
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={eventHandler}
+        events={["OnSelectKpi"]}
+        kpis={kpisWithoutId}
+      />,
+    );
+
+    const card = screen.getByLabelText("View calculation breakdown for Avg Daily PR count");
+    fireEvent.click(card);
+
+    expect(eventHandler).toHaveBeenCalledWith("OnSelectKpi", "dash", ["dailyPrs"]);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -78,6 +78,12 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
     }
   };
 
+  const fireKpiEvent = (kpiKey: string) => {
+    if (events.includes("OnSelectKpi")) {
+      eventHandler("OnSelectKpi", id, [kpiKey]);
+    }
+  };
+
   const statusItems = [
     { icon: <Feather size={16} />, count: draftCount, label: "Plans", event: "OnDrafts" },
     { icon: <Sprout size={16} />, count: inProgressCount, label: "In Progress", event: "OnJobs" },
@@ -136,25 +142,45 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
 
             {kpis.length > 0 && (
               <div className="tdb-kpis">
-                {kpis.map((kpi, index) => (
-                  <div className="tdb-kpi" data-tone={index % 4} key={kpi.label}>
-                    <div className="tdb-kpi-label">{kpi.label}</div>
-                    <div className="tdb-kpi-row">
-                      <span className="tdb-kpi-value">{kpi.value}</span>
-                      {kpi.delta && (
-                        <span className="tdb-kpi-delta">
-                          {kpi.delta}
-                          {kpi.direction === "down" ? (
-                            <TrendingDown />
-                          ) : (
-                            <TrendingUp />
-                          )}
-                        </span>
-                      )}
+                {kpis.map((kpi, index) => {
+                  const fallbackId =
+                    ["dailyPrs", "avgCostMonth", "forecastMonth", "avgCostPlan"][index] ??
+                    kpi.label;
+                  const kpiKey = kpi.id ?? fallbackId;
+                  return (
+                    <div
+                      className="tdb-kpi"
+                      data-tone={index % 4}
+                      key={kpi.label}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`View calculation breakdown for ${kpi.label}`}
+                      onClick={() => fireKpiEvent(kpiKey)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          fireKpiEvent(kpiKey);
+                        }
+                      }}
+                    >
+                      <div className="tdb-kpi-label">{kpi.label}</div>
+                      <div className="tdb-kpi-row">
+                        <span className="tdb-kpi-value">{kpi.value}</span>
+                        {kpi.delta && (
+                          <span className="tdb-kpi-delta">
+                            {kpi.delta}
+                            {kpi.direction === "down" ? (
+                              <TrendingDown />
+                            ) : (
+                              <TrendingUp />
+                            )}
+                          </span>
+                        )}
+                      </div>
+                      {kpi.hint && <div className="tdb-kpi-hint">{kpi.hint}</div>}
                     </div>
-                    {kpi.hint && <div className="tdb-kpi-hint">{kpi.hint}</div>}
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -219,6 +219,18 @@
   padding: 22px 24px;
   min-height: 110px;
   color: var(--tdb-fg);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.tdb-kpi:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.tdb-kpi:focus-visible {
+  outline: 2px solid var(--tdb-focus, var(--tdb-muted));
+  outline-offset: 2px;
 }
 
 .tdb-kpi[data-tone="0"] { background: var(--tdb-kpi-1); }

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -30,6 +30,13 @@ describe("dashboard.css KPI grid", () => {
     expect(css).toContain(".tdb-kpi-hint {");
     expect(css).toMatch(/\.tdb-kpi-hint\s*\{[^}]*opacity: 0\.7;/);
   });
+
+  it("defines cursor pointer, transition, hover, and focus-visible on .tdb-kpi", () => {
+    expect(css).toMatch(/\.tdb-kpi\s*\{[^}]*cursor:\s*pointer;/);
+    expect(css).toMatch(/\.tdb-kpi\s*\{[^}]*transition:\s*[^;]*transform/);
+    expect(css).toContain(".tdb-kpi:hover");
+    expect(css).toContain(".tdb-kpi:focus-visible");
+  });
 });
 
 describe("dashboard.css side block and git activity layout", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -1,6 +1,7 @@
 import type { IvyEventHandler } from "../TendrilProcessViewer/types";
 
 export interface DashboardKpiDto {
+  id?: string | null;
   label: string;
   value: string;
   delta?: string | null;

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -5,6 +5,7 @@ using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Jobs.Sheets;
 using Ivy.Tendril.Apps.Review;
 using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
@@ -47,6 +48,22 @@ public class DashboardApp : ViewBase
             return new Sheet(
                 () => isOpen.Set(false),
                 new OutputSheet(jobId, jobService),
+                title
+            ).Width(UxHelper.SheetWidth).Resizable();
+        });
+
+        var (kpiSheet, showKpiDetail) = UseTrigger<string>((isOpen, kpiKey) =>
+        {
+            if (!isOpen.Value) return null;
+            var currentToday = DateTime.UtcNow.Date;
+            var currentFirstActivityMonth = new DateTime(currentToday.Year, currentToday.Month, 1).AddMonths(-(ActivityMonths - 1));
+            var currentStats = planService.GetDashboardData(null);
+            var currentActivity = planService.GetDashboardActivity(TrendMonthsBack);
+            var currentPrDays = planService.GetCompletedPrsByDay((currentToday - currentFirstActivityMonth).Days + 1);
+            var title = GetKpiSheetTitle(kpiKey);
+            return new Sheet(
+                () => isOpen.Set(false),
+                new KpiBreakdownSheet(kpiKey, currentStats, currentActivity, currentPrDays, currentToday, planService),
                 title
             ).Width(UxHelper.SheetWidth).Resizable();
         });
@@ -127,10 +144,20 @@ public class DashboardApp : ViewBase
             .OnDrafts(() => navigator.Navigate<PlansApp>())
             .OnReview(() => navigator.Navigate<ReviewApp>())
             .OnJobs(() => navigator.Navigate<JobsApp>())
-            .OnJob(showOutput);
+            .OnJob(showOutput)
+            .OnSelectKpi(showKpiDetail);
 
-        return new Fragment(dashboard, outputSheet);
+        return new Fragment(dashboard, outputSheet, kpiSheet);
     }
+
+    internal static string GetKpiSheetTitle(string kpiKey) => kpiKey switch
+    {
+        "dailyPrs" => "Avg Daily PR Count",
+        "avgCostMonth" => "Avg Cost/Month",
+        "forecastMonth" => "Forecast This Month",
+        "avgCostPlan" => "Avg Cost/Plan",
+        _ => "KPI Breakdown"
+    };
 
     internal static List<DashboardJobDto> BuildActiveJobs(List<JobItem> jobs, IPlanReaderService planService)
     {
@@ -188,7 +215,7 @@ public class DashboardApp : ViewBase
         var prev30Start = DateOnly.FromDateTime(today.AddDays(-59));
         var dailyPrs = prDays.Where(p => p.Date >= last30Start).Sum(p => p.Count) / 30m;
         var prevDailyPrs = prDays.Where(p => p.Date >= prev30Start && p.Date < last30Start).Sum(p => p.Count) / 30m;
-        kpis.Add(Kpi("Avg Daily PR count", dailyPrs.ToString("0.#", CultureInfo.InvariantCulture), dailyPrs, prevDailyPrs));
+        kpis.Add(Kpi("Avg Daily PR count", dailyPrs.ToString("0.#", CultureInfo.InvariantCulture), dailyPrs, prevDailyPrs, "dailyPrs"));
 
         // Monthly cost/token averages over recent complete months with data; the delta
         // compares the two most recent complete months.
@@ -201,7 +228,7 @@ public class DashboardApp : ViewBase
             ? costMonths.Average(m => m.Cost)
             : activity.Months.Count > 0 ? activity.Months[^1].Cost : 0;
         var (lastCost, prevCost) = LastTwo(completeMonths, m => m.Cost);
-        kpis.Add(Kpi("Avg Cost/Month", FormatCost(avgMonthCost), lastCost, prevCost));
+        kpis.Add(Kpi("Avg Cost/Month", FormatCost(avgMonthCost), lastCost, prevCost, "avgCostMonth"));
 
         // Next to the retrospective average on purpose: what the month has cost so far and what it is
         // heading for are read together.
@@ -209,7 +236,7 @@ public class DashboardApp : ViewBase
 
 
         kpis.Add(Kpi("Avg Cost/Plan", FormatHelper.FormatCost(stats.AvgCostPerPlan),
-            stats.AvgCostPerPlan, activity.PrevWeekAvgCostPerPlan));
+            stats.AvgCostPerPlan, activity.PrevWeekAvgCostPerPlan, "avgCostPlan"));
 
         return kpis;
     }
@@ -223,9 +250,9 @@ public class DashboardApp : ViewBase
 
         var forecast = CostForecastCalculator.Project(dailyCosts ?? [], today);
         if (forecast.CalendarProjection is not { } projection)
-            return new DashboardKpiDto(label, "-", Hint: "No cost data in the last 30 days");
+            return new DashboardKpiDto(label, "-", Hint: "No cost data in the last 30 days", Id: "forecastMonth");
 
-        return new DashboardKpiDto(label, FormatCost(projection));
+        return new DashboardKpiDto(label, FormatCost(projection), Id: "forecastMonth");
     }
 
     private static (decimal Last, decimal Previous) LastTwo(
@@ -237,17 +264,17 @@ public class DashboardApp : ViewBase
             : (0, 0);
     }
 
-    internal static DashboardKpiDto Kpi(string label, string value, decimal current, decimal previous)
+    internal static DashboardKpiDto Kpi(string label, string value, decimal current, decimal previous, string? id = null)
     {
         if (previous <= 0 || current <= 0)
-            return new DashboardKpiDto(label, value);
+            return new DashboardKpiDto(label, value, Id: id);
 
         var pct = (current - previous) / previous * 100m;
         var magnitude = Math.Abs(pct) >= 10
             ? Math.Round(Math.Abs(pct)).ToString("0", CultureInfo.InvariantCulture)
             : Math.Abs(pct).ToString("0.##", CultureInfo.InvariantCulture);
         var delta = (pct >= 0 ? "+" : "-") + magnitude + "%";
-        return new DashboardKpiDto(label, value, delta, pct >= 0 ? "up" : "down");
+        return new DashboardKpiDto(label, value, delta, pct >= 0 ? "up" : "down", Id: id);
     }
 
     private static string FormatCost(decimal cost) =>

--- a/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
@@ -1,0 +1,335 @@
+using System.Globalization;
+using Ivy.Tendril.Database;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Apps.Views.Sheets;
+
+/// <summary>
+/// Displays detailed calculation breakdown, formula explanation, comparison window,
+/// and underlying data records for each of the four dashboard KPI metrics.
+/// </summary>
+public class KpiBreakdownSheet(
+    string kpiKey,
+    DashboardModels stats,
+    DashboardActivityStats activity,
+    List<(DateOnly Date, int Count)> prDays,
+    DateTime today,
+    IPlanReaderService planService) : ViewBase
+{
+    public override object Build()
+    {
+        return kpiKey switch
+        {
+            "dailyPrs" => BuildDailyPrsBreakdown(),
+            "avgCostMonth" => BuildAvgCostMonthBreakdown(),
+            "forecastMonth" => BuildForecastMonthBreakdown(),
+            "avgCostPlan" => BuildAvgCostPlanBreakdown(),
+            _ => Layout.Vertical().Gap(4)
+                 | Callout.Info($"No calculation breakdown available for key '{kpiKey}'.", "Unknown Metric")
+        };
+    }
+
+    private object BuildDailyPrsBreakdown()
+    {
+        var last30Start = DateOnly.FromDateTime(today.AddDays(-29));
+        var prev30Start = DateOnly.FromDateTime(today.AddDays(-59));
+        var last30Count = prDays.Where(p => p.Date >= last30Start).Sum(p => p.Count);
+        var prev30Count = prDays.Where(p => p.Date >= prev30Start && p.Date < last30Start).Sum(p => p.Count);
+        var dailyPrs = last30Count / 30m;
+        var prevDailyPrs = prev30Count / 30m;
+        var deltaText = CalculateDelta(dailyPrs, prevDailyPrs);
+
+        var details = new
+        {
+            Metric = "Average Daily Pull Requests",
+            Formula = "Total PRs merged in last 30 calendar days / 30",
+            Last30DaysMergedPrs = last30Count.ToString(CultureInfo.InvariantCulture),
+            Last30DaysDailyAverage = dailyPrs.ToString("0.#", CultureInfo.InvariantCulture),
+            Prior30DaysMergedPrs = prev30Count.ToString(CultureInfo.InvariantCulture),
+            Prior30DaysDailyAverage = prevDailyPrs.ToString("0.#", CultureInfo.InvariantCulture),
+            PeriodComparisonDelta = deltaText
+        }
+            .ToDetails()
+            .Label(x => x.Metric, "Metric")
+            .Label(x => x.Formula, "Formula")
+            .Label(x => x.Last30DaysMergedPrs, "Last 30 Days (Merged PRs)")
+            .Label(x => x.Last30DaysDailyAverage, "Last 30 Days (Daily Avg)")
+            .Label(x => x.Prior30DaysMergedPrs, "Prior 30 Days (Merged PRs)")
+            .Label(x => x.Prior30DaysDailyAverage, "Prior 30 Days (Daily Avg)")
+            .Label(x => x.PeriodComparisonDelta, "30-Day Period Delta");
+
+        var recentPrs = planService.GetRecentMergedPrs(50);
+        object tableContent = recentPrs.Count == 0
+            ? Callout.Info("No merged pull requests recorded yet.", "No Data")
+            : recentPrs
+                .Select(p => new PrRow
+                {
+                    PlanId = p.PlanId.ToString("D5", CultureInfo.InvariantCulture),
+                    Title = p.PlanTitle,
+                    Repository = string.IsNullOrEmpty(p.Repo) ? "None" : Path.GetFileName(p.Repo),
+                    MergedDate = p.MergedDate.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture),
+                    Url = p.PrUrl
+                })
+                .ToTable()
+                .Header(x => x.PlanId, "Plan")
+                .Header(x => x.Title, "Title")
+                .Header(x => x.Repository, "Repo")
+                .Header(x => x.MergedDate, "Merged")
+                .Header(x => x.Url, "PR URL")
+                .Width(Size.Full());
+
+        return Layout.Vertical().Gap(4)
+               | Callout.Info("Average Daily PRs measures pull request delivery throughput across a rolling 30-day window. Total merged pull requests from the last 30 calendar days are divided by 30.", "Throughput Metric")
+               | details
+               | (Layout.Vertical().Gap(2)
+                  | Text.H4("Recent Merged Pull Requests")
+                  | tableContent);
+    }
+
+    private object BuildAvgCostMonthBreakdown()
+    {
+        var completeMonths = activity.Months.Count > 0
+            ? activity.Months.Take(activity.Months.Count - 1).ToList()
+            : [];
+
+        var costMonths = completeMonths.TakeLast(6).Where(m => m.Cost > 0).ToList();
+        var avgMonthCost = costMonths.Count > 0
+            ? costMonths.Average(m => m.Cost)
+            : (activity.Months.Count > 0 ? activity.Months[^1].Cost : 0);
+        var (lastCost, prevCost) = LastTwo(completeMonths, m => m.Cost);
+        var deltaText = CalculateDelta(lastCost, prevCost);
+
+        var details = new
+        {
+            Metric = "Average Cost per Month",
+            Methodology = "Arithmetic mean of up to 6 complete historical months with spend > $0",
+            AverageCost = FormatCost(avgMonthCost),
+            IncludedMonthsCount = $"{costMonths.Count} completed month(s)",
+            LastCompletedMonthSpend = FormatCost(lastCost),
+            PriorCompletedMonthSpend = FormatCost(prevCost),
+            MonthOverMonthDelta = deltaText
+        }
+            .ToDetails()
+            .Label(x => x.Metric, "Metric")
+            .Label(x => x.Methodology, "Methodology")
+            .Label(x => x.AverageCost, "6-Month Historical Avg")
+            .Label(x => x.IncludedMonthsCount, "Completed Months in Divisor")
+            .Label(x => x.LastCompletedMonthSpend, "Last Completed Month")
+            .Label(x => x.PriorCompletedMonthSpend, "Prior Completed Month")
+            .Label(x => x.MonthOverMonthDelta, "Month-over-Month Delta");
+
+        var monthRows = activity.Months
+            .Select((m, idx) =>
+            {
+                var isInFlight = idx == activity.Months.Count - 1;
+                var isIncluded = costMonths.Contains(m);
+                var status = isInFlight
+                    ? "Excluded (In Flight)"
+                    : isIncluded
+                        ? "Included in Divisor"
+                        : "Excluded ($0 spend)";
+
+                return new MonthRow
+                {
+                    Month = $"{m.Year}-{m.Month:D2}",
+                    Spend = FormatCost(m.Cost),
+                    Tokens = FormatHelper.FormatCount(m.Tokens),
+                    PlansCreated = m.PlansCreated.ToString(CultureInfo.InvariantCulture),
+                    PrsMerged = m.PrsMerged.ToString(CultureInfo.InvariantCulture),
+                    Status = status
+                };
+            })
+            .ToList();
+
+        var table = monthRows
+            .ToTable()
+            .Header(x => x.Month, "Month")
+            .Header(x => x.Spend, "Spend")
+            .Header(x => x.Tokens, "Tokens")
+            .Header(x => x.PlansCreated, "Plans")
+            .Header(x => x.PrsMerged, "PRs Merged")
+            .Header(x => x.Status, "Divisor Status")
+            .Width(Size.Full());
+
+        return Layout.Vertical().Gap(4)
+               | Callout.Info("Average Cost/Month shows retrospective monthly spend across complete historical calendar months, strictly excluding the currently in-flight month to prevent partial-month bias.", "Retrospective Spend")
+               | details
+               | (Layout.Vertical().Gap(2)
+                  | Text.H4("Historical Monthly Breakdown")
+                  | table);
+    }
+
+    private object BuildForecastMonthBreakdown()
+    {
+        var forecast = CostForecastCalculator.Project(activity.DailyCosts ?? [], today);
+        var mtdSpend = activity.DailyCosts?
+            .Where(d => d.Date.Year == today.Year && d.Date.Month == today.Month)
+            .Sum(d => d.Cost) ?? 0m;
+        var daysInMonth = DateTime.DaysInMonth(today.Year, today.Month);
+        var daysRemaining = Math.Max(0, daysInMonth - today.Day);
+
+        var details = new
+        {
+            Metric = "Forecast This Month",
+            MonthToDateSpend = FormatCost(mtdSpend),
+            DaysRemainingInMonth = $"{daysRemaining} day(s)",
+            DaysInCurrentMonth = $"{daysInMonth} day(s)",
+            ObservedCalendarDays = $"{forecast.CalendarDays} day(s)",
+            ActiveSpendDays = $"{forecast.ActivityDays} day(s)",
+            TotalSpendInWindow = FormatCost(forecast.TotalSpend),
+            CalendarBasisProjection = forecast.CalendarProjection.HasValue ? FormatCost(forecast.CalendarProjection.Value) : "No data",
+            ActivityBasisProjection = forecast.ActivityProjection.HasValue ? FormatCost(forecast.ActivityProjection.Value) : "No data"
+        }
+            .ToDetails()
+            .Label(x => x.Metric, "Metric")
+            .Label(x => x.MonthToDateSpend, "Month-to-Date Spend")
+            .Label(x => x.DaysRemainingInMonth, "Days Remaining")
+            .Label(x => x.DaysInCurrentMonth, "Days in Month")
+            .Label(x => x.ObservedCalendarDays, "Calendar Days in Window")
+            .Label(x => x.ActiveSpendDays, "Active Days with Spend")
+            .Label(x => x.TotalSpendInWindow, "Total Window Spend")
+            .Label(x => x.CalendarBasisProjection, "Calendar Basis (Lower Bound)")
+            .Label(x => x.ActivityBasisProjection, "Activity Basis (Upper Bound)");
+
+        var cutoff = DateOnly.FromDateTime(today.AddDays(-29));
+        var daily = (activity.DailyCosts ?? [])
+            .Where(d => d.Date >= cutoff)
+            .OrderByDescending(d => d.Date)
+            .Select(d => new DailyCostRow
+            {
+                Date = d.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                Spend = FormatCost(d.Cost),
+                Tokens = FormatHelper.FormatCount(d.Tokens)
+            })
+            .ToList();
+
+        object tableContent = daily.Count == 0
+            ? Callout.Info("No daily spend records found in the 30-day window.", "No Data")
+            : daily
+                .ToTable()
+                .Header(x => x.Date, "Date")
+                .Header(x => x.Spend, "Daily Spend")
+                .Header(x => x.Tokens, "Tokens")
+                .Width(Size.Full());
+
+        return Layout.Vertical().Gap(4)
+               | Callout.Info("Forecast This Month projects month-end spend using daily activity over the last 30 days. Dual projections indicate uncertainty: Calendar Basis assumes idle days continue at the observed rate, while Activity Basis projects from active spend days only.", "Dual Projections")
+               | details
+               | (Layout.Vertical().Gap(2)
+                  | Text.H4("Daily Spend (Last 30 Days)")
+                  | tableContent);
+    }
+
+    private object BuildAvgCostPlanBreakdown()
+    {
+        var currentAvg = stats.AvgCostPerPlan;
+        var prevAvg = activity.PrevWeekAvgCostPerPlan;
+        var deltaText = CalculateDelta(currentAvg, prevAvg);
+
+        var details = new
+        {
+            Metric = "Average Cost per Plan",
+            RollingWindow = "7 days (plans created in last 7 days)",
+            EligibleStates = "Completed, Failed, Review",
+            Current7DayAverage = FormatHelper.FormatCost(currentAvg),
+            Prior7DayAverage = FormatHelper.FormatCost(prevAvg),
+            PeriodDelta = deltaText
+        }
+            .ToDetails()
+            .Label(x => x.Metric, "Metric")
+            .Label(x => x.RollingWindow, "Window")
+            .Label(x => x.EligibleStates, "Plan States Included")
+            .Label(x => x.Current7DayAverage, "Current 7-Day Average")
+            .Label(x => x.Prior7DayAverage, "Prior 7-Day Average (Days 8-14)")
+            .Label(x => x.PeriodDelta, "7-Day Period Delta");
+
+        var recentPlans = planService.GetRecentPlanCosts(7);
+        object tableContent = recentPlans.Count == 0
+            ? Callout.Info("No plans created in the 7-day rolling window.", "No Data")
+            : recentPlans
+                .Select(p => new PlanCostRow
+                {
+                    PlanId = p.PlanId.ToString("D5", CultureInfo.InvariantCulture),
+                    Title = p.PlanTitle,
+                    State = p.State,
+                    CreatedDate = p.CreatedDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    Tokens = FormatHelper.FormatCount(p.Tokens),
+                    Cost = p.Cost.HasValue ? FormatHelper.FormatCost(p.Cost.Value) : "Unpriced"
+                })
+                .ToTable()
+                .Header(x => x.PlanId, "Plan")
+                .Header(x => x.Title, "Title")
+                .Header(x => x.State, "State")
+                .Header(x => x.CreatedDate, "Created")
+                .Header(x => x.Tokens, "Tokens")
+                .Header(x => x.Cost, "Total Cost")
+                .Width(Size.Full());
+
+        return Layout.Vertical().Gap(4)
+               | Callout.Info("Average Cost per Plan calculates the mean execution and promptware spend for plans created in the last 7 days that reached Completed, Failed, or Review state. Unpriced plans (e.g. subscription runs where cost is null) are excluded from the divisor so they do not artificially deflate the average.", "7-Day Rolling Average")
+               | details
+               | (Layout.Vertical().Gap(2)
+                  | Text.H4("Plans in Rolling Window (Last 7 Days)")
+                  | tableContent);
+    }
+
+    private static (decimal Last, decimal Previous) LastTwo(
+        List<DashboardMonthStats> completeMonths, Func<DashboardMonthStats, decimal> value)
+    {
+        var lastIndex = completeMonths.FindLastIndex(m => value(m) > 0);
+        return lastIndex > 0
+            ? (value(completeMonths[lastIndex]), value(completeMonths[lastIndex - 1]))
+            : (0, 0);
+    }
+
+    private static string CalculateDelta(decimal current, decimal previous)
+    {
+        if (previous <= 0 || current <= 0) return "N/A";
+        var pct = (current - previous) / previous * 100m;
+        var magnitude = Math.Abs(pct) >= 10
+            ? Math.Round(Math.Abs(pct)).ToString("0", CultureInfo.InvariantCulture)
+            : Math.Abs(pct).ToString("0.##", CultureInfo.InvariantCulture);
+        return (pct >= 0 ? "+" : "-") + magnitude + "%";
+    }
+
+    private static string FormatCost(decimal cost) =>
+        cost >= 100 ? FormatHelper.FormatCost(Math.Round(cost), 0) : FormatHelper.FormatCost(cost);
+
+    private sealed record PrRow
+    {
+        public required string PlanId { get; init; }
+        public required string Title { get; init; }
+        public required string Repository { get; init; }
+        public required string MergedDate { get; init; }
+        public required string Url { get; init; }
+    }
+
+    private sealed record MonthRow
+    {
+        public required string Month { get; init; }
+        public required string Spend { get; init; }
+        public required string Tokens { get; init; }
+        public required string PlansCreated { get; init; }
+        public required string PrsMerged { get; init; }
+        public required string Status { get; init; }
+    }
+
+    private sealed record DailyCostRow
+    {
+        public required string Date { get; init; }
+        public required string Spend { get; init; }
+        public required string Tokens { get; init; }
+    }
+
+    private sealed record PlanCostRow
+    {
+        public required string PlanId { get; init; }
+        public required string Title { get; init; }
+        public required string State { get; init; }
+        public required string CreatedDate { get; init; }
+        public required string Tokens { get; init; }
+        public required string Cost { get; init; }
+    }
+}

--- a/src/Ivy.Tendril/Database/DashboardRepository.cs
+++ b/src/Ivy.Tendril/Database/DashboardRepository.cs
@@ -345,4 +345,78 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                 months, prevWeekAvgCost, dailyCosts, dailyPlans, dailyDataStart);
         }
     }
+
+    public List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50)
+    {
+        using (new ReadLockHandle(lockSlim))
+        {
+            var results = new List<RecentMergedPrDto>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT pr.PrUrl, p.Id, p.Title,
+                       (SELECT r.RepoPath FROM Repos r WHERE r.PlanId = p.Id LIMIT 1) AS Repo,
+                       p.Updated
+                FROM PullRequests pr
+                JOIN Plans p ON p.Id = pr.PlanId
+                WHERE p.State = 'Completed'
+                ORDER BY p.Updated DESC
+                LIMIT @limit
+                """;
+            cmd.Parameters.AddWithValue("@limit", limit);
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                var prUrl = r.GetString(0);
+                var planId = r.GetInt32(1);
+                var title = r.GetString(2);
+                var repo = r.IsDBNull(3) ? null : r.GetString(3);
+                var updatedStr = r.GetString(4);
+                var updated = DateTime.TryParse(updatedStr, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var dt)
+                    ? dt
+                    : DateTime.UtcNow;
+                results.Add(new RecentMergedPrDto(prUrl, planId, title, repo, updated));
+            }
+            return results;
+        }
+    }
+
+    public List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7)
+    {
+        using (new ReadLockHandle(lockSlim))
+        {
+            var cutoff = DateTime.UtcNow.Date.AddDays(-(days - 1)).ToString("yyyy-MM-dd");
+            var results = new List<RecentPlanCostDto>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT p.Id, p.Title, p.State, p.Created,
+                       SUM(c.Cost) AS TotalCost,
+                       COUNT(CASE WHEN c.Cost IS NOT NULL THEN 1 END) AS PricedRows,
+                       COALESCE(SUM(c.Tokens), 0) AS TotalTokens
+                FROM Plans p
+                LEFT JOIN Costs c ON c.PlanId = p.Id
+                WHERE p.Created >= @cutoff AND p.State IN ('Completed', 'Failed', 'Review')
+                GROUP BY p.Id, p.Title, p.State, p.Created
+                ORDER BY p.Created DESC
+                """;
+            cmd.Parameters.AddWithValue("@cutoff", cutoff);
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                var planId = r.GetInt32(0);
+                var title = r.GetString(1);
+                var state = r.GetString(2);
+                var createdStr = r.GetString(3);
+                var created = DateTime.TryParse(createdStr, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var dt)
+                    ? dt
+                    : DateTime.UtcNow;
+                var pricedRows = r.GetInt32(5);
+                decimal? cost = pricedRows > 0 && !r.IsDBNull(4)
+                    ? Convert.ToDecimal(r.GetValue(4), CultureInfo.InvariantCulture)
+                    : null;
+                var tokens = Convert.ToInt64(r.GetValue(6), CultureInfo.InvariantCulture);
+                results.Add(new RecentPlanCostDto(planId, title, state, created, cost, tokens));
+            }
+            return results;
+        }
+    }
 }

--- a/src/Ivy.Tendril/Models/DashboardModels.cs
+++ b/src/Ivy.Tendril/Models/DashboardModels.cs
@@ -57,3 +57,21 @@ public record DashboardMonthStats(
     decimal Cost,
     long Tokens
 );
+
+public record RecentMergedPrDto(
+    string PrUrl,
+    int PlanId,
+    string PlanTitle,
+    string? Repo,
+    DateTime MergedDate
+);
+
+public record RecentPlanCostDto(
+    int PlanId,
+    string PlanTitle,
+    string State,
+    DateTime CreatedDate,
+    decimal? Cost,
+    long Tokens
+);
+

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -15,6 +15,8 @@ public interface IPlanDatabaseService : IDisposable
     DashboardModels GetDashboardData(string? projectFilter);
     DashboardActivityStats GetActivityStats(int monthsBack = 24);
     List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days = 30);
+    List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50) => [];
+    List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) => [];
 
     // Costs and tokens
     decimal GetPlanTotalCost(int planId);

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -45,6 +45,8 @@ public interface IPlanReaderService
     DashboardModels GetDashboardData(string? projectFilter);
     DashboardActivityStats GetDashboardActivity(int monthsBack = 24);
     List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days);
+    List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50) => [];
+    List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) => [];
     decimal GetPlanTotalCost(string folderPath);
     int GetPlanTotalTokens(string folderPath);
     List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null);

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -253,6 +253,12 @@ public class PlanDatabaseService : IPlanDatabaseService
     public DashboardActivityStats GetActivityStats(int monthsBack = 24) =>
         _dashboardRepository.GetActivityStats(monthsBack);
 
+    public List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50) =>
+        _dashboardRepository.GetRecentMergedPrs(limit);
+
+    public List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) =>
+        _dashboardRepository.GetRecentPlanCosts(days);
+
     public List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days = 30)
     {
         using (new ReadLockHandle(_lock))

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -634,6 +634,26 @@ public class PlanReaderService(
         return [];
     }
 
+    public List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50)
+    {
+        if (_useDatabaseForReads && _database != null)
+        {
+            return _database.GetRecentMergedPrs(limit);
+        }
+
+        return [];
+    }
+
+    public List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7)
+    {
+        if (_useDatabaseForReads && _database != null)
+        {
+            return _database.GetRecentPlanCosts(days);
+        }
+
+        return [];
+    }
+
     /// <summary>
     ///     Calculates the total cost for a plan. Delegates to database when available,
     ///     otherwise parses costs.csv with a short cache to reduce file I/O.


### PR DESCRIPTION
# Summary

## Changes

Added interactive click-to-open calculation breakdown sheets for all four KPI cards on the dashboard ("Avg Daily PRs", "Avg Cost/Month", "Forecast This Month", and "Avg Cost/Plan"). KPI cards now provide accessible button semantics and focus/hover affordances in the React frontend, wired via an `OnSelectKpi` event to a C# sheet view showing detailed formulas, comparative historical windows, and underlying data records.

## API Changes

- Added `string? Id = null` to `DashboardKpiDto` in `Ivy.Tendril.Widgets`.
- Added `[Event] public EventHandler<Event<TendrilDashboard, string>>? OnSelectKpi` and extension method `TendrilDashboard OnSelectKpi(this TendrilDashboard, Action<string>)` to `TendrilDashboard`.
- Added `RecentMergedPrDto` and `RecentPlanCostDto` to `Ivy.Tendril.Models`.
- Added `Task<List<RecentMergedPrDto>> GetRecentMergedPrs(int limit = 50)` and `Task<List<RecentPlanCostDto>> GetRecentPlanCosts(int days = 7)` to `IPlanDatabaseService`, `PlanDatabaseService`, `IPlanReaderService`, `PlanReaderService`, and `DashboardRepository`.
- Added `KpiBreakdownSheet` component in `Ivy.Tendril.Apps.Views.Sheets`.

## Files Modified

- **Frontend Widget & Styles**:
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx`
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx`
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`
  - `src/Ivy.Tendril.Widgets/TendrilDashboard.cs`
- **Application & Views**:
  - `src/Ivy.Tendril/Apps/DashboardApp.cs`
  - `src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs`
  - `src/Ivy.Tendril/Models/DashboardModels.cs`
- **Database & Services**:
  - `src/Ivy.Tendril/Database/DashboardRepository.cs`
  - `src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs`
  - `src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs`
  - `src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs`
  - `src/Ivy.Tendril/Services/Plans/PlanReaderService.cs`
- **Tests**:
  - `src/Ivy.Tendril.Test/FakePlanReaderService.cs`
  - `src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs`
  - `src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs`

## Manual Testing

1. Launch Tendril and navigate to the Dashboard tab.
2. Hover over any of the four KPI cards (e.g. "Avg Daily PRs" or "Forecast This Month"); observe pointer cursor, hover elevation, and outline affordances.
3. Click on or tab to and press Enter on "Avg Daily PRs": observe the KPI Breakdown Sheet opening with the formula, 30-day comparison window, and merged PRs table.
4. Close the sheet and click on "Forecast This Month": observe the breakdown sheet opening with dual calendar-basis and activity-basis projections alongside daily spend entries.
5. Test the remaining cards ("Avg Cost/Month" and "Avg Cost/Plan") to verify respective historical month averages and rolling 7-day plan spend tables display properly.


---
- e9b4d8ce 00098: Add interactive calculation breakdown sheets and data queries for KPI cards
- c5ca67e1 00098: Add interactive KPI card affordances and selection event to dashboard widget

---
Created using [Ivy Tendril](https://ivy.app).
