### PR TITLE
[00105] Implement Project Environment Files and Dynamic Port Allocation

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/ReviewActionAppTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/ReviewActionAppTests.cs
@@ -97,4 +97,152 @@ public class ReviewActionAppTests
 
         Assert.Null(workDir);
     }
+
+    // --- Ports & environment ---
+
+    private static PlanFile BuildPlan(Dictionary<string, int>? allocatedPorts = null, string folderPath = "/plans/00001-Test")
+    {
+        var metadata = new PlanMetadata(
+            1, "Tendril", "Feature", "Test", PlanStatus.Draft,
+            [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null,
+            AllocatedPorts: allocatedPorts);
+        return new PlanFile(metadata, "", folderPath, "");
+    }
+
+    private static ProjectConfig BuildProjectWithPorts(params (string Name, int DefaultPort)[] ports)
+    {
+        var project = new ProjectConfig { Name = "Tendril" };
+        foreach (var (name, defaultPort) in ports)
+            project.Ports[name] = new ProjectPortConfig { DefaultPort = defaultPort };
+        return project;
+    }
+
+    [Fact]
+    public void ResolvePorts_AllocatedPortWins_OverConfiguredDefault()
+    {
+        var ports = ReviewActionApp.ResolvePorts(
+            BuildPlan(new Dictionary<string, int> { ["backend"] = 31234 }),
+            BuildProjectWithPorts(("backend", 3001)));
+
+        Assert.Equal(31234, ports["backend"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_NoPlan_FallsBackToConfiguredDefaults()
+    {
+        // Review actions also run outside a plan, where nothing has been allocated.
+        var ports = ReviewActionApp.ResolvePorts(null, BuildProjectWithPorts(("backend", 3001)));
+
+        Assert.Equal(3001, ports["backend"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_FollowsTheProjectsConfiguredOrder()
+    {
+        var ports = ReviewActionApp.ResolvePorts(
+            BuildPlan(new Dictionary<string, int> { ["frontend"] = 3000, ["backend"] = 3001 }),
+            BuildProjectWithPorts(("backend", 3001), ("frontend", 3000)));
+
+        // The first configured port is the primary one %PORT% resolves to, so the order must not
+        // depend on the allocation dictionary's insertion order.
+        Assert.Equal(new[] { "backend", "frontend" }, ports.Keys);
+    }
+
+    [Fact]
+    public void ResolvePorts_AllocatedNameMissingFromConfig_IsStillIncluded()
+    {
+        var ports = ReviewActionApp.ResolvePorts(
+            BuildPlan(new Dictionary<string, int> { ["retired"] = 31234 }),
+            BuildProjectWithPorts(("backend", 3001)));
+
+        Assert.Equal(31234, ports["retired"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_ZeroDefaultAndNoAllocation_IsOmitted()
+    {
+        var ports = ReviewActionApp.ResolvePorts(null, BuildProjectWithPorts(("backend", 0)));
+
+        Assert.Empty(ports);
+    }
+
+    [Fact]
+    public void ResolvePorts_NoPlanAndNoProject_ReturnsEmpty()
+    {
+        Assert.Empty(ReviewActionApp.ResolvePorts(null, null));
+    }
+
+    [Fact]
+    public void InterpolateCommand_ExpandsNamedPortPlaceholder()
+    {
+        var command = ReviewActionApp.InterpolateCommand(
+            "dotnet run --urls http://localhost:${ports.backend}",
+            new Dictionary<string, int> { ["backend"] = 31234 });
+
+        Assert.Equal("dotnet run --urls http://localhost:31234", command);
+    }
+
+    [Fact]
+    public void InterpolateCommand_ExpandsBarePortToken_ToTheFirstPort()
+    {
+        var ports = new Dictionary<string, int> { ["backend"] = 31234, ["frontend"] = 31235 };
+
+        var command = ReviewActionApp.InterpolateCommand("npm run dev -- --port %PORT%", ports);
+
+        Assert.Equal("npm run dev -- --port 31234", command);
+    }
+
+    [Fact]
+    public void InterpolateCommand_NoPortsAllocated_LeavesCommandUnchanged()
+    {
+        var command = ReviewActionApp.InterpolateCommand("npm run dev -- --port %PORT%", new Dictionary<string, int>());
+
+        Assert.Equal("npm run dev -- --port %PORT%", command);
+    }
+
+    [Fact]
+    public void BuildEnvironment_ExposesPerPortAndPrimaryVariables()
+    {
+        var env = ReviewActionApp.BuildEnvironment(
+            BuildPlan(new Dictionary<string, int> { ["backend"] = 31234, ["web-ui"] = 31235 }),
+            BuildProjectWithPorts(("backend", 3001), ("web-ui", 3000)));
+
+        Assert.Equal("31234", env["PORT_BACKEND"]);
+        Assert.Equal("31235", env["PORT_WEB_UI"]);
+        Assert.Equal("31234", env["PORT"]);
+    }
+
+    [Fact]
+    public void BuildEnvironment_ExposesPlanContext()
+    {
+        var env = ReviewActionApp.BuildEnvironment(BuildPlan(), BuildProjectWithPorts());
+
+        Assert.Equal("00001", env["PLAN_ID"]);
+        Assert.Equal("/plans/00001-Test", env["PLAN_FOLDER"]);
+        Assert.Equal("Tendril", env["PROJECT_NAME"]);
+    }
+
+    [Fact]
+    public void BuildEnvironment_NoWorktreeOnDisk_OmitsWorktreeDir()
+    {
+        var env = ReviewActionApp.BuildEnvironment(BuildPlan(), BuildProjectWithPorts());
+
+        Assert.False(env.ContainsKey("WORKTREE_DIR"));
+    }
+
+    [Fact]
+    public void BuildEnvironment_NoPlan_StillNamesTheProject()
+    {
+        var env = ReviewActionApp.BuildEnvironment(null, BuildProjectWithPorts(("backend", 3001)));
+
+        Assert.Equal("Tendril", env["PROJECT_NAME"]);
+        Assert.Equal("3001", env["PORT_BACKEND"]);
+        Assert.False(env.ContainsKey("PLAN_ID"));
+    }
+
+    [Fact]
+    public void BuildEnvironment_NoPlanAndNoProject_ReturnsEmpty()
+    {
+        Assert.Empty(ReviewActionApp.BuildEnvironment(null, null));
+    }
 }

--- a/src/Ivy.Tendril.Test/Apps/ReviewActionsBarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/ReviewActionsBarViewTests.cs
@@ -84,4 +84,61 @@ public class ReviewActionsBarViewTests
         Assert.False(button.Disabled);
         Assert.Equal("Run: dotnet run verify", button.Tooltip);
     }
+
+    // --- Allocated ports in the tooltip ---
+
+    [Fact]
+    public void GetTooltip_WithAllocatedPorts_AppendsThemToTheCommand()
+    {
+        var action = new ReviewActionConfig { Name = "Run", Condition = "$true", Command = "dotnet run" };
+
+        var tooltip = ReviewActionsBarView.GetTooltip(action, conditionMet: true,
+            new Dictionary<string, int> { ["frontend"] = 3000, ["backend"] = 3001 });
+
+        // Sorted by name so the tooltip does not reshuffle between renders.
+        Assert.Equal("Run: dotnet run (ports: backend: 3001, frontend: 3000)", tooltip);
+    }
+
+    [Fact]
+    public void GetTooltip_WithAllocatedPortsAndNoCommand_AppendsThemToTheActionName()
+    {
+        var action = new ReviewActionConfig { Name = "Run", Condition = "$true", Command = "" };
+
+        var tooltip = ReviewActionsBarView.GetTooltip(action, conditionMet: true,
+            new Dictionary<string, int> { ["backend"] = 3001 });
+
+        Assert.Equal("Run Run (ports: backend: 3001)", tooltip);
+    }
+
+    [Fact]
+    public void GetTooltip_EmptyAllocatedPorts_OmitsThePortSuffix()
+    {
+        var action = new ReviewActionConfig { Name = "Run", Condition = "$true", Command = "dotnet run" };
+
+        var tooltip = ReviewActionsBarView.GetTooltip(action, conditionMet: true, new Dictionary<string, int>());
+
+        Assert.Equal("Run: dotnet run", tooltip);
+    }
+
+    [Fact]
+    public void GetTooltip_ConditionNotMet_IgnoresAllocatedPorts()
+    {
+        var action = new ReviewActionConfig { Name = "Run", Condition = "$false", Command = "dotnet run" };
+
+        var tooltip = ReviewActionsBarView.GetTooltip(action, conditionMet: false,
+            new Dictionary<string, int> { ["backend"] = 3001 });
+
+        Assert.Equal("Disabled: Condition not met ($false)", tooltip);
+    }
+
+    [Fact]
+    public void BuildActionButton_WithAllocatedPorts_ShowsThemInTheTooltip()
+    {
+        var action = new ReviewActionConfig { Name = "Run", Condition = "$true", Command = "dotnet run" };
+
+        var button = ReviewActionsBarView.BuildActionButton(action, conditionMet: true,
+            allocatedPorts: new Dictionary<string, int> { ["backend"] = 3001 });
+
+        Assert.Equal("Run: dotnet run (ports: backend: 3001)", button.Tooltip);
+    }
 }

--- a/src/Ivy.Tendril.Test/Commands/PlanEnvCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PlanEnvCommandTests.cs
@@ -1,0 +1,341 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test.Commands;
+
+[Collection("TendrilHome")]
+public class PlanEnvCommandTests : IDisposable
+{
+    private readonly string _originalPlans;
+    private readonly string _originalTendrilHome;
+    private readonly string _plansDir;
+    private readonly string _repoPath;
+    private readonly TempDirectoryFixture _tempDir = new("tendril-plan-env-test");
+
+    public PlanEnvCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS") ?? "";
+
+        _plansDir = Path.Combine(_tempDir.Path, "Plans");
+        Directory.CreateDirectory(_plansDir);
+        _repoPath = Path.Combine(_tempDir.Path, "repos", "acme", "widgets");
+        Directory.CreateDirectory(_repoPath);
+
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _plansDir);
+        File.WriteAllText(Path.Combine(_tempDir.Path, "config.yaml"), "projects: []\nverifications: []\n");
+    }
+
+    public void Dispose()
+    {
+        CliOutput.PlainOverride = null;
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalPlans);
+        _tempDir.Dispose();
+    }
+
+    private void SeedProject(
+        Dictionary<string, ProjectPortConfig>? ports = null,
+        List<ProjectEnvFileConfig>? envFiles = null)
+    {
+        var config = new ConfigService();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Widgets",
+            Ports = ports ?? new Dictionary<string, ProjectPortConfig>(),
+            EnvFiles = envFiles ?? new List<ProjectEnvFileConfig>()
+        });
+        config.SaveSettings();
+    }
+
+    private string CreatePlan(string id = "21001", Dictionary<string, int>? allocatedPorts = null)
+    {
+        var planFolder = Path.Combine(_plansDir, $"{id}-PlanEnv");
+        Directory.CreateDirectory(planFolder);
+
+        var plan = new PlanYaml
+        {
+            State = "Executing",
+            Project = "Widgets",
+            Title = "PlanEnv",
+            Repos = [_repoPath],
+            AllocatedPorts = allocatedPorts
+        };
+
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), YamlHelper.Serializer.Serialize(plan));
+        return planFolder;
+    }
+
+    /// <summary>Creates the worktree directory the commands expect for the plan's single repo.</summary>
+    private static string CreateWorktree(string planFolder, string repoPath)
+    {
+        var worktree = WorktreePathHelper.GetWorktreePath(planFolder, repoPath);
+        Directory.CreateDirectory(worktree);
+        return worktree;
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("plan", plan =>
+            {
+                plan.AddBranch("env", env =>
+                {
+                    env.AddCommand<PlanEnvMaterializeCommand>("materialize");
+                    env.AddCommand<PlanEnvGetCommand>("get");
+                });
+            });
+        });
+        return app;
+    }
+
+    private static string CaptureConsoleOut(Action action)
+    {
+        lock (TestLocks.ConsoleLock)
+        {
+            var original = Console.Out;
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            return writer.ToString();
+        }
+    }
+
+    // Mirrors CliOutputTests: AnsiConsole caches its writer, so it has to be swapped separately.
+    private static string CaptureAnsiConsoleOutput(Action action)
+    {
+        var original = AnsiConsole.Console;
+        var writer = new StringWriter();
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(writer)
+        });
+        try
+        {
+            action();
+        }
+        finally
+        {
+            AnsiConsole.Console = original;
+        }
+
+        return writer.ToString();
+    }
+
+    // --- materialize ---
+
+    [Fact]
+    public void Materialize_WritesEnvFileIntoWorktree()
+    {
+        SeedProject(
+            new Dictionary<string, ProjectPortConfig> { ["backend"] = new() { DefaultPort = 3001 } },
+            [
+                new ProjectEnvFileConfig
+                {
+                    Path = ".env",
+                    Overrides = new Dictionary<string, string> { ["PORT"] = "${ports.backend}" }
+                }
+            ]);
+        var planFolder = CreatePlan();
+        var worktree = CreateWorktree(planFolder, _repoPath);
+
+        var exitCode = BuildApp().Run(["plan", "env", "materialize", "21001"]);
+
+        Assert.Equal(0, exitCode);
+        var allocated = PlanCommandHelpers.ReadPlan(planFolder).AllocatedPorts!["backend"];
+        Assert.Equal($"PORT={allocated}\n", File.ReadAllText(Path.Combine(worktree, ".env")));
+    }
+
+    [Fact]
+    public void Materialize_RecordsAllocatedPortsOnThePlan()
+    {
+        SeedProject(new Dictionary<string, ProjectPortConfig> { ["backend"] = new() { DefaultPort = 3001 } });
+        var planFolder = CreatePlan();
+        CreateWorktree(planFolder, _repoPath);
+
+        BuildApp().Run(["plan", "env", "materialize", "21001"]);
+
+        Assert.Single(PlanCommandHelpers.ReadPlan(planFolder).AllocatedPorts!);
+    }
+
+    [Fact]
+    public void Materialize_NoWorktree_ReturnsOne()
+    {
+        SeedProject();
+        CreatePlan();
+
+        var output = CaptureAnsiConsoleOutput(() =>
+        {
+            var exitCode = BuildApp().Run(["plan", "env", "materialize", "21001"]);
+            Assert.Equal(1, exitCode);
+        });
+
+        Assert.Contains("No worktrees found for this plan", output);
+    }
+
+    [Fact]
+    public void Materialize_RepoFilterMatchesRepoName_WritesTheFile()
+    {
+        SeedProject(envFiles:
+        [
+            new ProjectEnvFileConfig
+            {
+                Path = ".env",
+                Overrides = new Dictionary<string, string> { ["A"] = "1" }
+            }
+        ]);
+        var planFolder = CreatePlan();
+        var worktree = CreateWorktree(planFolder, _repoPath);
+
+        var exitCode = BuildApp().Run(["plan", "env", "materialize", "21001", "--repo", "widgets"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(Path.Combine(worktree, ".env")));
+    }
+
+    [Fact]
+    public void Materialize_RepoFilterMatchesNothing_ReturnsOne()
+    {
+        SeedProject();
+        var planFolder = CreatePlan();
+        CreateWorktree(planFolder, _repoPath);
+
+        var output = CaptureAnsiConsoleOutput(() =>
+        {
+            var exitCode = BuildApp().Run(["plan", "env", "materialize", "21001", "--repo", "gadgets"]);
+            Assert.Equal(1, exitCode);
+        });
+
+        Assert.Contains("No worktree found for repo gadgets", output);
+    }
+
+    [Fact]
+    public void Materialize_NoEnvFilesConfigured_SucceedsWithoutWriting()
+    {
+        SeedProject(new Dictionary<string, ProjectPortConfig> { ["backend"] = new() { DefaultPort = 3001 } });
+        var planFolder = CreatePlan();
+        var worktree = CreateWorktree(planFolder, _repoPath);
+
+        var exitCode = BuildApp().Run(["plan", "env", "materialize", "21001"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(Directory.GetFiles(worktree));
+    }
+
+    [Fact]
+    public void Materialize_UnknownProject_ListsAvailable()
+    {
+        SeedProject();
+        var planFolder = Path.Combine(_plansDir, "21002-Orphan");
+        Directory.CreateDirectory(planFolder);
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), YamlHelper.Serializer.Serialize(new PlanYaml
+        {
+            State = "Executing",
+            Project = "Gone",
+            Title = "Orphan",
+            Repos = [_repoPath]
+        }));
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => BuildApp().Run(["plan", "env", "materialize", "21002"]));
+
+        Assert.Contains("Available: Widgets", ex.Message);
+    }
+
+    [Fact]
+    public void Materialize_UnknownPlan_Throws()
+    {
+        SeedProject();
+
+        Assert.Throws<DirectoryNotFoundException>(() => BuildApp().Run(["plan", "env", "materialize", "29999"]));
+    }
+
+    [Fact]
+    public void MaterializeSettings_Validate_BlankPlanId_Fails()
+    {
+        Assert.False(new PlanEnvMaterializeSettings { PlanId = "" }.Validate().Successful);
+    }
+
+    // --- get ---
+
+    [Fact]
+    public void Get_PlainMode_ListsAllocatedPorts()
+    {
+        SeedProject(new Dictionary<string, ProjectPortConfig> { ["backend"] = new() { DefaultPort = 3001 } });
+        CreatePlan(allocatedPorts: new Dictionary<string, int> { ["backend"] = 31801 });
+        CliOutput.PlainOverride = true;
+
+        var output = CaptureConsoleOut(() => BuildApp().Run(["plan", "env", "get", "21001"]));
+
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Equal("Port\tValue", lines[0]);
+        Assert.Equal("backend\t31801", lines[1]);
+    }
+
+    [Fact]
+    public void Get_PrintsResolvedEnvValues()
+    {
+        SeedProject(
+            new Dictionary<string, ProjectPortConfig> { ["backend"] = new() { DefaultPort = 3001 } },
+            [
+                new ProjectEnvFileConfig
+                {
+                    Path = ".env",
+                    Overrides = new Dictionary<string, string> { ["PORT"] = "${ports.backend}" }
+                }
+            ]);
+        CreatePlan(allocatedPorts: new Dictionary<string, int> { ["backend"] = 31802 });
+        CliOutput.PlainOverride = true;
+
+        var output = CaptureConsoleOut(() => BuildApp().Run(["plan", "env", "get", "21001"]));
+
+        Assert.Contains("PORT=31802", output);
+    }
+
+    [Fact]
+    public void Get_DoesNotAllocateOrWrite()
+    {
+        SeedProject(
+            new Dictionary<string, ProjectPortConfig> { ["backend"] = new() { DefaultPort = 3001 } },
+            [new ProjectEnvFileConfig { Path = ".env", Overrides = new Dictionary<string, string> { ["A"] = "1" } }]);
+        var planFolder = CreatePlan();
+        var worktree = CreateWorktree(planFolder, _repoPath);
+
+        var exitCode = BuildApp().Run(["plan", "env", "get", "21001"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Null(PlanCommandHelpers.ReadPlan(planFolder).AllocatedPorts);
+        Assert.Empty(Directory.GetFiles(worktree));
+    }
+
+    [Fact]
+    public void Get_NoWorktree_StillResolvesOverrides()
+    {
+        SeedProject(envFiles:
+            [new ProjectEnvFileConfig { Path = ".env", Overrides = new Dictionary<string, string> { ["A"] = "1" } }]);
+        CreatePlan();
+        CliOutput.PlainOverride = true;
+
+        var output = CaptureConsoleOut(() => BuildApp().Run(["plan", "env", "get", "21001"]));
+
+        Assert.Contains("A=1", output);
+    }
+}

--- a/src/Ivy.Tendril.Test/Commands/ProjectEnvFileCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/ProjectEnvFileCommandTests.cs
@@ -1,0 +1,238 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test.Commands;
+
+[Collection("TendrilHome")]
+public class ProjectEnvFileCommandTests : IDisposable
+{
+    private readonly string _originalTendrilHome;
+    private readonly TempDirectoryFixture _tempDir = new("tendril-project-envfile-test");
+
+    public ProjectEnvFileCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+        File.WriteAllText(Path.Combine(_tempDir.Path, "config.yaml"), "projects: []\nverifications: []\n");
+    }
+
+    public void Dispose()
+    {
+        CliOutput.PlainOverride = null;
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private ConfigService CreateConfig() => new();
+
+    private void SeedProject(params ProjectEnvFileConfig[] envFiles)
+    {
+        var config = CreateConfig();
+        var project = new ProjectConfig { Name = "Tendril" };
+        project.EnvFiles.AddRange(envFiles);
+        config.Settings.Projects.Add(project);
+        config.SaveSettings();
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("project", project =>
+            {
+                project.AddBranch("env-file", envFile =>
+                {
+                    envFile.AddCommand<ProjectListEnvFilesCommand>("list");
+                    envFile.AddCommand<ProjectAddEnvFileCommand>("add");
+                    envFile.AddCommand<ProjectRemoveEnvFileCommand>("remove");
+                });
+            });
+        });
+        return app;
+    }
+
+    private static string CaptureConsoleOut(Action action)
+    {
+        lock (TestLocks.ConsoleLock)
+        {
+            var original = Console.Out;
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            return writer.ToString();
+        }
+    }
+
+    [Fact]
+    public void AddEnvFile_PersistsPathTemplateAndOverrides()
+    {
+        SeedProject();
+
+        var exitCode = BuildApp().Run(["project", "env-file", "add", "Tendril", "apps/web/.env",
+            "--template", ".env.example",
+            "--override", "PORT=${ports.backend}",
+            "--override", "LOG_LEVEL=debug"]);
+
+        Assert.Equal(0, exitCode);
+        var envFile = Assert.Single(CreateConfig().Settings.Projects[0].EnvFiles);
+        Assert.Equal("apps/web/.env", envFile.Path);
+        Assert.Equal(".env.example", envFile.Template);
+        Assert.Equal("${ports.backend}", envFile.Overrides["PORT"]);
+        Assert.Equal("debug", envFile.Overrides["LOG_LEVEL"]);
+    }
+
+    [Fact]
+    public void AddEnvFile_WithoutTemplate_LeavesTemplateNull()
+    {
+        SeedProject();
+
+        BuildApp().Run(["project", "env-file", "add", "Tendril", ".env"]);
+
+        Assert.Null(CreateConfig().Settings.Projects[0].EnvFiles[0].Template);
+    }
+
+    [Fact]
+    public void AddEnvFile_ValueContainingEquals_KeepsTheWholeValue()
+    {
+        SeedProject();
+
+        BuildApp().Run(["project", "env-file", "add", "Tendril", ".env",
+            "--override", "CONNECTION=Host=localhost;Port=5432"]);
+
+        Assert.Equal(
+            "Host=localhost;Port=5432",
+            CreateConfig().Settings.Projects[0].EnvFiles[0].Overrides["CONNECTION"]);
+    }
+
+    [Fact]
+    public void AddEnvFile_SamePath_ReplacesTheEntry()
+    {
+        SeedProject(new ProjectEnvFileConfig
+        {
+            Path = ".env",
+            Overrides = new Dictionary<string, string> { ["OLD"] = "1" }
+        });
+
+        var output = CaptureConsoleOut(() =>
+            BuildApp().Run(["project", "env-file", "add", "Tendril", ".env", "--override", "NEW=2"]));
+
+        Assert.Contains("Updated environment file: .env", output);
+        var envFile = Assert.Single(CreateConfig().Settings.Projects[0].EnvFiles);
+        Assert.Equal(new[] { "NEW" }, envFile.Overrides.Keys);
+    }
+
+    [Fact]
+    public void AddEnvFile_NewPath_ReportsAdded()
+    {
+        SeedProject();
+
+        var output = CaptureConsoleOut(() =>
+            BuildApp().Run(["project", "env-file", "add", "Tendril", ".env"]));
+
+        Assert.Contains("Added environment file: .env", output);
+    }
+
+    [Fact]
+    public void AddEnvFile_UnknownProject_ListsAvailable()
+    {
+        SeedProject();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => BuildApp().Run(["project", "env-file", "add", "Missing", ".env"]));
+
+        Assert.Contains("Available: Tendril", ex.Message);
+    }
+
+    [Fact]
+    public void AddEnvFileSettings_Validate_OverrideWithoutEquals_Fails()
+    {
+        var settings = new ProjectAddEnvFileSettings
+        {
+            ProjectName = "Tendril",
+            Path = ".env",
+            Overrides = ["PORT"]
+        };
+
+        var result = settings.Validate();
+
+        Assert.False(result.Successful);
+        Assert.Contains("--override must be KEY=VALUE", result.Message);
+    }
+
+    [Fact]
+    public void AddEnvFileSettings_Validate_WellFormedOverride_Succeeds()
+    {
+        var settings = new ProjectAddEnvFileSettings
+        {
+            ProjectName = "Tendril",
+            Path = ".env",
+            Overrides = ["PORT=3001"]
+        };
+
+        Assert.True(settings.Validate().Successful);
+    }
+
+    [Fact]
+    public void ListEnvFiles_PlainMode_WritesTabSeparatedRows()
+    {
+        SeedProject(new ProjectEnvFileConfig
+        {
+            Path = ".env",
+            Template = ".env.example",
+            Overrides = new Dictionary<string, string> { ["PORT"] = "3001" }
+        });
+        CliOutput.PlainOverride = true;
+
+        var output = CaptureConsoleOut(() => BuildApp().Run(["project", "env-file", "list", "Tendril"]));
+
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Equal("Path\tTemplate\tOverrides", lines[0]);
+        Assert.Equal(".env\t.env.example\tPORT", lines[1]);
+    }
+
+    [Fact]
+    public void ListEnvFiles_NoneConfigured_Succeeds()
+    {
+        SeedProject();
+
+        Assert.Equal(0, BuildApp().Run(["project", "env-file", "list", "Tendril"]));
+    }
+
+    [Fact]
+    public void RemoveEnvFile_DeletesFromConfig()
+    {
+        SeedProject(
+            new ProjectEnvFileConfig { Path = ".env" },
+            new ProjectEnvFileConfig { Path = "apps/web/.env" });
+
+        var exitCode = BuildApp().Run(["project", "env-file", "remove", "Tendril", ".env"]);
+
+        Assert.Equal(0, exitCode);
+        var remaining = Assert.Single(CreateConfig().Settings.Projects[0].EnvFiles);
+        Assert.Equal("apps/web/.env", remaining.Path);
+    }
+
+    [Fact]
+    public void RemoveEnvFile_UnknownPath_Throws()
+    {
+        SeedProject(new ProjectEnvFileConfig { Path = ".env" });
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => BuildApp().Run(["project", "env-file", "remove", "Tendril", "missing/.env"]));
+
+        Assert.Contains("Environment file not found: missing/.env", ex.Message);
+        Assert.Single(CreateConfig().Settings.Projects[0].EnvFiles);
+    }
+}

--- a/src/Ivy.Tendril.Test/Commands/ProjectPortCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/ProjectPortCommandTests.cs
@@ -1,0 +1,217 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test.Commands;
+
+[Collection("TendrilHome")]
+public class ProjectPortCommandTests : IDisposable
+{
+    private readonly string _originalTendrilHome;
+    private readonly TempDirectoryFixture _tempDir = new("tendril-project-port-test");
+
+    public ProjectPortCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+        File.WriteAllText(Path.Combine(_tempDir.Path, "config.yaml"), "projects: []\nverifications: []\n");
+    }
+
+    public void Dispose()
+    {
+        CliOutput.PlainOverride = null;
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private ConfigService CreateConfig() => new();
+
+    private void SeedProject(params (string Name, int DefaultPort)[] ports)
+    {
+        var config = CreateConfig();
+        var project = new ProjectConfig { Name = "Tendril" };
+        foreach (var (name, defaultPort) in ports)
+            project.Ports[name] = new ProjectPortConfig { DefaultPort = defaultPort };
+        config.Settings.Projects.Add(project);
+        config.SaveSettings();
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("project", project =>
+            {
+                project.AddBranch("port", port =>
+                {
+                    port.AddCommand<ProjectListPortsCommand>("list");
+                    port.AddCommand<ProjectAddPortCommand>("add");
+                    port.AddCommand<ProjectRemovePortCommand>("remove");
+                });
+            });
+        });
+        return app;
+    }
+
+    private static string CaptureConsoleOut(Action action)
+    {
+        lock (TestLocks.ConsoleLock)
+        {
+            var original = Console.Out;
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            return writer.ToString();
+        }
+    }
+
+    [Fact]
+    public void AddPort_PersistsToConfig()
+    {
+        SeedProject();
+
+        var exitCode = BuildApp().Run(["project", "port", "add", "Tendril", "backend", "3001",
+            "--description", "ASP.NET API"]);
+
+        Assert.Equal(0, exitCode);
+        var port = Assert.Single(CreateConfig().Settings.Projects[0].Ports);
+        Assert.Equal("backend", port.Key);
+        Assert.Equal(3001, port.Value.DefaultPort);
+        Assert.Equal("ASP.NET API", port.Value.Description);
+    }
+
+    [Fact]
+    public void AddPort_WithoutDescription_StoresEmptyDescription()
+    {
+        SeedProject();
+
+        BuildApp().Run(["project", "port", "add", "Tendril", "backend", "3001"]);
+
+        Assert.Equal("", CreateConfig().Settings.Projects[0].Ports["backend"].Description);
+    }
+
+    [Fact]
+    public void AddPort_ExistingName_UpdatesInPlace()
+    {
+        SeedProject(("backend", 3001));
+
+        var output = CaptureConsoleOut(() =>
+            BuildApp().Run(["project", "port", "add", "Tendril", "backend", "4001"]));
+
+        Assert.Contains("Updated port: backend -> 4001", output);
+        var port = Assert.Single(CreateConfig().Settings.Projects[0].Ports);
+        Assert.Equal(4001, port.Value.DefaultPort);
+    }
+
+    [Fact]
+    public void AddPort_NewName_ReportsAdded()
+    {
+        SeedProject();
+
+        var output = CaptureConsoleOut(() =>
+            BuildApp().Run(["project", "port", "add", "Tendril", "frontend", "3000"]));
+
+        Assert.Contains("Added port: frontend -> 3000", output);
+    }
+
+    [Fact]
+    public void AddPort_UnknownProject_ListsAvailable()
+    {
+        SeedProject();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => BuildApp().Run(["project", "port", "add", "Missing", "backend", "3001"]));
+
+        Assert.Contains("Available: Tendril", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("70000")]
+    public void AddPort_OutOfRangePort_FailsValidation(string port)
+    {
+        var settings = new ProjectAddPortSettings
+        {
+            ProjectName = "Tendril",
+            Name = "backend",
+            DefaultPort = int.Parse(port)
+        };
+
+        var result = settings.Validate();
+
+        Assert.False(result.Successful);
+        Assert.Contains("default-port must be between 1 and 65535", result.Message);
+    }
+
+    [Fact]
+    public void AddPortSettings_Validate_ValidPort_Succeeds()
+    {
+        var settings = new ProjectAddPortSettings
+        {
+            ProjectName = "Tendril",
+            Name = "backend",
+            DefaultPort = 3001
+        };
+
+        Assert.True(settings.Validate().Successful);
+    }
+
+    [Fact]
+    public void ListPorts_PlainMode_WritesTabSeparatedRows()
+    {
+        SeedProject();
+        BuildApp().Run(["project", "port", "add", "Tendril", "backend", "3001", "--description", "API"]);
+        CliOutput.PlainOverride = true;
+
+        var output = CaptureConsoleOut(() => BuildApp().Run(["project", "port", "list", "Tendril"]));
+
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Equal("Name\tDefault Port\tDescription", lines[0]);
+        Assert.Equal("backend\t3001\tAPI", lines[1]);
+    }
+
+    [Fact]
+    public void ListPorts_NoPortsConfigured_Succeeds()
+    {
+        SeedProject();
+
+        Assert.Equal(0, BuildApp().Run(["project", "port", "list", "Tendril"]));
+    }
+
+    [Fact]
+    public void RemovePort_DeletesFromConfig()
+    {
+        SeedProject(("backend", 3001), ("frontend", 3000));
+
+        var exitCode = BuildApp().Run(["project", "port", "remove", "Tendril", "backend"]);
+
+        Assert.Equal(0, exitCode);
+        var remaining = Assert.Single(CreateConfig().Settings.Projects[0].Ports);
+        Assert.Equal("frontend", remaining.Key);
+    }
+
+    [Fact]
+    public void RemovePort_UnknownName_Throws()
+    {
+        SeedProject(("backend", 3001));
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => BuildApp().Run(["project", "port", "remove", "Tendril", "missing"]));
+
+        Assert.Contains("Port not found: missing", ex.Message);
+        // The failed mutation must not have dropped the port that does exist.
+        Assert.Single(CreateConfig().Settings.Projects[0].Ports);
+    }
+}

--- a/src/Ivy.Tendril.Test/Helpers/EnvironmentMaterializationHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/EnvironmentMaterializationHelperTests.cs
@@ -1,0 +1,257 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+public class EnvironmentMaterializationHelperTests : IDisposable
+{
+    private readonly TempDirectoryFixture _worktree = new("tendril-env-mat-test");
+
+    public void Dispose() => _worktree.Dispose();
+
+    private static ProjectConfig BuildProject(ProjectEnvFileConfig envFile, params (string Name, int DefaultPort)[] ports)
+    {
+        var project = new ProjectConfig { Name = "Env" };
+        project.EnvFiles.Add(envFile);
+        foreach (var (name, defaultPort) in ports)
+            project.Ports[name] = new ProjectPortConfig { DefaultPort = defaultPort };
+        return project;
+    }
+
+    private void WriteTemplate(string relativePath, string content) =>
+        File.WriteAllText(Path.Combine(_worktree.Path, relativePath), content);
+
+    private string ReadWritten(string relativePath) =>
+        File.ReadAllText(Path.Combine(_worktree.Path, relativePath));
+
+    [Fact]
+    public void MaterializeEnvFiles_TemplateAndOverrides_MergesBoth()
+    {
+        WriteTemplate(".env.example", "DATABASE_URL=postgres://localhost/dev\nLOG_LEVEL=info\n");
+        var project = BuildProject(new ProjectEnvFileConfig
+        {
+            Path = ".env",
+            Template = ".env.example",
+            Overrides = new Dictionary<string, string> { ["LOG_LEVEL"] = "debug", ["API_KEY"] = "local" }
+        });
+
+        var written = EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int>(), _worktree.Path);
+
+        Assert.Equal(1, written);
+        Assert.Equal(
+            "DATABASE_URL=postgres://localhost/dev\nLOG_LEVEL=debug\nAPI_KEY=local\n",
+            ReadWritten(".env"));
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_PortPlaceholder_ResolvesToAllocatedPort()
+    {
+        var project = BuildProject(
+            new ProjectEnvFileConfig
+            {
+                Path = ".env",
+                Overrides = new Dictionary<string, string>
+                {
+                    ["PORT"] = "${ports.backend}",
+                    ["VITE_API_URL"] = "http://localhost:${ports.backend}/api"
+                }
+            },
+            ("backend", 3001));
+
+        EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int> { ["backend"] = 31234 }, _worktree.Path);
+
+        Assert.Equal("PORT=31234\nVITE_API_URL=http://localhost:31234/api\n", ReadWritten(".env"));
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_PortNotAllocated_FallsBackToConfiguredDefault()
+    {
+        var project = BuildProject(
+            new ProjectEnvFileConfig
+            {
+                Path = ".env",
+                Overrides = new Dictionary<string, string> { ["PORT"] = "${ports.backend}" }
+            },
+            ("backend", 3001));
+
+        EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int>(), _worktree.Path);
+
+        Assert.Equal("PORT=3001\n", ReadWritten(".env"));
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_UnknownPortName_LeavesPlaceholderVisible()
+    {
+        var project = BuildProject(new ProjectEnvFileConfig
+        {
+            Path = ".env",
+            Overrides = new Dictionary<string, string> { ["PORT"] = "${ports.nope}" }
+        });
+
+        EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int>(), _worktree.Path);
+
+        // An empty value would look like a working config; the literal placeholder does not.
+        Assert.Equal("PORT=${ports.nope}\n", ReadWritten(".env"));
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_TemplatePortPlaceholder_IsExpandedToo()
+    {
+        WriteTemplate(".env.example", "PORT=${ports.backend}\n");
+        var project = BuildProject(
+            new ProjectEnvFileConfig { Path = ".env", Template = ".env.example" },
+            ("backend", 3001));
+
+        EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int> { ["backend"] = 31235 }, _worktree.Path);
+
+        Assert.Equal("PORT=31235\n", ReadWritten(".env"));
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_EnvPlaceholder_ReadsHostEnvironment()
+    {
+        var variable = $"TENDRIL_ENV_MAT_TEST_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(variable, "from-host");
+        try
+        {
+            var project = BuildProject(new ProjectEnvFileConfig
+            {
+                Path = ".env",
+                Overrides = new Dictionary<string, string>
+                {
+                    ["PRESENT"] = $"${{env.{variable}}}",
+                    ["ABSENT"] = "${env.TENDRIL_ENV_MAT_TEST_UNSET}"
+                }
+            });
+
+            EnvironmentMaterializationHelper.MaterializeEnvFiles(
+                project, new Dictionary<string, int>(), _worktree.Path);
+
+            Assert.Equal("PRESENT=from-host\nABSENT=\n", ReadWritten(".env"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_PreservesCommentsAndBlankLines()
+    {
+        WriteTemplate(".env.example", "# Database\n\nDATABASE_URL=postgres://localhost/dev\n");
+        var project = BuildProject(new ProjectEnvFileConfig { Path = ".env", Template = ".env.example" });
+
+        EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int>(), _worktree.Path);
+
+        Assert.Equal("# Database\n\nDATABASE_URL=postgres://localhost/dev\n", ReadWritten(".env"));
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_UsesUnixLineEndings()
+    {
+        var project = BuildProject(new ProjectEnvFileConfig
+        {
+            Path = ".env",
+            Overrides = new Dictionary<string, string> { ["A"] = "1", ["B"] = "2" }
+        });
+
+        EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int>(), _worktree.Path);
+
+        // A trailing CR would become part of the value in Node and Python dotenv parsers.
+        Assert.DoesNotContain('\r', ReadWritten(".env"));
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_NestedPath_CreatesDirectories()
+    {
+        var project = BuildProject(new ProjectEnvFileConfig
+        {
+            Path = Path.Combine("apps", "web", ".env"),
+            Overrides = new Dictionary<string, string> { ["A"] = "1" }
+        });
+
+        var written = EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int>(), _worktree.Path);
+
+        Assert.Equal(1, written);
+        Assert.True(File.Exists(Path.Combine(_worktree.Path, "apps", "web", ".env")));
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_MissingTemplate_WritesOverridesOnly()
+    {
+        var project = BuildProject(new ProjectEnvFileConfig
+        {
+            Path = ".env",
+            Template = "does-not-exist.env",
+            Overrides = new Dictionary<string, string> { ["A"] = "1" }
+        });
+
+        var written = EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int>(), _worktree.Path);
+
+        Assert.Equal(1, written);
+        Assert.Equal("A=1\n", ReadWritten(".env"));
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_BlankPath_IsSkipped()
+    {
+        var project = BuildProject(new ProjectEnvFileConfig { Path = "  " });
+
+        var written = EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int>(), _worktree.Path);
+
+        Assert.Equal(0, written);
+    }
+
+    [Fact]
+    public void MaterializeEnvFiles_ExportPrefixedTemplateKey_IsOverridden()
+    {
+        WriteTemplate(".env.example", "export LOG_LEVEL=info\n");
+        var project = BuildProject(new ProjectEnvFileConfig
+        {
+            Path = ".env",
+            Template = ".env.example",
+            Overrides = new Dictionary<string, string> { ["LOG_LEVEL"] = "debug" }
+        });
+
+        EnvironmentMaterializationHelper.MaterializeEnvFiles(
+            project, new Dictionary<string, int>(), _worktree.Path);
+
+        Assert.Equal("LOG_LEVEL=debug\n", ReadWritten(".env"));
+    }
+
+    [Fact]
+    public void ResolveEnvValues_ReturnsResolvedPairsWithoutWriting()
+    {
+        var envFile = new ProjectEnvFileConfig
+        {
+            Path = ".env",
+            Overrides = new Dictionary<string, string> { ["PORT"] = "${ports.backend}" }
+        };
+        var project = BuildProject(envFile, ("backend", 3001));
+
+        var values = EnvironmentMaterializationHelper.ResolveEnvValues(
+            envFile, project, new Dictionary<string, int> { ["backend"] = 31236 }, _worktree.Path);
+
+        Assert.Equal(new KeyValuePair<string, string>("PORT", "31236"), Assert.Single(values));
+        Assert.False(File.Exists(Path.Combine(_worktree.Path, ".env")));
+    }
+
+    [Fact]
+    public void ExpandPortPlaceholders_NoPlaceholder_ReturnsInputUnchanged()
+    {
+        var result = EnvironmentMaterializationHelper.ExpandPortPlaceholders(
+            "dotnet run", new Dictionary<string, int> { ["backend"] = 3001 });
+
+        Assert.Equal("dotnet run", result);
+    }
+}

--- a/src/Ivy.Tendril.Test/Helpers/PortAllocationHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PortAllocationHelperTests.cs
@@ -1,0 +1,278 @@
+using System.Net;
+using System.Net.Sockets;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+public class PortAllocationHelperTests
+{
+    private static ProjectConfig BuildProject(params (string Name, int DefaultPort)[] ports)
+    {
+        var project = new ProjectConfig { Name = "Ports" };
+        foreach (var (name, defaultPort) in ports)
+            project.Ports[name] = new ProjectPortConfig { DefaultPort = defaultPort };
+        return project;
+    }
+
+    /// <summary>Availability probe that treats the named ports as occupied and everything else as free.</summary>
+    private static Func<int, bool> Busy(params int[] busyPorts) => port => !busyPorts.Contains(port);
+
+    [Fact]
+    public void ResolvePorts_DefaultPortFree_UsesDefaultPort()
+    {
+        var resolved = PortAllocationHelper.ResolvePorts(
+            BuildProject(("backend", 3001)), null, new HashSet<int>(), Busy());
+
+        Assert.Equal(3001, resolved["backend"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_DefaultPortBusy_FallsBackToEphemeralRange()
+    {
+        var resolved = PortAllocationHelper.ResolvePorts(
+            BuildProject(("backend", 3001)), null, new HashSet<int>(), Busy(3001));
+
+        Assert.Equal(PortAllocationHelper.EphemeralRangeStart, resolved["backend"]);
+        Assert.InRange(resolved["backend"],
+            PortAllocationHelper.EphemeralRangeStart, PortAllocationHelper.EphemeralRangeEnd);
+    }
+
+    [Fact]
+    public void ResolvePorts_ExistingPortStillFree_IsRetained()
+    {
+        var existing = new Dictionary<string, int> { ["backend"] = 31234 };
+
+        var resolved = PortAllocationHelper.ResolvePorts(
+            BuildProject(("backend", 3001)), existing, new HashSet<int>(), Busy());
+
+        // The default port is free, but a reviewer may already have the retained URL open.
+        Assert.Equal(31234, resolved["backend"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_ExistingPortNowBusy_IsReallocated()
+    {
+        var existing = new Dictionary<string, int> { ["backend"] = 31234 };
+
+        var resolved = PortAllocationHelper.ResolvePorts(
+            BuildProject(("backend", 3001)), existing, new HashSet<int>(), Busy(31234));
+
+        Assert.Equal(3001, resolved["backend"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_TwoNamesSharingADefault_DoNotCollide()
+    {
+        var resolved = PortAllocationHelper.ResolvePorts(
+            BuildProject(("backend", 3000), ("frontend", 3000)), null, new HashSet<int>(), Busy());
+
+        Assert.Equal(3000, resolved["backend"]);
+        Assert.NotEqual(3000, resolved["frontend"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_PortReservedByAnotherPlan_IsAvoided()
+    {
+        var resolved = PortAllocationHelper.ResolvePorts(
+            BuildProject(("backend", 3001)), null, new HashSet<int> { 3001 }, Busy());
+
+        Assert.NotEqual(3001, resolved["backend"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_ReservedExistingPort_IsNotRetained()
+    {
+        var existing = new Dictionary<string, int> { ["backend"] = 31234 };
+
+        var resolved = PortAllocationHelper.ResolvePorts(
+            BuildProject(("backend", 3001)), existing, new HashSet<int> { 31234 }, Busy());
+
+        Assert.Equal(3001, resolved["backend"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_RangeExhausted_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PortAllocationHelper.ResolvePorts(
+                BuildProject(("backend", 3001)), null, new HashSet<int>(), _ => false));
+
+        Assert.Contains("No free TCP port available for 'backend'", ex.Message);
+    }
+
+    [Fact]
+    public void ResolvePorts_NameRemovedFromConfig_KeepsItsRecordedPort()
+    {
+        var existing = new Dictionary<string, int> { ["retired"] = 31234 };
+
+        var resolved = PortAllocationHelper.ResolvePorts(
+            BuildProject(("backend", 3001)), existing, new HashSet<int>(), Busy());
+
+        Assert.Equal(3001, resolved["backend"]);
+        Assert.Equal(31234, resolved["retired"]);
+    }
+
+    [Fact]
+    public void ResolvePorts_NoPortsConfigured_ReturnsEmpty()
+    {
+        var resolved = PortAllocationHelper.ResolvePorts(
+            new ProjectConfig { Name = "None" }, null, new HashSet<int>(), Busy());
+
+        Assert.Empty(resolved);
+    }
+
+    [Fact]
+    public void IsPortAvailable_BoundPort_ReturnsFalse()
+    {
+        // Loopback only: binding 0.0.0.0 is blocked on some hosts.
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        try
+        {
+            Assert.False(PortAllocationHelper.IsPortAvailable(port));
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public void IsPortAvailable_FreePort_ReturnsTrue()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+
+        Assert.True(PortAllocationHelper.IsPortAvailable(port));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(70000)]
+    public void IsPortAvailable_OutOfRange_ReturnsFalse(int port)
+    {
+        Assert.False(PortAllocationHelper.IsPortAvailable(port));
+    }
+}
+
+[Collection("TendrilHome")]
+public class PortAllocationHelperPlanTests : IDisposable
+{
+    private readonly string _plansDir;
+    private readonly TempDirectoryFixture _tempDir = new("tendril-port-alloc-test");
+
+    public PortAllocationHelperPlanTests()
+    {
+        _plansDir = Path.Combine(_tempDir.Path, "Plans");
+        Directory.CreateDirectory(_plansDir);
+    }
+
+    public void Dispose() => _tempDir.Dispose();
+
+    private string CreatePlan(string id, string title, string state = "Executing", Dictionary<string, int>? allocatedPorts = null)
+    {
+        var planFolder = Path.Combine(_plansDir, $"{id}-{title}");
+        Directory.CreateDirectory(planFolder);
+
+        var plan = new PlanYaml
+        {
+            State = state,
+            Project = "Ports",
+            Title = title,
+            Repos = [_tempDir.Path],
+            AllocatedPorts = allocatedPorts
+        };
+
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), YamlHelper.Serializer.Serialize(plan));
+        return planFolder;
+    }
+
+    private static ProjectConfig BuildProject(params (string Name, int DefaultPort)[] ports)
+    {
+        var project = new ProjectConfig { Name = "Ports" };
+        foreach (var (name, defaultPort) in ports)
+            project.Ports[name] = new ProjectPortConfig { DefaultPort = defaultPort };
+        return project;
+    }
+
+    [Fact]
+    public void AllocatePorts_WritesAllocationToPlanYaml()
+    {
+        var planFolder = CreatePlan("20001", "AllocateWrites");
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        var allocated = PortAllocationHelper.AllocatePorts(BuildProject(("backend", 0)), plan, planFolder);
+
+        Assert.Single(allocated);
+        var reloaded = PlanCommandHelpers.ReadPlan(planFolder);
+        Assert.Equal(allocated["backend"], reloaded.AllocatedPorts!["backend"]);
+    }
+
+    [Fact]
+    public void AllocatePorts_SecondCall_RetainsTheSamePorts()
+    {
+        var planFolder = CreatePlan("20002", "AllocateStable");
+
+        var first = PortAllocationHelper.AllocatePorts(
+            BuildProject(("backend", 0)), PlanCommandHelpers.ReadPlan(planFolder), planFolder);
+        var second = PortAllocationHelper.AllocatePorts(
+            BuildProject(("backend", 0)), PlanCommandHelpers.ReadPlan(planFolder), planFolder);
+
+        Assert.Equal(first["backend"], second["backend"]);
+    }
+
+    [Fact]
+    public void AllocatePorts_NoPortsConfigured_LeavesPlanUntouched()
+    {
+        var planFolder = CreatePlan("20003", "NoPorts");
+        var before = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
+
+        var allocated = PortAllocationHelper.AllocatePorts(
+            new ProjectConfig { Name = "Ports" }, PlanCommandHelpers.ReadPlan(planFolder), planFolder);
+
+        Assert.Empty(allocated);
+        Assert.Equal(before, File.ReadAllText(Path.Combine(planFolder, "plan.yaml")));
+    }
+
+    [Fact]
+    public void AllocatePorts_PortHeldByAnotherActivePlan_PicksADifferentOne()
+    {
+        CreatePlan("20004", "Neighbour", allocatedPorts: new Dictionary<string, int> { ["backend"] = 31500 });
+        var planFolder = CreatePlan("20005", "Allocating");
+
+        var allocated = PortAllocationHelper.AllocatePorts(
+            BuildProject(("backend", 31500)), PlanCommandHelpers.ReadPlan(planFolder), planFolder);
+
+        Assert.NotEqual(31500, allocated["backend"]);
+    }
+
+    [Fact]
+    public void CollectReservedPorts_SkipsCompletedPlans()
+    {
+        CreatePlan("20006", "Done", "Completed", new Dictionary<string, int> { ["backend"] = 31600 });
+        CreatePlan("20007", "Running", "Review", new Dictionary<string, int> { ["backend"] = 31601 });
+
+        var reserved = PortAllocationHelper.CollectReservedPorts(_plansDir, null);
+
+        // A completed plan's worktree is gone, so holding its port back would exhaust the range.
+        Assert.DoesNotContain(31600, reserved);
+        Assert.Contains(31601, reserved);
+    }
+
+    [Fact]
+    public void CollectReservedPorts_ExcludesTheRequestingPlan()
+    {
+        var planFolder = CreatePlan("20008", "Self", allocatedPorts: new Dictionary<string, int> { ["backend"] = 31700 });
+
+        var reserved = PortAllocationHelper.CollectReservedPorts(_plansDir, planFolder);
+
+        Assert.DoesNotContain(31700, reserved);
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/PortAllocationYamlRepairTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PortAllocationYamlRepairTests.cs
@@ -1,0 +1,99 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test.Services;
+
+/// <summary>
+///     The repair pass rewrites plan.yaml before it is deserialized, so it has to recognise
+///     <c>allocatedPorts</c> as a mapping. Without that, a port named after a plan field - or an
+///     indentation slip - loses the whole allocation and every worktree is handed a new port.
+/// </summary>
+public class PortAllocationYamlRepairTests
+{
+    private const string Preamble =
+        "schemaVersion: 1\n" +
+        "state: Executing\n" +
+        "project: Widgets\n" +
+        "title: Test\n";
+
+    private static PlanYaml Repair(string yaml) =>
+        YamlHelper.Deserializer.Deserialize<PlanYaml>(PlanYamlRepairService.RepairPlanYaml(yaml));
+
+    [Fact]
+    public void RepairPlanYaml_WellFormedAllocatedPorts_SurvivesRoundTrip()
+    {
+        var plan = Repair(Preamble +
+                          "allocatedPorts:\n" +
+                          "  backend: 31234\n" +
+                          "  frontend: 31235\n");
+
+        Assert.Equal(31234, plan.AllocatedPorts!["backend"]);
+        Assert.Equal(31235, plan.AllocatedPorts["frontend"]);
+    }
+
+    [Fact]
+    public void RepairPlanYaml_PortNamedAfterAPlanField_DoesNotClobberThatField()
+    {
+        var plan = Repair(Preamble +
+                          "allocatedPorts:\n" +
+                          "  title: 31234\n");
+
+        // A port sharing a top-level key's name is dropped rather than hoisted: the mapping has to
+        // terminate at the next real key, and losing the plan's title would be far worse.
+        Assert.Equal("Test", plan.Title);
+        Assert.True(plan.AllocatedPorts is null || !plan.AllocatedPorts.ContainsKey("title"));
+    }
+
+    [Fact]
+    public void RepairPlanYaml_ScalarKeyFollowingAllocatedPorts_TerminatesTheMapping()
+    {
+        var plan = Repair(Preamble +
+                          "allocatedPorts:\n" +
+                          "  backend: 31234\n" +
+                          "level: Feature\n");
+
+        Assert.Equal(31234, plan.AllocatedPorts!["backend"]);
+        Assert.Equal("Feature", plan.Level);
+    }
+
+    [Fact]
+    public void RepairPlanYaml_UnderIndentedPortEntry_IsStillReadAsAPort()
+    {
+        var plan = Repair(Preamble +
+                          "allocatedPorts:\n" +
+                          "backend: 31234\n");
+
+        Assert.Equal(31234, plan.AllocatedPorts!["backend"]);
+    }
+
+    [Fact]
+    public void RepairPlanYaml_HyphenatedPortName_IsPreserved()
+    {
+        var plan = Repair(Preamble +
+                          "allocatedPorts:\n" +
+                          "  web-ui: 31235\n");
+
+        Assert.Equal(31235, plan.AllocatedPorts!["web-ui"]);
+    }
+
+    [Fact]
+    public void RepairPlanYaml_KeyAfterAllocatedPorts_StaysTopLevel()
+    {
+        var plan = Repair(Preamble +
+                          "allocatedPorts:\n" +
+                          "  backend: 31234\n" +
+                          "repos:\n" +
+                          "  - /repos/widgets\n");
+
+        Assert.Equal(31234, plan.AllocatedPorts!["backend"]);
+        Assert.Equal(["/repos/widgets"], plan.Repos);
+    }
+
+    [Fact]
+    public void RepairPlanYaml_NoAllocatedPorts_LeavesItNull()
+    {
+        var plan = Repair(Preamble + "repos:\n  - /repos/widgets\n");
+
+        Assert.Null(plan.AllocatedPorts);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
@@ -35,7 +35,8 @@ public class ReviewActionsBarView(
             var btn = BuildActionButton(
                 action,
                 conditionMet,
-                () => nav.Navigate<ReviewActionApp>(new ReviewActionAppArgs(selectedPlan.FolderName, actionCapture.Name)));
+                () => nav.Navigate<ReviewActionApp>(new ReviewActionAppArgs(selectedPlan.FolderName, actionCapture.Name)),
+                selectedPlan.AllocatedPorts);
 
             actionsBar |= btn;
         }
@@ -43,7 +44,12 @@ public class ReviewActionsBarView(
         return actionsBar;
     }
 
-    internal static string GetTooltip(ReviewActionConfig action, bool conditionMet)
+    /// <summary>
+    ///     The button's tooltip. When the plan has ports allocated they are appended to the command, so a
+    ///     reviewer can see which URLs the action will serve on without opening the terminal first.
+    /// </summary>
+    internal static string GetTooltip(
+        ReviewActionConfig action, bool conditionMet, IReadOnlyDictionary<string, int>? allocatedPorts = null)
     {
         if (!conditionMet)
         {
@@ -52,15 +58,21 @@ public class ReviewActionsBarView(
                 : "Disabled: Condition not met";
         }
 
+        var ports = allocatedPorts is { Count: > 0 }
+            ? $" (ports: {string.Join(", ", allocatedPorts.OrderBy(p => p.Key, StringComparer.Ordinal).Select(p => $"{p.Key}: {p.Value}"))})"
+            : "";
+
         return !string.IsNullOrWhiteSpace(action.Command)
-            ? $"Run: {action.Command}"
-            : $"Run {action.Name}";
+            ? $"Run: {action.Command}{ports}"
+            : $"Run {action.Name}{ports}";
     }
 
-    internal static Button BuildActionButton(ReviewActionConfig action, bool conditionMet, Action? onNavigate = null)
+    internal static Button BuildActionButton(
+        ReviewActionConfig action, bool conditionMet, Action? onNavigate = null,
+        IReadOnlyDictionary<string, int>? allocatedPorts = null)
     {
         var btn = new Button(action.Name).Icon(Icons.Play).Outline();
-        var tooltip = GetTooltip(action, conditionMet);
+        var tooltip = GetTooltip(action, conditionMet, allocatedPorts);
 
         if (!conditionMet)
         {

--- a/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
@@ -71,7 +71,10 @@ public class ReviewActionApp : ViewBase
                 var resolvedAction = resolvedPlan is not null
                     ? ResolveAction(configService, resolvedPlan.Project, args?.ActionName)
                     : null;
-                return (resolvedPlan, (ProjectConfig?)null, resolvedAction, resolvedPlan?.FolderPath);
+                // The project config comes along for its port definitions: it fixes the order the
+                // plan's allocated ports are presented in, which decides the primary %PORT%.
+                var planProject = resolvedPlan is not null ? configService.GetProject(resolvedPlan.Project) : null;
+                return (resolvedPlan, planProject, resolvedAction, resolvedPlan?.FolderPath);
             }
 
             if (!string.IsNullOrEmpty(args?.ProjectName))
@@ -86,8 +89,12 @@ public class ReviewActionApp : ViewBase
         });
 
         var ptyHandle = Context.UsePty(
-            GetCommandLine(action),
-            workingDirectory);
+            GetCommandLine(action, plan, project),
+            workingDirectory,
+            new PtyOptions
+            {
+                Environment = BuildEnvironment(plan, project)
+            });
         // ptyHandleRef.Value = ptyHandle; // Commented out - ptyHandleRef not used
 
         if (!string.IsNullOrEmpty(args?.PlanId))
@@ -131,10 +138,94 @@ public class ReviewActionApp : ViewBase
             .RemoveParentPadding();
     }
 
-    private static string[] GetCommandLine(ReviewActionConfig? action) =>
+    private static string[] GetCommandLine(ReviewActionConfig? action, PlanFile? plan, ProjectConfig? project) =>
         action is not null
-            ? [PathHelper.GetPwshPath(), "-NoExit", "-NoProfile", "-Command", action.Command]
+            ? [PathHelper.GetPwshPath(), "-NoExit", "-NoProfile", "-Command",
+                InterpolateCommand(action.Command, ResolvePorts(plan, project))]
             : [];
+
+    /// <summary>
+    ///     Substitutes the session's ports into the command: <c>${ports.&lt;name&gt;}</c> for a named
+    ///     service and <c>%PORT%</c> for the primary one. pwsh does not expand <c>%VAR%</c>, so a command
+    ///     written that way has to be rewritten here rather than left to the injected environment.
+    /// </summary>
+    internal static string InterpolateCommand(string command, IReadOnlyDictionary<string, int> ports)
+    {
+        if (string.IsNullOrEmpty(command) || ports.Count == 0) return command;
+
+        var expanded = EnvironmentMaterializationHelper.ExpandPortPlaceholders(command, ports);
+        return expanded.Replace("%PORT%", ports.First().Value.ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     The ports this session should use, in the project's configured order so the first entry is the
+    ///     primary one. A plan contributes the ports allocated to its worktree; a project opened without a
+    ///     plan has no worktree and therefore no allocation, so its configured defaults are used instead.
+    /// </summary>
+    internal static Dictionary<string, int> ResolvePorts(PlanFile? plan, ProjectConfig? project)
+    {
+        var allocated = plan?.AllocatedPorts ?? new Dictionary<string, int>();
+        var ports = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        if (project is not null)
+            foreach (var (name, config) in project.Ports)
+            {
+                if (allocated.TryGetValue(name, out var port))
+                    ports[name] = port;
+                else if (config.DefaultPort > 0)
+                    ports[name] = config.DefaultPort;
+            }
+
+        // Ports the project no longer configures are still honoured while the worktree that uses them
+        // exists, so a command referencing one keeps working until the plan is cleaned up.
+        foreach (var (name, port) in allocated)
+            ports.TryAdd(name, port);
+
+        return ports;
+    }
+
+    /// <summary>
+    ///     Environment injected into the PTY: <c>PORT_&lt;NAME&gt;</c> per named service plus <c>PORT</c>
+    ///     for the primary one, and the plan's identity so a review action can locate its worktree
+    ///     without the command line having to hard-code paths.
+    /// </summary>
+    internal static Dictionary<string, string> BuildEnvironment(PlanFile? plan, ProjectConfig? project)
+    {
+        var env = new Dictionary<string, string>(StringComparer.Ordinal);
+        var ports = ResolvePorts(plan, project);
+
+        foreach (var (name, port) in ports)
+            env[$"PORT_{ToEnvVarSuffix(name)}"] = port.ToString();
+
+        if (ports.Count > 0)
+            env["PORT"] = ports.First().Value.ToString();
+
+        if (plan is not null)
+        {
+            env["PLAN_ID"] = plan.Id.ToString("D5");
+            env["PLAN_FOLDER"] = plan.FolderPath;
+            env["PROJECT_NAME"] = plan.Project;
+
+            if (ResolveWorktreeDir(plan) is { } worktreeDir)
+                env["WORKTREE_DIR"] = worktreeDir;
+        }
+        else if (project is not null)
+        {
+            env["PROJECT_NAME"] = project.Name;
+        }
+
+        return env;
+    }
+
+    /// <summary>Uppercases a port name into an environment variable suffix (<c>web-api</c> → <c>WEB_API</c>).</summary>
+    private static string ToEnvVarSuffix(string name) =>
+        string.Concat(name.Select(c => char.IsLetterOrDigit(c) ? char.ToUpperInvariant(c) : '_'));
+
+    /// <summary>The plan's first existing worktree, or null when none has been created.</summary>
+    private static string? ResolveWorktreeDir(PlanFile plan) =>
+        plan.Repos
+            .Select(repo => WorktreePathHelper.GetWorktreePath(plan.FolderPath, repo))
+            .FirstOrDefault(Directory.Exists);
 
     private static PlanFile? ResolvePlan(IPlanReaderService planService, string? planId)
     {

--- a/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
@@ -421,6 +421,86 @@ public class ReviewActionsTableView(
     private record ReviewActionRow(string Name, int Index);
 }
 
+/// <summary>
+///     The project's named service ports. Each row's default port is what a plan worktree tries first;
+///     the port actually assigned to a plan is shown on its review actions bar.
+/// </summary>
+public class ProjectPortsTableView(
+    IState<Dictionary<string, ProjectPortConfig>> ports,
+    Action<string?> onEdit) : ViewBase
+{
+    public override object? Build()
+    {
+        var current = ports.Value;
+        if (current.Count == 0) return null;
+
+        var rows = current.Select((p, i) => new PortRow(p.Key, p.Value.DefaultPort, p.Value.Description, i)).ToList();
+
+        return new TableBuilder<PortRow>(rows)
+            .Header(t => t.Name, "Name")
+            .Builder(t => t.Name, f => f.Func<PortRow, string>(name =>
+                Text.Block(name).Bold()
+            ))
+            .Header(t => t.DefaultPort, "Default Port")
+            .Header(t => t.Description, "Description")
+            .Header(t => t.Index, "")
+            .Builder(t => t.Index, f => f.Func<PortRow, int>(idx =>
+                Layout.Horizontal().Gap(1)
+                | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(rows[idx].Name))
+                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
+                {
+                    var updated = new Dictionary<string, ProjectPortConfig>(ports.Value);
+                    updated.Remove(rows[idx].Name);
+                    ports.Set(updated);
+                })
+            ))
+            .Width(Size.Fit());
+    }
+
+    private record PortRow(string Name, int DefaultPort, string Description, int Index);
+}
+
+/// <summary>
+///     The environment files recreated inside every plan worktree, since a fresh worktree has none of
+///     the untracked <c>.env</c> files the original checkout relies on.
+/// </summary>
+public class ProjectEnvFilesTableView(
+    IState<List<ProjectEnvFileConfig>> envFiles,
+    Action<int?> onEdit) : ViewBase
+{
+    public override object? Build()
+    {
+        var list = envFiles.Value;
+        if (list.Count == 0) return null;
+
+        var rows = list
+            .Select((f, i) => new EnvFileRow(f.Path, f.Template ?? "", string.Join(", ", f.Overrides.Keys), i))
+            .ToList();
+
+        return new TableBuilder<EnvFileRow>(rows)
+            .Header(t => t.Path, "Path")
+            .Builder(t => t.Path, f => f.Func<EnvFileRow, string>(path =>
+                Text.Block(path).Bold()
+            ))
+            .Header(t => t.Template, "Template")
+            .Header(t => t.Overrides, "Overrides")
+            .Header(t => t.Index, "")
+            .Builder(t => t.Index, f => f.Func<EnvFileRow, int>(idx =>
+                Layout.Horizontal().Gap(1)
+                | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
+                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
+                {
+                    var updated = new List<ProjectEnvFileConfig>(envFiles.Value);
+                    updated.RemoveAt(idx);
+                    envFiles.Set(updated);
+                })
+            ))
+            .Width(Size.Fit());
+    }
+
+    private record EnvFileRow(string Path, string Template, string Overrides, int Index);
+}
+
 public class ProjectVerificationsTableView(
     IState<List<ProjectVerificationRef>> verifications,
     Action<string?> onEdit) : ViewBase

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectEnvFileDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectEnvFileDialog.cs
@@ -1,0 +1,105 @@
+using System.Text;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Settings.Dialogs;
+
+/// <summary>
+///     Adds or edits one of the environment files recreated inside every plan worktree. Overrides are
+///     edited as <c>KEY=VALUE</c> lines - the same shape as the file itself - and support the
+///     <c>${ports.&lt;name&gt;}</c>, <c>${env.&lt;VAR&gt;}</c> and <c>%VAR%</c> placeholders described in
+///     <see cref="Helpers.EnvironmentMaterializationHelper" />.
+/// </summary>
+internal class EditProjectEnvFileDialog(
+    IState<bool> isOpen,
+    int? existingIndex,
+    IState<List<ProjectEnvFileConfig>> envFiles) : ViewBase
+{
+    public override object? Build()
+    {
+        var editPath = UseState("");
+        var editTemplate = UseState("");
+        var editOverrides = UseState("");
+
+        UseEffect(() =>
+        {
+            var files = envFiles.Value;
+            if (existingIndex is >= 0 && existingIndex < files.Count)
+            {
+                var existing = files[existingIndex.Value];
+                editPath.Set(existing.Path);
+                editTemplate.Set(existing.Template ?? "");
+                editOverrides.Set(FormatOverrides(existing.Overrides));
+            }
+        }, EffectTrigger.OnMount());
+
+        var isNew = existingIndex == null;
+
+        return new Dialog(
+            _ => isOpen.Set(false),
+            new DialogHeader(isNew ? "Add Environment File" : "Edit Environment File"),
+            new DialogBody(
+                Layout.Vertical()
+                | editPath.ToTextInput("e.g. apps/web/.env").WithField().Label("Path").Required()
+                | editTemplate.ToTextInput("e.g. .env.example").WithField().Label("Template")
+                | editOverrides.ToCodeInput("PORT=${ports.backend}").Height(Size.Units(40)).WithField().Label("Overrides")
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() => isOpen.Set(false)),
+                new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>
+                {
+                    var path = editPath.Value.Trim();
+                    if (string.IsNullOrWhiteSpace(path)) return;
+
+                    var entry = new ProjectEnvFileConfig
+                    {
+                        Path = path,
+                        Template = string.IsNullOrWhiteSpace(editTemplate.Value) ? null : editTemplate.Value.Trim(),
+                        Overrides = ParseOverrides(editOverrides.Value)
+                    };
+
+                    var list = new List<ProjectEnvFileConfig>(envFiles.Value);
+                    if (isNew)
+                        list.Add(entry);
+                    else
+                        list[existingIndex!.Value] = entry;
+
+                    envFiles.Set(list);
+                    isOpen.Set(false);
+                })
+            )
+        ).Width(Size.Rem(34));
+    }
+
+    /// <summary>
+    ///     Parses <c>KEY=VALUE</c> lines into overrides. Blank lines and <c>#</c> comments are dropped, and
+    ///     a line without <c>=</c> is ignored rather than saved as an empty key, which would produce an
+    ///     unparseable env file.
+    /// </summary>
+    internal static Dictionary<string, string> ParseOverrides(string text)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(text)) return result;
+
+        foreach (var rawLine in text.Replace("\r\n", "\n").Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+
+            var separator = line.IndexOf('=');
+            if (separator <= 0) continue;
+
+            result[line[..separator].Trim()] = line[(separator + 1)..];
+        }
+
+        return result;
+    }
+
+    /// <summary>Renders overrides back into the <c>KEY=VALUE</c> lines the editor shows.</summary>
+    internal static string FormatOverrides(IReadOnlyDictionary<string, string> overrides)
+    {
+        var sb = new StringBuilder();
+        foreach (var (key, value) in overrides)
+            sb.Append(key).Append('=').Append(value).Append('\n');
+        return sb.ToString().TrimEnd('\n');
+    }
+}

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectPortDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectPortDialog.cs
@@ -1,0 +1,69 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Settings.Dialogs;
+
+/// <summary>
+///     Adds or edits one of a project's named service ports. The default port is only a preference: a
+///     plan worktree falls back to a free port when it is taken, so two reviews can run at once (see
+///     <see cref="Helpers.PortAllocationHelper" />).
+/// </summary>
+internal class EditProjectPortDialog(
+    IState<bool> isOpen,
+    string? existingName,
+    IState<Dictionary<string, ProjectPortConfig>> ports) : ViewBase
+{
+    public override object? Build()
+    {
+        var editName = UseState("");
+        var editPort = UseState(3000);
+        var editDescription = UseState("");
+
+        UseEffect(() =>
+        {
+            if (existingName != null && ports.Value.TryGetValue(existingName, out var existing))
+            {
+                editName.Set(existingName);
+                editPort.Set(existing.DefaultPort);
+                editDescription.Set(existing.Description);
+            }
+        }, EffectTrigger.OnMount());
+
+        var isNew = existingName == null;
+
+        return new Dialog(
+            _ => isOpen.Set(false),
+            new DialogHeader(isNew ? "Add Port" : "Edit Port"),
+            new DialogBody(
+                Layout.Vertical()
+                | editName.ToTextInput("e.g. backend").WithField().Label("Name").Required()
+                | editPort.ToNumberInput().Min(1).Max(65535).WithField().Label("Default Port").Required()
+                | editDescription.ToTextInput("What listens here...").WithField().Label("Description")
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() => isOpen.Set(false)),
+                new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>
+                {
+                    var name = editName.Value.Trim();
+                    if (string.IsNullOrWhiteSpace(name)) return;
+                    if (editPort.Value is < 1 or > 65535) return;
+
+                    var updated = new Dictionary<string, ProjectPortConfig>(ports.Value);
+
+                    // A rename drops the old key, so an env file's ${ports.<old>} stops resolving rather
+                    // than silently keeping a stale duplicate entry alive.
+                    if (existingName != null && existingName != name)
+                        updated.Remove(existingName);
+
+                    updated[name] = new ProjectPortConfig
+                    {
+                        DefaultPort = editPort.Value,
+                        Description = editDescription.Value
+                    };
+
+                    ports.Set(updated);
+                    isOpen.Set(false);
+                })
+            )
+        ).Width(Size.Rem(30));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -46,6 +46,10 @@ public class ProjectDetailView(
         // Verifications State
         var verifications = UseState(() => projectIndex >= 0 && projectIndex < config.Settings.Projects.Count ? new List<ProjectVerificationRef>(config.Settings.Projects[projectIndex].Verifications) : new List<ProjectVerificationRef>());
 
+        // Ports & Environment Files State
+        var ports = UseState(() => projectIndex >= 0 && projectIndex < config.Settings.Projects.Count ? new Dictionary<string, ProjectPortConfig>(config.Settings.Projects[projectIndex].Ports) : new Dictionary<string, ProjectPortConfig>());
+        var envFiles = UseState(() => projectIndex >= 0 && projectIndex < config.Settings.Projects.Count ? new List<ProjectEnvFileConfig>(config.Settings.Projects[projectIndex].EnvFiles) : new List<ProjectEnvFileConfig>());
+
         // MCP & Skills States
         var mcpServers = UseState(() => projectIndex >= 0 && projectIndex < config.Settings.Projects.Count ? new List<ProjectMcpServerRef>(config.Settings.Projects[projectIndex].McpServers) : new List<ProjectMcpServerRef>());
         var skills = UseState(() => projectIndex >= 0 && projectIndex < config.Settings.Projects.Count ? new List<ProjectSkillRef>(config.Settings.Projects[projectIndex].Skills) : new List<ProjectSkillRef>());
@@ -57,6 +61,12 @@ public class ProjectDetailView(
 
         var (verificationTrigger, showVerificationTrigger) = UseTrigger((IState<bool> isOpen, string? existingVerificationName) =>
             new OnboardingEditVerificationDialog(isOpen, existingVerificationName, config, client, refreshToken, projectIndex >= 0 && projectIndex < config.Settings.Projects.Count ? config.Settings.Projects[projectIndex].Name : "", projectVerifications: verifications));
+
+        var (portTrigger, showPortTrigger) = UseTrigger((IState<bool> isOpen, string? existingPortName) =>
+            new EditProjectPortDialog(isOpen, existingPortName, ports));
+
+        var (envFileTrigger, showEnvFileTrigger) = UseTrigger((IState<bool> isOpen, int? existingIndex) =>
+            new EditProjectEnvFileDialog(isOpen, existingIndex, envFiles));
 
         var (mcpSheet, openMcpSheet) = UseTrigger((IState<bool> isOpen, int? editingIndex) =>
             new EditMcpServerSheet(isOpen, editingIndex, mcpServers));
@@ -108,6 +118,16 @@ public class ProjectDetailView(
             if (!AreVerificationsEqual(currentProj.Verifications, verifications.Value))
             {
                 currentProj.Verifications = new List<ProjectVerificationRef>(verifications.Value);
+                changed = true;
+            }
+            if (!ArePortsEqual(currentProj.Ports, ports.Value))
+            {
+                currentProj.Ports = new Dictionary<string, ProjectPortConfig>(ports.Value);
+                changed = true;
+            }
+            if (!AreEnvFilesEqual(currentProj.EnvFiles, envFiles.Value))
+            {
+                currentProj.EnvFiles = new List<ProjectEnvFileConfig>(envFiles.Value);
                 changed = true;
             }
             if (!AreMcpServersEqual(currentProj.McpServers, mcpServers.Value))
@@ -182,7 +202,7 @@ public class ProjectDetailView(
             }
         }
 
-        UseEffect(SaveProjectChanges, [projectColor, autoImplement, repos, reviewActions, verifications, mcpServers, skills]);
+        UseEffect(SaveProjectChanges, [projectColor, autoImplement, repos, reviewActions, verifications, ports, envFiles, mcpServers, skills]);
 
         var currentProjectList = config.Settings.Projects;
         if (projectIndex < 0 || projectIndex >= currentProjectList.Count)
@@ -308,21 +328,33 @@ public class ProjectDetailView(
             | new ProjectVerificationsTableView(verifications, name => showVerificationTrigger(name))
             | new Button("Add Verification").Icon(Icons.Plus).Outline().OnClick(() => showVerificationTrigger(null))
 
-            // Section 5: Agent Behavior
+            // Section 5: Ports
+            | Text.H4("Ports").Bold()
+            | Text.Muted("Named service ports. A plan's worktree takes the default port when it is free and falls back to a free one otherwise, so concurrent reviews do not collide.")
+            | new ProjectPortsTableView(ports, name => showPortTrigger(name))
+            | new Button("Add Port").Icon(Icons.Plus).Outline().OnClick(() => showPortTrigger(null))
+
+            // Section 6: Environment Files
+            | Text.H4("Environment Files").Bold()
+            | Text.Muted("Recreated inside every plan worktree, which starts without the untracked .env files the original checkout relies on. Values support ${ports.<name>}, ${env.<VAR>} and %VAR%.")
+            | new ProjectEnvFilesTableView(envFiles, idx => showEnvFileTrigger(idx))
+            | new Button("Add Environment File").Icon(Icons.Plus).Outline().OnClick(() => showEnvFileTrigger(null))
+
+            // Section 7: Agent Behavior
             | (isBeta
                 ? (object)(Layout.Vertical()
                     | Text.H4("Agent Behavior").Bold()
                     | autoImplementSelect)
                 : null!)
 
-            // Section 6: Local Permissions (MCP Tools & Servers)
+            // Section 8: Local Permissions (MCP Tools & Servers)
             | (isBeta
                 ? (object)(Layout.Vertical()
                     | Text.H4("Local Permissions").Bold()
                     | new McpServersTableView(mcpServers, repos, idx => openMcpSheet(idx), onImport: () => openImportMcpDialog(), onDelete: idx => DeleteMcpServer(idx)))
                 : null!)
 
-            // Section 7: Customizations
+            // Section 9: Customizations
             | (isBeta
                 ? (object)(Layout.Vertical()
                     | Text.H4("Customizations").Bold()
@@ -330,7 +362,7 @@ public class ProjectDetailView(
                     | new SkillsTableView(skills, repos, idx => openSkillSheet(idx), onImport: () => openImportSkillsDialog(), onDelete: idx => DeleteSkill(idx)))
                 : null!)
 
-            // Section 8: Danger Zone
+            // Section 10: Danger Zone
             | Text.H4("Danger Zone").Bold()
             | new Button("Delete Project").Destructive().OnClick(() =>
             {
@@ -343,6 +375,8 @@ public class ProjectDetailView(
             )
             | reviewActionTrigger
             | verificationTrigger
+            | portTrigger
+            | envFileTrigger
             | mcpSheet
             | skillSheet
             | memorySheet
@@ -382,6 +416,35 @@ public class ProjectDetailView(
         {
             if (a[i].Name != b[i].Name || a[i].Required != b[i].Required)
                 return false;
+        }
+        return true;
+    }
+
+    private static bool ArePortsEqual(Dictionary<string, ProjectPortConfig> a, Dictionary<string, ProjectPortConfig> b)
+    {
+        if (a.Count != b.Count) return false;
+        foreach (var (name, config) in a)
+        {
+            if (!b.TryGetValue(name, out var other)) return false;
+            if (config.DefaultPort != other.DefaultPort || config.Description != other.Description)
+                return false;
+        }
+        return true;
+    }
+
+    private static bool AreEnvFilesEqual(List<ProjectEnvFileConfig> a, List<ProjectEnvFileConfig> b)
+    {
+        if (a.Count != b.Count) return false;
+        for (int i = 0; i < a.Count; i++)
+        {
+            if (a[i].Path != b[i].Path || a[i].Template != b[i].Template)
+                return false;
+            if (a[i].Overrides.Count != b[i].Overrides.Count) return false;
+            foreach (var (key, value) in a[i].Overrides)
+            {
+                if (!b[i].Overrides.TryGetValue(key, out var other) || other != value)
+                    return false;
+            }
         }
         return true;
     }

--- a/src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -108,7 +109,44 @@ public class PlanAddWorktreeCommand : Command<PlanAddWorktreeSettings>
 
         AnsiConsole.MarkupLine($"[green]Worktree created: {worktreePath.EscapeMarkup()}[/]");
         AnsiConsole.MarkupLine($"[green]Branch: {branchName.EscapeMarkup()}[/]");
+
+        MaterializeEnvironment(planFolder, worktreePath);
         return 0;
+    }
+
+    /// <summary>
+    ///     Allocates the plan's service ports and recreates the project's environment files in the fresh
+    ///     worktree, which starts without the untracked <c>.env</c> files the original checkout relies on.
+    ///     Failures are reported but do not fail the command: the worktree itself is usable, and
+    ///     <c>tendril plan env materialize</c> can retry once the project config is fixed.
+    /// </summary>
+    private void MaterializeEnvironment(string planFolder, string worktreePath)
+    {
+        try
+        {
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var project = new ConfigService().Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(plan.Project, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null || (project.Ports.Count == 0 && project.EnvFiles.Count == 0))
+                return;
+
+            var allocatedPorts = PortAllocationHelper.AllocatePorts(project, plan, planFolder);
+            foreach (var (name, port) in allocatedPorts.OrderBy(p => p.Key, StringComparer.Ordinal))
+                AnsiConsole.MarkupLine($"[green]Port {name.EscapeMarkup()}: {port}[/]");
+
+            if (project.EnvFiles.Count == 0)
+                return;
+
+            var count = EnvironmentMaterializationHelper.MaterializeEnvFiles(project, allocatedPorts, worktreePath);
+            AnsiConsole.MarkupLine($"[green]Materialized {count} environment file(s) into worktree.[/]");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to materialize environment for plan folder {PlanFolder}", planFolder);
+            AnsiConsole.MarkupLine($"[yellow]Warning: could not materialize environment files: {ex.Message.EscapeMarkup()}[/]");
+            AnsiConsole.MarkupLine("[yellow]Run 'tendril plan env materialize <plan-id>' after fixing the project config.[/]");
+        }
     }
 
     private static string DeriveBranchName(string planFolder)

--- a/src/Ivy.Tendril/Commands/PlanEnvCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanEnvCommand.cs
@@ -1,0 +1,175 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class PlanEnvMaterializeSettings : CommandSettings
+{
+    [Description("Plan ID (e.g., 00105)")]
+    [CommandArgument(0, "<plan-id>")]
+    public string PlanId { get; set; } = "";
+
+    [CommandOption("--repo <repo>")]
+    [Description("Only materialize into this repo's worktree (path or repo name; default: every worktree)")]
+    public string? Repo { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(PlanId, "plan-id");
+    }
+}
+
+public class PlanEnvGetSettings : CommandSettings
+{
+    [Description("Plan ID (e.g., 00105)")]
+    [CommandArgument(0, "<plan-id>")]
+    public string PlanId { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(PlanId, "plan-id");
+    }
+}
+
+/// <summary>
+///     Allocates the plan's service ports and writes the project's configured environment files into
+///     its worktrees. Run automatically by <see cref="PlanAddWorktreeCommand" />; exposed separately so
+///     a worktree that already exists can be refreshed after the project's <c>envFiles</c> change.
+/// </summary>
+public class PlanEnvMaterializeCommand : Command<PlanEnvMaterializeSettings>
+{
+    protected override int Execute(CommandContext context, PlanEnvMaterializeSettings settings, CancellationToken cancellationToken)
+    {
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var project = PlanEnvHelpers.ResolveProject(plan);
+
+        var allocatedPorts = PortAllocationHelper.AllocatePorts(project, plan, planFolder);
+        foreach (var (name, port) in allocatedPorts.OrderBy(p => p.Key, StringComparer.Ordinal))
+            AnsiConsole.MarkupLine($"[green]Port {name.EscapeMarkup()}: {port}[/]");
+
+        var worktrees = PlanEnvHelpers.ResolveWorktrees(plan, planFolder, settings.Repo);
+        if (worktrees.Count == 0)
+        {
+            AnsiConsole.MarkupLine(settings.Repo is null
+                ? "[yellow]No worktrees found for this plan - run 'tendril plan add-worktree' first.[/]"
+                : $"[yellow]No worktree found for repo {settings.Repo.EscapeMarkup()}.[/]");
+            return 1;
+        }
+
+        if (project.EnvFiles.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No environment files configured for this project.[/]");
+            return 0;
+        }
+
+        foreach (var worktree in worktrees)
+        {
+            var written = EnvironmentMaterializationHelper.MaterializeEnvFiles(project, allocatedPorts, worktree);
+            AnsiConsole.MarkupLine(
+                $"[green]Materialized {written} environment file(s) into {worktree.EscapeMarkup()}.[/]");
+        }
+
+        return 0;
+    }
+}
+
+/// <summary>
+///     Prints what a plan's worktree receives: its allocated ports and, per configured environment
+///     file, the key/value pairs the template and overrides resolve to. Read-only - it neither
+///     allocates a port nor writes a file, so it is safe to run against a plan under review.
+/// </summary>
+public class PlanEnvGetCommand : Command<PlanEnvGetSettings>
+{
+    protected override int Execute(CommandContext context, PlanEnvGetSettings settings, CancellationToken cancellationToken)
+    {
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var project = PlanEnvHelpers.ResolveProject(plan);
+        var allocatedPorts = plan.AllocatedPorts ?? new Dictionary<string, int>();
+
+        if (allocatedPorts.Count == 0)
+            AnsiConsole.MarkupLine("[dim]No ports allocated for this plan.[/]");
+        else
+            CliOutput.WriteTable(
+                ["Port", "Value"],
+                allocatedPorts
+                    .OrderBy(p => p.Key, StringComparer.Ordinal)
+                    .Select(p => new[] { p.Key, p.Value.ToString() }));
+
+        if (project.EnvFiles.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No environment files configured for this project.[/]");
+            return 0;
+        }
+
+        // Values are resolved against the first worktree, since a template is read relative to it.
+        // Without one the templates are simply absent and only the overrides are shown.
+        var worktree = PlanEnvHelpers.ResolveWorktrees(plan, planFolder, null).FirstOrDefault() ?? planFolder;
+
+        foreach (var envFile in project.EnvFiles)
+        {
+            var values = EnvironmentMaterializationHelper.ResolveEnvValues(envFile, project, allocatedPorts, worktree);
+            AnsiConsole.MarkupLine($"[bold]{envFile.Path.EscapeMarkup()}[/]");
+            if (values.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[dim]  (empty)[/]");
+                continue;
+            }
+
+            foreach (var (key, value) in values)
+                Console.WriteLine($"  {key}={value}");
+        }
+
+        return 0;
+    }
+}
+
+internal static class PlanEnvHelpers
+{
+    /// <summary>Resolves the plan's project config, or throws with the configured project names.</summary>
+    public static ProjectConfig ResolveProject(PlanYaml plan)
+    {
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(plan.Project, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+            CliValidation.ThrowProjectNotFound(plan.Project, config.Settings.Projects.Select(p => p.Name));
+
+        return project;
+    }
+
+    /// <summary>
+    ///     The existing worktree directories for the plan's repos, filtered to
+    ///     <paramref name="repoFilter" /> when given (matched against the repo path or its last segment).
+    ///     Repos whose worktree has not been created are skipped rather than reported: a plan commonly
+    ///     lists repos it has not needed to check out.
+    /// </summary>
+    public static List<string> ResolveWorktrees(PlanYaml plan, string planFolder, string? repoFilter)
+    {
+        var worktrees = new List<string>();
+
+        foreach (var repo in plan.Repos)
+        {
+            if (repoFilter != null && !MatchesRepo(repo, repoFilter)) continue;
+
+            var worktree = WorktreePathHelper.GetWorktreePath(planFolder, repo);
+            if (Directory.Exists(worktree))
+                worktrees.Add(worktree);
+        }
+
+        return worktrees;
+    }
+
+    private static bool MatchesRepo(string repoPath, string filter)
+    {
+        if (repoPath.Equals(filter, StringComparison.OrdinalIgnoreCase)) return true;
+        var name = PathHelper.GetFileNameCrossPlatform(repoPath.TrimEnd('/', '\\'));
+        return name.Equals(PathHelper.GetFileNameCrossPlatform(filter.TrimEnd('/', '\\')), StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -402,6 +402,125 @@ public class ProjectRemoveSkillSettings : CommandSettings
     }
 }
 
+public class ProjectListPortsSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(ProjectName, "project-name");
+    }
+}
+
+public class ProjectAddPortSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Logical port name (e.g. backend)")]
+    [CommandArgument(1, "<name>")]
+    public string Name { get; set; } = "";
+
+    [Description("Preferred port, used when free")]
+    [CommandArgument(2, "<default-port>")]
+    public int DefaultPort { get; set; }
+
+    [CommandOption("--description <description>")]
+    [Description("What listens on this port")]
+    public string? Description { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(Name, "name"),
+            DefaultPort is > 0 and <= 65535
+                ? Spectre.Console.ValidationResult.Success()
+                : Spectre.Console.ValidationResult.Error($"default-port must be between 1 and 65535, got: {DefaultPort}"));
+    }
+}
+
+public class ProjectRemovePortSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Logical port name")]
+    [CommandArgument(1, "<name>")]
+    public string Name { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(Name, "name"));
+    }
+}
+
+public class ProjectListEnvFilesSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(ProjectName, "project-name");
+    }
+}
+
+public class ProjectAddEnvFileSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Target path, relative to the worktree root (e.g. apps/web/.env)")]
+    [CommandArgument(1, "<path>")]
+    public string Path { get; set; } = "";
+
+    [CommandOption("--template <template>")]
+    [Description("Source file to copy, relative to the worktree root (e.g. .env.example)")]
+    public string? Template { get; set; }
+
+    [CommandOption("--override <key=value>")]
+    [Description("Key written on top of the template; repeat for several keys")]
+    public string[] Overrides { get; set; } = [];
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var malformed = Overrides.FirstOrDefault(o => !o.Contains('='));
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(Path, "path"),
+            malformed == null
+                ? Spectre.Console.ValidationResult.Success()
+                : Spectre.Console.ValidationResult.Error($"--override must be KEY=VALUE, got: {malformed}"));
+    }
+}
+
+public class ProjectRemoveEnvFileSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Target path of the env file to remove")]
+    [CommandArgument(1, "<path>")]
+    public string Path { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(Path, "path"));
+    }
+}
+
 public class ProjectImportSettings : CommandSettings
 {
     [Description("Project name")]
@@ -1203,6 +1322,186 @@ public class ProjectRemoveSkillCommand : Command<ProjectRemoveSkillSettings>
         });
 
         Console.WriteLine($"Removed custom skill: {settings.Name}");
+        return 0;
+    }
+}
+
+public class ProjectListPortsCommand : Command<ProjectListPortsSettings>
+{
+    protected override int Execute(CommandContext context, ProjectListPortsSettings settings, CancellationToken cancellationToken)
+    {
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
+
+        if (project.Ports.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No ports configured for this project.[/]");
+            return 0;
+        }
+
+        CliOutput.WriteTable(
+            ["Name", "Default Port", "Description"],
+            project.Ports.Select(p => new[] { p.Key, p.Value.DefaultPort.ToString(), p.Value.Description }));
+
+        return 0;
+    }
+}
+
+public class ProjectAddPortCommand : Command<ProjectAddPortSettings>
+{
+    protected override int Execute(CommandContext context, ProjectAddPortSettings settings, CancellationToken cancellationToken)
+    {
+        var config = new ConfigService();
+        var updated = false;
+
+        config.MutateAndSave(s =>
+        {
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
+
+            updated = project.Ports.ContainsKey(settings.Name);
+            project.Ports[settings.Name] = new ProjectPortConfig
+            {
+                DefaultPort = settings.DefaultPort,
+                Description = settings.Description ?? ""
+            };
+        });
+
+        Console.WriteLine($"{(updated ? "Updated" : "Added")} port: {settings.Name} -> {settings.DefaultPort}");
+        return 0;
+    }
+}
+
+public class ProjectRemovePortCommand : Command<ProjectRemovePortSettings>
+{
+    protected override int Execute(CommandContext context, ProjectRemovePortSettings settings, CancellationToken cancellationToken)
+    {
+        var config = new ConfigService();
+
+        config.MutateAndSave(s =>
+        {
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
+
+            if (!project.Ports.Remove(settings.Name))
+                throw new InvalidOperationException($"Port not found: {settings.Name}");
+        });
+
+        Console.WriteLine($"Removed port: {settings.Name}");
+        return 0;
+    }
+}
+
+public class ProjectListEnvFilesCommand : Command<ProjectListEnvFilesSettings>
+{
+    protected override int Execute(CommandContext context, ProjectListEnvFilesSettings settings, CancellationToken cancellationToken)
+    {
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
+
+        if (project.EnvFiles.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No environment files configured for this project.[/]");
+            return 0;
+        }
+
+        CliOutput.WriteTable(
+            ["Path", "Template", "Overrides"],
+            project.EnvFiles.Select(f => new[]
+            {
+                f.Path,
+                f.Template ?? "",
+                string.Join(", ", f.Overrides.Keys)
+            }));
+
+        return 0;
+    }
+}
+
+public class ProjectAddEnvFileCommand : Command<ProjectAddEnvFileSettings>
+{
+    protected override int Execute(CommandContext context, ProjectAddEnvFileSettings settings, CancellationToken cancellationToken)
+    {
+        var config = new ConfigService();
+        var updated = false;
+
+        var overrides = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var entry in settings.Overrides)
+        {
+            var separator = entry.IndexOf('=');
+            overrides[entry[..separator].Trim()] = entry[(separator + 1)..];
+        }
+
+        config.MutateAndSave(s =>
+        {
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
+
+            var existing = project.EnvFiles
+                .FirstOrDefault(f => f.Path.Equals(settings.Path, StringComparison.OrdinalIgnoreCase));
+
+            // Re-running with the same path replaces the entry rather than adding a duplicate: two
+            // configs for one file would race, with the last one written winning silently.
+            if (existing != null)
+            {
+                updated = true;
+                project.EnvFiles.Remove(existing);
+            }
+
+            project.EnvFiles.Add(new ProjectEnvFileConfig
+            {
+                Path = settings.Path,
+                Template = string.IsNullOrWhiteSpace(settings.Template) ? null : settings.Template,
+                Overrides = overrides
+            });
+        });
+
+        Console.WriteLine($"{(updated ? "Updated" : "Added")} environment file: {settings.Path}");
+        return 0;
+    }
+}
+
+public class ProjectRemoveEnvFileCommand : Command<ProjectRemoveEnvFileSettings>
+{
+    protected override int Execute(CommandContext context, ProjectRemoveEnvFileSettings settings, CancellationToken cancellationToken)
+    {
+        var config = new ConfigService();
+
+        config.MutateAndSave(s =>
+        {
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
+
+            var match = project.EnvFiles
+                .FirstOrDefault(f => f.Path.Equals(settings.Path, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+                throw new InvalidOperationException($"Environment file not found: {settings.Path}");
+
+            project.EnvFiles.Remove(match);
+        });
+
+        Console.WriteLine($"Removed environment file: {settings.Path}");
         return 0;
     }
 }

--- a/src/Ivy.Tendril/Helpers/EnvironmentMaterializationHelper.cs
+++ b/src/Ivy.Tendril/Helpers/EnvironmentMaterializationHelper.cs
@@ -1,0 +1,176 @@
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Recreates a project's environment files inside a worktree. A git worktree is a clean checkout,
+///     so the untracked <c>.env</c> files the original repo relies on are absent and services and
+///     database migrations fail to boot. Each <see cref="ProjectEnvFileConfig" /> is rebuilt from its
+///     template plus overrides, with placeholders resolved against the plan's allocated ports so
+///     inter-service URLs (<c>VITE_API_URL</c>, <c>DB_SERVICE_URL</c>) point at the right ports.
+/// </summary>
+public static class EnvironmentMaterializationHelper
+{
+    /// <summary><c>${ports.&lt;name&gt;}</c> — the port assigned to a named service.</summary>
+    private static readonly Regex PortPlaceholder = new(@"\$\{ports\.([A-Za-z0-9_.-]+)\}", RegexOptions.Compiled);
+
+    /// <summary><c>${env.&lt;VAR&gt;}</c> — a host environment variable, empty when unset.</summary>
+    private static readonly Regex EnvPlaceholder = new(@"\$\{env\.([A-Za-z_][A-Za-z0-9_]*)\}", RegexOptions.Compiled);
+
+    /// <summary>A <c>KEY=VALUE</c> line, optionally prefixed with <c>export </c>.</summary>
+    private static readonly Regex EnvAssignment = new(@"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$", RegexOptions.Compiled);
+
+    /// <summary>
+    ///     Writes every environment file the project configures into <paramref name="worktreeRoot" /> and
+    ///     returns the number of files written.
+    /// </summary>
+    public static int MaterializeEnvFiles(
+        ProjectConfig project,
+        IReadOnlyDictionary<string, int> allocatedPorts,
+        string worktreeRoot,
+        string? tendrilHome = null)
+    {
+        var written = 0;
+        foreach (var envFile in project.EnvFiles)
+        {
+            if (string.IsNullOrWhiteSpace(envFile.Path)) continue;
+
+            var targetPath = Path.GetFullPath(Path.Combine(worktreeRoot, envFile.Path));
+            var content = BuildEnvFileContent(envFile, project, allocatedPorts, worktreeRoot, tendrilHome);
+
+            var targetDir = Path.GetDirectoryName(targetPath);
+            if (!string.IsNullOrEmpty(targetDir))
+                Directory.CreateDirectory(targetDir);
+
+            // Content is joined with "\n" unconditionally: dotenv parsers in Node and Python treat a
+            // trailing CR as part of the value, which silently corrupts URLs and ports on Windows hosts.
+            FileHelper.WriteAllText(targetPath, content);
+            written++;
+        }
+
+        return written;
+    }
+
+    /// <summary>
+    ///     Renders one environment file: the template's lines with placeholders expanded (comments and
+    ///     blank lines preserved), then <see cref="ProjectEnvFileConfig.Overrides" /> applied — replacing
+    ///     a key the template already defines in place, appending the rest.
+    /// </summary>
+    public static string BuildEnvFileContent(
+        ProjectEnvFileConfig envFile,
+        ProjectConfig project,
+        IReadOnlyDictionary<string, int> allocatedPorts,
+        string worktreeRoot,
+        string? tendrilHome = null)
+    {
+        string Expand(string value) => ExpandPlaceholders(value, allocatedPorts, project.Ports, tendrilHome);
+
+        var lines = new List<string>();
+        var keyLineIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        if (!string.IsNullOrWhiteSpace(envFile.Template))
+        {
+            var templatePath = Path.GetFullPath(Path.Combine(worktreeRoot, envFile.Template));
+            if (File.Exists(templatePath))
+                foreach (var rawLine in FileHelper.ReadAllLines(templatePath))
+                {
+                    var match = EnvAssignment.Match(rawLine.Trim());
+                    if (!match.Success)
+                    {
+                        lines.Add(rawLine.TrimEnd('\r'));
+                        continue;
+                    }
+
+                    var key = match.Groups[1].Value;
+                    keyLineIndex[key] = lines.Count;
+                    lines.Add($"{key}={Expand(match.Groups[2].Value.Trim())}");
+                }
+        }
+
+        foreach (var (key, rawValue) in envFile.Overrides)
+        {
+            var line = $"{key}={Expand(rawValue ?? "")}";
+            if (keyLineIndex.TryGetValue(key, out var index))
+                lines[index] = line;
+            else
+            {
+                keyLineIndex[key] = lines.Count;
+                lines.Add(line);
+            }
+        }
+
+        return lines.Count == 0 ? "" : string.Join("\n", lines) + "\n";
+    }
+
+    /// <summary>
+    ///     Resolves <c>${ports.&lt;name&gt;}</c>, <c>${env.&lt;VAR&gt;}</c> and <c>%VAR%</c> in one value.
+    ///     A port name resolves to its allocated port, falling back to the project's configured default;
+    ///     an unknown name is left as written so the misconfiguration is visible in the generated file
+    ///     rather than becoming an empty string. <c>%VAR%</c> is delegated to
+    ///     <see cref="VariableExpansion.ExpandVariables" /> with path normalization off, which would
+    ///     otherwise rewrite the separators of URLs and Windows paths held in env values.
+    /// </summary>
+    internal static string ExpandPlaceholders(
+        string value,
+        IReadOnlyDictionary<string, int> allocatedPorts,
+        IReadOnlyDictionary<string, ProjectPortConfig> portDefaults,
+        string? tendrilHome = null)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+
+        var expanded = ExpandPortPlaceholders(value, allocatedPorts, portDefaults);
+
+        expanded = EnvPlaceholder.Replace(expanded, match =>
+            Environment.GetEnvironmentVariable(match.Groups[1].Value) ?? "");
+
+        return VariableExpansion.ExpandVariables(expanded, tendrilHome, normalizePaths: false);
+    }
+
+    /// <summary>
+    ///     Replaces every <c>${ports.&lt;name&gt;}</c> with the port allocated to that name, falling back to
+    ///     the project's configured default. Shared with review action command lines, which need the same
+    ///     placeholder but none of the env-file expansions.
+    /// </summary>
+    public static string ExpandPortPlaceholders(
+        string value,
+        IReadOnlyDictionary<string, int> allocatedPorts,
+        IReadOnlyDictionary<string, ProjectPortConfig>? portDefaults = null)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+
+        return PortPlaceholder.Replace(value, match =>
+        {
+            var name = match.Groups[1].Value;
+            if (allocatedPorts.TryGetValue(name, out var port))
+                return port.ToString();
+            if (portDefaults != null && portDefaults.TryGetValue(name, out var config) && config.DefaultPort > 0)
+                return config.DefaultPort.ToString();
+            return match.Value;
+        });
+    }
+
+    /// <summary>
+    ///     The key/value pairs an environment file resolves to, without writing it. Used by
+    ///     <c>tendril plan env get</c> to show what a worktree would receive.
+    /// </summary>
+    public static List<KeyValuePair<string, string>> ResolveEnvValues(
+        ProjectEnvFileConfig envFile,
+        ProjectConfig project,
+        IReadOnlyDictionary<string, int> allocatedPorts,
+        string worktreeRoot,
+        string? tendrilHome = null)
+    {
+        var content = BuildEnvFileContent(envFile, project, allocatedPorts, worktreeRoot, tendrilHome);
+        var values = new List<KeyValuePair<string, string>>();
+
+        foreach (var line in content.Split('\n'))
+        {
+            var match = EnvAssignment.Match(line.Trim());
+            if (match.Success)
+                values.Add(new KeyValuePair<string, string>(match.Groups[1].Value, match.Groups[2].Value));
+        }
+
+        return values;
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PortAllocationHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PortAllocationHelper.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Sockets;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Assigns a concrete TCP port to each of a project's named service ports for one plan.
+///     A multi-service repo binds static defaults (3000/3001/3002), so a host process already on
+///     one of them — or a second plan under review at the same time — makes the whole stack fail
+///     with <c>EADDRINUSE</c>. Assignments are recorded in <see cref="PlanYaml.AllocatedPorts" />
+///     so a review session keeps stable URLs across re-executions.
+/// </summary>
+public static class PortAllocationHelper
+{
+    /// <summary>First port scanned when a service's default port is unavailable.</summary>
+    public const int EphemeralRangeStart = 30000;
+
+    /// <summary>Last port scanned (inclusive) when a service's default port is unavailable.</summary>
+    public const int EphemeralRangeEnd = 45000;
+
+    /// <summary>
+    ///     Plan states whose <see cref="PlanYaml.AllocatedPorts" /> are treated as taken. A finished
+    ///     plan's worktree is gone, so holding its ports back would exhaust the range over time.
+    /// </summary>
+    private static readonly HashSet<string> ActiveStates = new(StringComparer.OrdinalIgnoreCase)
+    {
+        nameof(PlanStatus.Draft), nameof(PlanStatus.Creating), nameof(PlanStatus.Updating),
+        nameof(PlanStatus.Executing), nameof(PlanStatus.Review), nameof(PlanStatus.Blocked)
+    };
+
+    /// <summary>
+    ///     True when a listener can bind <paramref name="port" /> on loopback. Only loopback is probed:
+    ///     review actions and verifications bind 127.0.0.1 (binding 0.0.0.0 is blocked on some hosts),
+    ///     so a service occupying only an external interface must not count as a collision.
+    /// </summary>
+    public static bool IsPortAvailable(int port)
+    {
+        if (port is < 1 or > 65535) return false;
+
+        TcpListener? listener = null;
+        try
+        {
+            listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            return true;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+        finally
+        {
+            listener?.Stop();
+        }
+    }
+
+    /// <summary>
+    ///     Ensures every named port in <paramref name="project" /> has an assignment for
+    ///     <paramref name="plan" />, persisting <c>plan.yaml</c> when anything changed, and returns the
+    ///     full mapping. Ports already recorded on the plan are retained when still free, so the URLs a
+    ///     reviewer has open survive a re-execution.
+    /// </summary>
+    /// <param name="planFolder">
+    ///     The plan's folder. Its parent is used to find sibling plans whose ports are already taken.
+    /// </param>
+    public static Dictionary<string, int> AllocatePorts(
+        ProjectConfig project, PlanYaml plan, string planFolder, IPlanWatcherService? watcher = null)
+    {
+        if (project.Ports.Count == 0)
+            return plan.AllocatedPorts is null
+                ? new Dictionary<string, int>()
+                : new Dictionary<string, int>(plan.AllocatedPorts);
+
+        var plansDir = Path.GetDirectoryName(Path.GetFullPath(planFolder.TrimEnd(
+            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)));
+        var reserved = plansDir is null
+            ? new HashSet<int>()
+            : CollectReservedPorts(plansDir, planFolder);
+
+        var resolved = ResolvePorts(project, plan.AllocatedPorts, reserved, IsPortAvailable);
+
+        if (!AreEqual(plan.AllocatedPorts, resolved))
+        {
+            plan.AllocatedPorts = resolved;
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan, watcher);
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    ///     Pure allocation logic, separated from disk and socket access so it can be exercised
+    ///     deterministically. Iterates the project's ports in configuration order.
+    /// </summary>
+    /// <param name="existing">Ports already recorded on the plan, retained when still free.</param>
+    /// <param name="reserved">Ports held by other plans or by earlier names in this same pass.</param>
+    /// <param name="isAvailable">Availability probe (<see cref="IsPortAvailable" /> in production).</param>
+    internal static Dictionary<string, int> ResolvePorts(
+        ProjectConfig project,
+        IReadOnlyDictionary<string, int>? existing,
+        ISet<int> reserved,
+        Func<int, bool> isAvailable)
+    {
+        var taken = new HashSet<int>(reserved);
+        var resolved = new Dictionary<string, int>();
+
+        foreach (var (name, portConfig) in project.Ports)
+        {
+            if (existing != null &&
+                existing.TryGetValue(name, out var previous) &&
+                !taken.Contains(previous) &&
+                isAvailable(previous))
+            {
+                resolved[name] = previous;
+                taken.Add(previous);
+                continue;
+            }
+
+            var assigned = PickPort(portConfig.DefaultPort, taken, isAvailable);
+            if (assigned == 0)
+                throw new InvalidOperationException(
+                    $"No free TCP port available for '{name}': the default port {portConfig.DefaultPort} is in " +
+                    $"use and the range {EphemeralRangeStart}-{EphemeralRangeEnd} is exhausted.");
+
+            resolved[name] = assigned;
+            taken.Add(assigned);
+        }
+
+        // Names dropped from the project config keep no reservation, but a plan that recorded them is
+        // not rewritten to lose data an in-flight worktree may still be using.
+        if (existing != null)
+            foreach (var (name, port) in existing)
+                resolved.TryAdd(name, port);
+
+        return resolved;
+    }
+
+    /// <summary>Returns the default port when usable, otherwise the first free ephemeral port (0 if none).</summary>
+    private static int PickPort(int defaultPort, ICollection<int> taken, Func<int, bool> isAvailable)
+    {
+        if (defaultPort is > 0 and <= 65535 && !taken.Contains(defaultPort) && isAvailable(defaultPort))
+            return defaultPort;
+
+        for (var candidate = EphemeralRangeStart; candidate <= EphemeralRangeEnd; candidate++)
+        {
+            if (taken.Contains(candidate)) continue;
+            if (isAvailable(candidate)) return candidate;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    ///     Collects the ports recorded by every other plan in <paramref name="plansDir" /> that is still
+    ///     active, so two concurrent reviews never receive the same port. Unreadable plans are skipped:
+    ///     a corrupt neighbour must not block allocation.
+    /// </summary>
+    internal static HashSet<int> CollectReservedPorts(string plansDir, string? excludePlanFolder)
+    {
+        var reserved = new HashSet<int>();
+        if (!Directory.Exists(plansDir)) return reserved;
+
+        var excluded = excludePlanFolder is null
+            ? null
+            : Path.GetFullPath(excludePlanFolder.TrimEnd(
+                Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+
+        foreach (var folder in Directory.EnumerateDirectories(plansDir))
+        {
+            if (excluded != null &&
+                Path.GetFullPath(folder).Equals(excluded, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            PlanYaml? other;
+            try
+            {
+                other = PlanYamlHelper.ReadPlanYaml(folder);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (other?.AllocatedPorts is not { Count: > 0 }) continue;
+            if (!ActiveStates.Contains(other.State ?? "")) continue;
+
+            foreach (var port in other.AllocatedPorts.Values)
+                reserved.Add(port);
+        }
+
+        return reserved;
+    }
+
+    private static bool AreEqual(IReadOnlyDictionary<string, int>? a, IReadOnlyDictionary<string, int> b)
+    {
+        if (a is null) return b.Count == 0;
+        if (a.Count != b.Count) return false;
+        return a.All(kv => b.TryGetValue(kv.Key, out var value) && value == kv.Value);
+    }
+}

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -36,7 +36,8 @@ public record PlanMetadata(
     string? InitialPrompt,
     string? SourceUrl,
     bool PartialDelivery = false,
-    string? ChatSessionId = null);
+    string? ChatSessionId = null,
+    Dictionary<string, int>? AllocatedPorts = null);
 
 public record PlanFile(
     PlanMetadata Metadata,
@@ -62,6 +63,13 @@ public record PlanFile(
     public string? InitialPrompt => Metadata.InitialPrompt;
     public string? SourceUrl => Metadata.SourceUrl;
     public string? ChatSessionId => Metadata.ChatSessionId;
+
+    /// <summary>
+    ///     Ports assigned to this plan's named services, keyed by the project's port name. Empty when
+    ///     the project defines no ports or the plan has not been materialized yet. See
+    ///     <see cref="PlanYaml.AllocatedPorts" />.
+    /// </summary>
+    public Dictionary<string, int> AllocatedPorts => Metadata.AllocatedPorts ?? new();
 
     /// <summary>
     ///     True when the plan reached Completed over a failed verification. See
@@ -195,6 +203,15 @@ public class PlanYaml
     /// </summary>
     [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
     public bool PartialDelivery { get; set; }
+
+    /// <summary>
+    ///     Ports assigned to the project's named services for this plan, keyed by port name (see
+    ///     <see cref="Services.ProjectPortConfig" />). Written when a worktree is created and retained
+    ///     across re-executions so a review session keeps the same URLs. Additive and
+    ///     absent-means-none, so it needs no <see cref="CurrentSchemaVersion" /> bump.
+    /// </summary>
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public Dictionary<string, int>? AllocatedPorts { get; set; }
 
     public string? ExecutionProfile { get; set; }
     public string? InitialPrompt { get; set; }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -783,6 +783,14 @@ public class Program
                     verification.AddCommand<PlanVerificationRemoveCommand>("remove")
                         .WithDescription("Remove a verification from a plan");
                 });
+
+                plan.AddBranch("env", env =>
+                {
+                    env.AddCommand<PlanEnvMaterializeCommand>("materialize")
+                        .WithDescription("Allocate ports and write the project's environment files into the plan's worktrees");
+                    env.AddCommand<PlanEnvGetCommand>("get")
+                        .WithDescription("Print the plan's allocated ports and resolved environment values");
+                });
             });
 
             config.AddBranch("verification", verification =>
@@ -853,6 +861,26 @@ public class Program
                     .WithDescription("Import MCP servers from a repository into a project");
                 project.AddCommand<ProjectImportSkillsCommand>("import-skills")
                     .WithDescription("Import custom skills from a repository into a project");
+
+                project.AddBranch("port", port =>
+                {
+                    port.AddCommand<ProjectListPortsCommand>("list")
+                        .WithDescription("List the project's named service ports");
+                    port.AddCommand<ProjectAddPortCommand>("add")
+                        .WithDescription("Add or update a named service port");
+                    port.AddCommand<ProjectRemovePortCommand>("remove")
+                        .WithDescription("Remove a named service port");
+                });
+
+                project.AddBranch("env-file", envFile =>
+                {
+                    envFile.AddCommand<ProjectListEnvFilesCommand>("list")
+                        .WithDescription("List the environment files materialized into plan worktrees");
+                    envFile.AddCommand<ProjectAddEnvFileCommand>("add")
+                        .WithDescription("Add or update an environment file");
+                    envFile.AddCommand<ProjectRemoveEnvFileCommand>("remove")
+                        .WithDescription("Remove an environment file");
+                });
             });
 
             config.AddBranch("config", cfg =>

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -124,6 +124,14 @@ tendril plan rec set <plan-id> <title> <field> <value>
 tendril plan rec remove <plan-id> <title>
 tendril plan rec list <plan-id> [--state=Pending|Accepted|Declined]
 
+# Environment files and dynamic ports
+tendril plan env materialize <plan-id> [--repo=<repo>]
+# Allocates a free port for each of the project's named `ports` (retaining any already recorded in
+# `allocatedPorts`) and writes the project's configured `envFiles` into the plan's worktree. Run by
+# `tendril plan add-worktree` automatically; use it directly to refresh a worktree in place.
+tendril plan env get <plan-id>
+# Prints the plan's allocated ports and the environment variables each configured env file resolves to.
+
 # Validate plan health
 tendril plan validate <plan-id>
 ```
@@ -206,6 +214,9 @@ verifications:
 relatedPlans: []
 dependsOn: []
 priority: 0
+allocatedPorts:
+  backend: 3001
+  frontend: 3000
 ```
 
 ### Fields
@@ -230,6 +241,7 @@ priority: 0
 | `dependsOn`    | Plan folder names this plan depends on (e.g. `- 01478-WorktreeIsolation`). ExecutePlan will block until all dependencies are `Completed` and their PRs are merged. |
 | `priority`     | Integer priority (0 = normal). Higher values are executed first. Set by CreatePlan launcher, not by agents. |
 | `executionProfile` | (Optional) Recommended execution profile for ExecutePlan: `deep` or `balanced`. If set, overrides config.yaml default. CreatePlan sets this based on task complexity analysis. |
+| `allocatedPorts` | (Optional) Mapping of the project's named service ports (from the `ports` entry in `config.yaml`) to the TCP port assigned to this plan, e.g. `backend: 3001`. Written by `tendril plan add-worktree` / `tendril plan env materialize` and reused on re-execution so a review session keeps the same URLs. Managed by the CLI — do not hand-edit. |
 
 **Do NOT add fields beyond those listed above.** Unknown fields (e.g. `tags`, `category`) will be stripped by the normalizer and may cause parse errors.
 

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -52,6 +52,36 @@ public record NetworkAccessRuleConfig
     public string Mode { get; set; } = "Allow"; // Allow, Deny
 }
 
+/// <summary>
+///     A named service port the project's processes listen on (e.g. <c>frontend</c>, <c>backend</c>).
+///     <see cref="DefaultPort"/> is the preferred port; plan worktrees and review sessions fall back
+///     to a free port in the ephemeral range when it is already taken, so two concurrent reviews of
+///     the same project do not collide (see <c>PortAllocationHelper</c>).
+/// </summary>
+public record ProjectPortConfig
+{
+    public int DefaultPort { get; set; }
+    public string Description { get; set; } = "";
+}
+
+/// <summary>
+///     An environment file to materialize into a plan's worktree. Git worktrees start without the
+///     untracked <c>.env</c> files that exist in the original checkout, so services and migrations
+///     cannot boot until the file is recreated from <see cref="Template"/> plus
+///     <see cref="Overrides"/> (see <c>EnvironmentMaterializationHelper</c>).
+/// </summary>
+public record ProjectEnvFileConfig
+{
+    /// <summary>Target path, relative to the worktree root (e.g. <c>apps/web/.env</c>).</summary>
+    public string Path { get; set; } = "";
+
+    /// <summary>Optional source file, relative to the worktree root (e.g. <c>.env.example</c>).</summary>
+    public string? Template { get; set; }
+
+    /// <summary>Keys written on top of the template. Values support placeholder expansion.</summary>
+    public Dictionary<string, string> Overrides { get; set; } = new();
+}
+
 public record ProjectConfig
 {
     public string Name { get; set; } = "";
@@ -66,6 +96,12 @@ public record ProjectConfig
     public List<string> BuildDependencies { get; set; } = new();
     public List<ProjectMcpServerRef> McpServers { get; set; } = new();
     public List<ProjectSkillRef> Skills { get; set; } = new();
+
+    /// <summary>Named service ports, keyed by logical service name (e.g. <c>backend</c>).</summary>
+    public Dictionary<string, ProjectPortConfig> Ports { get; set; } = new();
+
+    /// <summary>Environment files to recreate inside each plan worktree.</summary>
+    public List<ProjectEnvFileConfig> EnvFiles { get; set; } = new();
 
     public string SecurityPreset { get; set; } = "Custom";
     public string OutsideFileAccessPolicy { get; set; } = "Allow";

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -1222,9 +1222,11 @@ public class PlanDatabaseService : IPlanDatabaseService
         var created = DateTime.Parse(createdStr, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
         var updated = DateTime.Parse(updatedStr, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
 
-        // partialDelivery comes from the mirrored YAML rather than a dedicated column: it is an
-        // additive flag on a rare path, so it does not warrant a schema migration.
-        var partialDelivery = PlanYamlHelper.ParsePlanYaml(yamlRaw)?.PartialDelivery ?? false;
+        // partialDelivery and allocatedPorts come from the mirrored YAML rather than dedicated
+        // columns: both are additive and read on rare paths, so neither warrants a schema migration.
+        var mirroredYaml = PlanYamlHelper.ParsePlanYaml(yamlRaw);
+        var partialDelivery = mirroredYaml?.PartialDelivery ?? false;
+        var allocatedPorts = mirroredYaml?.AllocatedPorts;
 
         if (string.IsNullOrEmpty(chatSessionId))
         {
@@ -1233,7 +1235,7 @@ public class PlanDatabaseService : IPlanDatabaseService
 
         var metadata = new PlanMetadata(planId, project, level, title, status,
             repos, commits, prs, verifications, relatedPlans, dependsOn, created, updated, initialPrompt, sourceUrl,
-            partialDelivery, chatSessionId);
+            partialDelivery, chatSessionId, allocatedPorts);
 
         return new PlanFile(metadata, latestContent, folderPath, yamlRaw, revisionCount);
     }

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -1101,7 +1101,8 @@ public class PlanReaderService(
                 planYaml.InitialPrompt,
                 planYaml.SourceUrl,
                 planYaml.PartialDelivery,
-                planYaml.ChatSessionId
+                planYaml.ChatSessionId,
+                planYaml.AllocatedPorts
             );
 
             var latestContent = ReadLatestRevisionFromFileSystem(folderName);

--- a/src/Ivy.Tendril/Services/Plans/PlanYamlRepairService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanYamlRepairService.cs
@@ -10,7 +10,7 @@ public static class PlanYamlRepairService
         "state", "project", "level", "title", "sessionId",
         "repos", "created", "updated", "initialPrompt", "sourceUrl",
         "prs", "commits", "verifications", "relatedPlans", "dependsOn",
-        "priority", "executionProfile", "recommendations"
+        "priority", "executionProfile", "recommendations", "allocatedPorts"
     };
 
     private static readonly HashSet<string> ListKeys = new(StringComparer.Ordinal)
@@ -18,6 +18,19 @@ public static class PlanYamlRepairService
         "repos", "prs", "commits", "verifications", "relatedPlans", "dependsOn",
         "recommendations"
     };
+
+    /// <summary>
+    ///     Top-level keys whose value is a nested mapping of scalars rather than a list. Without this,
+    ///     the normalizer treats each indented child (<c>backend: 3001</c>) as a stray unknown key and
+    ///     drops it, leaving the parent key with no value.
+    /// </summary>
+    private static readonly HashSet<string> MappingKeys = new(StringComparer.Ordinal)
+    {
+        "allocatedPorts"
+    };
+
+    /// <summary>Matches an <c>allocatedPorts</c> child: a name mapped to an integer port.</summary>
+    private static readonly Regex MappingEntryPattern = new(@"^[A-Za-z_][A-Za-z0-9_.-]*:\s*\d+\s*$", RegexOptions.Compiled);
 
     private static readonly Dictionary<string, (string ItemStartPattern, string SubKeyPattern)> StructuredListKeys = new()
     {
@@ -90,7 +103,10 @@ public static class PlanYamlRepairService
             return $"{prefix}'{escaped}'";
         });
 
-        repaired = Regex.Replace(repaired, @"(?m)^(\s*\w+:\s+)(.+)$", m =>
+        // Horizontal whitespace only: a plain \s+ after the colon also matches the newline, so
+        // "allocatedPorts:\n  backend: 3001" was read as one key whose value is "backend: 3001" and
+        // the port got quoted onto the parent line, losing the whole mapping.
+        repaired = Regex.Replace(repaired, @"(?m)^([ \t]*\w+:[ \t]+)(.+)$", m =>
         {
             var prefix = m.Groups[1].Value;
             var value = m.Groups[2].Value.TrimEnd();
@@ -131,6 +147,7 @@ public static class PlanYamlRepairService
         var lines = normalized.Split('\n');
         var output = new List<string>(lines.Length);
         string? currentListKey = null;
+        string? currentMappingKey = null;
         var inStructuredListItem = false;
         var inListItemBlockScalar = false;
         var inBlockScalar = false;
@@ -148,6 +165,16 @@ public static class PlanYamlRepairService
                 continue;
             }
 
+            // Children of a nested mapping are matched before top-level detection, so an indented
+            // "backend: 3001" is kept as a port rather than dropped as a stray key. Names that collide
+            // with a real top-level key are excluded: the mapping has to terminate at the next key
+            // (e.g. "priority: 0"), and losing one oddly named port beats losing the plan's title.
+            if (currentMappingKey != null && !inBlockScalar && IsMappingEntry(trimmed))
+            {
+                output.Add($"  {trimmed}");
+                continue;
+            }
+
             var detectedKey = TryExtractTopLevelKey(trimmed, out var normalizedTopLevelLine);
             if (inBlockScalar && detectedKey == null)
             {
@@ -161,6 +188,7 @@ public static class PlanYamlRepairService
                     continue;
 
                 currentListKey = ListKeys.Contains(detectedKey) ? detectedKey : null;
+                currentMappingKey = MappingKeys.Contains(detectedKey) ? detectedKey : null;
                 inStructuredListItem = false;
                 inListItemBlockScalar = false;
                 inBlockScalar = false;
@@ -195,7 +223,8 @@ public static class PlanYamlRepairService
             if (currentListKey != null)
             {
                 ProcessListContext(trimmed, line, currentListKey, ref inStructuredListItem,
-                    ref inListItemBlockScalar, ref inUnknownKey, ref currentListKey, output);
+                    ref inListItemBlockScalar, ref inUnknownKey, ref currentListKey,
+                    ref currentMappingKey, output);
                 continue;
             }
 
@@ -216,6 +245,7 @@ public static class PlanYamlRepairService
         string trimmed, string line, string currentListKey,
         ref bool inStructuredListItem, ref bool inListItemBlockScalar,
         ref bool inUnknownKey, ref string? currentListKeyRef,
+        ref string? currentMappingKeyRef,
         List<string> output)
     {
         var isStructured = StructuredListKeys.TryGetValue(currentListKey, out var patterns);
@@ -245,6 +275,7 @@ public static class PlanYamlRepairService
             {
                 var key = strayKeyMatch.Groups[1].Value;
                 currentListKeyRef = ListKeys.Contains(key) ? key : null;
+                currentMappingKeyRef = MappingKeys.Contains(key) ? key : null;
                 inStructuredListItem = false;
                 inListItemBlockScalar = false;
                 output.Add(trimmed);
@@ -252,6 +283,7 @@ public static class PlanYamlRepairService
             else if (strayKeyMatch.Success)
             {
                 currentListKeyRef = null;
+                currentMappingKeyRef = null;
                 inUnknownKey = true;
                 inListItemBlockScalar = false;
             }
@@ -396,6 +428,17 @@ public static class PlanYamlRepairService
     private static bool IsBlockScalarValue(string value)
     {
         return value is "|" or "|-" or ">" or ">-";
+    }
+
+    /// <summary>
+    ///     True when the line is a <c>name: &lt;int&gt;</c> child of a <see cref="MappingKeys" /> block
+    ///     rather than the next top-level key.
+    /// </summary>
+    private static bool IsMappingEntry(string trimmedLine)
+    {
+        if (!MappingEntryPattern.IsMatch(trimmedLine)) return false;
+        var key = trimmedLine[..trimmedLine.IndexOf(':')];
+        return !TopLevelKeys.Contains(key);
     }
 
     private static string? TryExtractTopLevelKey(string trimmedLine, out string normalizedLine)


### PR DESCRIPTION
Fixes #2282

# Summary

## Changes

Projects can now declare named service ports and environment files, and every plan gets its own
conflict-free port assignment plus real `.env` files materialized into its worktree. Ports are
allocated when a worktree is created (preferring the configured default, falling back to a scan of
30000–45000, and avoiding ports held by other active plans), recorded in `plan.yaml` as
`allocatedPorts` so they survive re-execution, and propagated into env file values and review action
commands via `${ports.<name>}` and `PORT_<NAME>` environment variables.

Fixing `allocatedPorts` so it survives plan.yaml normalization also uncovered a real bug in
`PlanYamlRepairService`: the scalar-quoting pass used `\s+` after the key's colon, which matches
newlines, so any nested mapping was read as a single key/value pair and destroyed. Narrowed to
`[ \t]+`, with a 244-test regression sweep over the surrounding plan.yaml suites.

## API Changes

**New config records** in `Ivy.Tendril.Services`:

- `ProjectPortConfig` — `int DefaultPort`, `string Description`
- `ProjectEnvFileConfig` — `string Path`, `string? Template`, `Dictionary<string, string> Overrides`
- `ProjectConfig.Ports` (`Dictionary<string, ProjectPortConfig>`) and `ProjectConfig.EnvFiles`
  (`List<ProjectEnvFileConfig>`)

**Plan model:**

- `PlanYaml.AllocatedPorts` (`Dictionary<string, int>?`, `OmitDefaults`) — new optional `allocatedPorts`
  key in plan.yaml
- `PlanMetadata` gained a trailing `Dictionary<string, int>? AllocatedPorts = null` parameter
  (positional callers past `ChatSessionId` are unaffected; use the named argument)
- `PlanFile.AllocatedPorts` (`Dictionary<string, int>`, never null)

**New helpers:**

- `PortAllocationHelper.AllocatePorts(ProjectConfig, PlanFile, string planFolder)`,
  `ResolvePorts`, `IsPortAvailable`, `CollectReservedPorts`
- `EnvironmentMaterializationHelper.MaterializeEnvFiles(ProjectConfig, IReadOnlyDictionary<string, int>, string worktreeRoot)`
  → `int` count, plus `ResolveEnvValues` and `ExpandPortPlaceholders`

**Changed signatures:**

- `ReviewActionsBarView.GetTooltip` and `BuildActionButton` gained an optional trailing
  `IReadOnlyDictionary<string, int>? allocatedPorts` parameter
- `ReviewActionApp` gained internal `ResolvePorts`, `InterpolateCommand`, `BuildEnvironment`

**New CLI commands:**

```
tendril project port add <project> <name> <default-port> [--description=...]
tendril project port list <project>
tendril project port remove <project> <name>
tendril project env-file add <project> <path> [--template=...] [--override=KEY=VALUE]...
tendril project env-file list <project>
tendril project env-file remove <project> <path>
tendril plan env materialize <plan-id> [--repo=...]
tendril plan env get <plan-id>
```

**New review action environment variables:** `PORT_<UPPER_NAME>` per configured port, `PORT` for the
primary one, plus `PLAN_ID`, `PLAN_FOLDER`, `PROJECT_NAME`, `WORKTREE_DIR`.

**New placeholders** in env file values and review action commands: `${ports.<name>}`, `${env.<VAR>}`,
`%PORT%` (`%VAR%` continues to go through `VariableExpansion`).

## Files Modified

**Configuration and plan model**

- `src/Ivy.Tendril/Services/ConfigService.cs` — the two new records and the `ProjectConfig` properties
- `src/Ivy.Tendril/Models/PlanModels.cs` — `AllocatedPorts` on `PlanYaml`, `PlanMetadata`, `PlanFile`
- `src/Ivy.Tendril/Services/Plans/PlanReaderService.cs`, `PlanDatabaseService.cs` — field mapping
- `src/Ivy.Tendril/Services/Plans/PlanYamlRepairService.cs` — `MappingKeys` / `IsMappingEntry` so
  nested port entries survive normalization, plus the `[ \t]+` scalar-quoting fix
- `src/Ivy.Tendril/Prompts/Plans.md` — `allocatedPorts` and the `plan env` commands documented

**Allocation and materialization**

- `src/Ivy.Tendril/Helpers/PortAllocationHelper.cs` (new)
- `src/Ivy.Tendril/Helpers/EnvironmentMaterializationHelper.cs` (new)

**Integration**

- `src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs` — allocate and materialize after
  `git worktree add`
- `src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs` — command interpolation and `PtyOptions.Environment`
- `src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs` — ports in the button tooltip

**CLI**

- `src/Ivy.Tendril/Commands/ProjectCommand.cs`, `src/Ivy.Tendril/Commands/PlanEnvCommand.cs` (new),
  `src/Ivy.Tendril/Program.cs`

**Settings UI**

- `src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs`,
  `Apps/Settings/Blades/ProjectTableViews.cs`,
  `Apps/Settings/Dialogs/EditProjectPortDialog.cs` (new),
  `Apps/Settings/Dialogs/EditProjectEnvFileDialog.cs` (new)

**Tests** — six new files under `src/Ivy.Tendril.Test/{Helpers,Commands,Services}` plus additions to
`Apps/ReviewActionAppTests.cs` and `Apps/ReviewActionsBarViewTests.cs`.

## Manual Testing

1. **Configure a project.** Pick a project with a runnable service and give it a port and an env file:

   ```bash
   tendril project port add <project> backend 3001 --description="API gateway"
   tendril project port add <project> frontend 3000
   tendril project env-file add <project> .env --template=.env.example \
     --override="PORT=\${ports.backend}" --override="VITE_API_URL=http://localhost:\${ports.backend}"
   ```

   Then run `tendril project port list <project>` and `tendril project env-file list <project>` — both
   should show what you just added. Re-running `port add` with the same name should print
   `Updated port:` rather than creating a duplicate.

2. **Check the settings UI.** Launch Tendril, open Settings → the project. The Ports and Environment
   Files cards should show the same entries. Add a port through the dialog, then confirm it appears in
   `tendril project port list` — that verifies `SaveProjectChanges()` persisted it to `config.yaml`.

3. **Create a worktree.** Run `tendril plan add-worktree <plan-id>` for a plan on that project. The
   output should include a `Port backend: <n>` line per port and
   `Materialized 1 environment file(s) into worktree.` Open the worktree's `.env`: the template's keys
   should be present, the overrides should have won where they overlap, and `${ports.backend}` should
   have become the actual number from the port lines.

4. **Confirm the collision handling.** Occupy port 3001 on loopback (e.g. `nc -l 127.0.0.1 3001`), then
   run `tendril plan env materialize <plan-id>` for a *different* plan on the same project. The
   reported backend port should be somewhere in 30000–45000 instead of 3001. Run
   `tendril plan env materialize` again on the same plan — the port should not change, because a port
   the plan already holds is retained.

5. **Check the review action.** Open the plan's Review tab. Hover a run button: the tooltip should read
   like `Run: npm run dev (ports: backend: 3001, frontend: 3000)`. Click it, and in the terminal run
   `echo $env:PORT_BACKEND` / `echo $env:PLAN_ID` (pwsh) — both should be populated. If the action's
   command contains `${ports.backend}` or `%PORT%`, the command line shown at the top of the terminal
   should already have the number substituted in.

6. **Check `plan env get` is read-only.** Run `tendril plan env get <plan-id>` on a plan with no
   worktree. It should print the allocated ports and resolved values without creating any file and
   without changing `allocatedPorts` in `plan.yaml`.


---
## Commits
- 691b443b Add port and env-file config models and plan.yaml allocatedPorts (Plan 00105)
- 0a51665d Add port allocation and environment materialization helpers (Plan 00105)
- bc54ec88 Allocate ports and materialize env files for worktrees and review actions (Plan 00105)
- 7b558477 Add project port/env-file and plan env CLI commands (Plan 00105)
- a42fd0f0 Add Ports and Environment Files cards to the project settings view (Plan 00105)
- 58478a50 Add tests for port allocation, env materialization and the new commands (Plan 00105)

---
Created using [Ivy Tendril](https://ivy.app).
