### PR TITLE
[00127] Give the Default Theme an Accessible Destructive Foreground

### DIFF
--- a/src/Ivy.Tendril.Test/Themes/ThemeRegistryTests.cs
+++ b/src/Ivy.Tendril.Test/Themes/ThemeRegistryTests.cs
@@ -180,7 +180,7 @@ public class ThemeRegistryTests
     [Fact]
     public void AllThemes_DestructiveColors_MeetWcagContrastRatio()
     {
-        foreach (var theme in TendrilThemes.All.Where(t => t.Id != TendrilThemes.Default.Id))
+        foreach (var theme in TendrilThemes.All)
         {
             var light = theme.IvyTheme?.Colors?.Light;
             Assert.NotNull(light);
@@ -200,6 +200,30 @@ public class ThemeRegistryTests
             Assert.True(darkRatio >= 4.5,
                 $"Theme '{theme.Id}' Dark mode destructive contrast ratio is {darkRatio:F2}:1 ({dark.Destructive} vs {dark.DestructiveForeground}), expected at least 4.5:1 (WCAG AA).");
         }
+    }
+
+    [Fact]
+    public void DefaultTheme_DestructiveForeground_IsAccessible()
+    {
+        var light = TendrilThemes.Default.IvyTheme.Colors!.Light!;
+        var dark = TendrilThemes.Default.IvyTheme.Colors!.Dark!;
+
+        Assert.Equal("#000000", light.DestructiveForeground, ignoreCase: true);
+        Assert.Equal("#000000", dark.DestructiveForeground, ignoreCase: true);
+
+        Assert.True(CalculateContrastRatio(light.Destructive!, light.DestructiveForeground!) >= 4.5,
+            "Default theme Light mode destructive contrast ratio is below the WCAG AA minimum of 4.5:1.");
+        Assert.True(CalculateContrastRatio(dark.Destructive!, dark.DestructiveForeground!) >= 4.5,
+            "Default theme Dark mode destructive contrast ratio is below the WCAG AA minimum of 4.5:1.");
+    }
+
+    [Fact]
+    public void CreateDefaultIvyTheme_DoesNotMutateIvyDefault()
+    {
+        TendrilThemes.CreateDefaultIvyTheme();
+
+        Assert.Equal("#ffffff", Theme.Default.Colors!.Light!.DestructiveForeground, ignoreCase: true);
+        Assert.Equal("#ffffff", Theme.Default.Colors!.Dark!.DestructiveForeground, ignoreCase: true);
     }
 
     private static double CalculateContrastRatio(string hex1, string hex2)

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/VaultThemesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/VaultThemesDialog.cs
@@ -80,7 +80,7 @@ public class VaultThemesDialog(
 
         var presets = new Dictionary<string, Theme>(StringComparer.OrdinalIgnoreCase)
         {
-            ["Default"] = Theme.Default,
+            ["Default"] = TendrilThemes.CreateDefaultIvyTheme(),
             ["Ocean"] = GetOceanTheme(),
             ["Forest"] = GetForestTheme(),
             ["Sunset"] = GetSunsetTheme(),

--- a/src/Ivy.Tendril/Commands/VaultThemeCommand.cs
+++ b/src/Ivy.Tendril/Commands/VaultThemeCommand.cs
@@ -566,7 +566,7 @@ public class VaultThemeCreateCommand(IVaultService vaultService) : AsyncCommand<
         }
         else
         {
-            theme = TendrilThemes.CloneTheme(Theme.Default);
+            theme = TendrilThemes.CreateDefaultIvyTheme();
             isDark = false;
         }
 

--- a/src/Ivy.Tendril/Themes/TendrilThemes.cs
+++ b/src/Ivy.Tendril/Themes/TendrilThemes.cs
@@ -13,7 +13,7 @@ public class TendrilThemeDescriptor
     public string Description { get; init; } = "";
     public bool IsDark { get; init; }
     public string[] PreviewColors { get; init; } = [];
-    public Theme IvyTheme { get; init; } = Theme.Default;
+    public Theme IvyTheme { get; init; } = TendrilThemes.CreateDefaultIvyTheme();
     public string? VaultId { get; init; }
     public string? VaultName { get; init; }
     public bool IsVaultTheme { get; init; }
@@ -28,7 +28,7 @@ public static class TendrilThemes
         Description = "Standard clean Tendril theme with slate light and dark zinc",
         IsDark = false,
         PreviewColors = ["#18181b", "#71717a", "#27272a", "#ffffff"],
-        IvyTheme = Theme.Default
+        IvyTheme = CreateDefaultIvyTheme()
     };
 
     public static readonly TendrilThemeDescriptor Cupcake = new()
@@ -1237,7 +1237,7 @@ public static class TendrilThemes
             PreviewColors = manifest.PreviewColors != null && manifest.PreviewColors.Length > 0
                 ? manifest.PreviewColors
                 : ExtractPreviewColors(manifest.IvyTheme, manifest.IsDark),
-            IvyTheme = manifest.IvyTheme ?? Theme.Default,
+            IvyTheme = manifest.IvyTheme ?? CreateDefaultIvyTheme(),
             VaultId = vaultId,
             VaultName = vaultName,
             IsVaultTheme = true
@@ -1358,6 +1358,18 @@ public static class TendrilThemes
                 Dark = CloneThemeColors(source.Colors?.Dark ?? ThemeColors.DefaultDark)
             }
         };
+    }
+
+    /// <summary>
+    /// Ivy's Theme.Default pairs Destructive #ef4444 with #ffffff (3.76:1), below the WCAG 2.1 AA
+    /// minimum of 4.5:1. Black on the same red is 5.58:1.
+    /// </summary>
+    public static Theme CreateDefaultIvyTheme()
+    {
+        var theme = CloneTheme(Theme.Default);
+        theme.Colors.Light!.DestructiveForeground = "#000000";
+        theme.Colors.Dark!.DestructiveForeground = "#000000";
+        return theme;
     }
 
     public static ThemeColors CloneThemeColors(ThemeColors source)


### PR DESCRIPTION
# Summary

## Changes

Ivy's `Theme.Default` pairs `Destructive #ef4444` with white text (3.76:1 contrast), failing WCAG
2.1 AA's 4.5:1 minimum. Added `TendrilThemes.CreateDefaultIvyTheme()`, which clones `Theme.Default`
and overrides `DestructiveForeground` to `#000000` (5.58:1) for both light and dark schemes, and
routed every place in Tendril that previously resolved `Theme.Default` directly through this factory
instead. The theme registry's contrast regression test now covers the default theme too, closing the
gap left by Plan 00090.

## API Changes

- **New:** `TendrilThemes.CreateDefaultIvyTheme(): Theme`: returns a fresh clone of `Theme.Default`
  with an accessible `#000000` destructive foreground applied to both color schemes.
- No breaking changes to existing public members; `Theme.Default` itself (from the upstream Ivy
  framework) is untouched.

## Files Modified

- `src/Ivy.Tendril/Themes/TendrilThemes.cs`: added `CreateDefaultIvyTheme()`; routed the `Default`
  descriptor, `TendrilThemeDescriptor.IvyTheme`'s property default, and the vault manifest fallback
  through it instead of `Theme.Default`.
- `src/Ivy.Tendril/Apps/Settings/Dialogs/VaultThemesDialog.cs`: `presets["Default"]` now uses
  `TendrilThemes.CreateDefaultIvyTheme()`.
- `src/Ivy.Tendril/Commands/VaultThemeCommand.cs`: `vault theme create` with no `--base-preset` now
  uses `TendrilThemes.CreateDefaultIvyTheme()` directly (dropped the redundant `CloneTheme` wrapper).
- `src/Ivy.Tendril.Test/Themes/ThemeRegistryTests.cs`: removed the default-theme exclusion from
  `AllThemes_DestructiveColors_MeetWcagContrastRatio`; added
  `DefaultTheme_DestructiveForeground_IsAccessible` and `CreateDefaultIvyTheme_DoesNotMutateIvyDefault`.

## Manual Testing

1. Run the app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`.
2. Open Settings -> Themes and select the "Default" theme (or leave it as-is, since it's the default).
3. Trigger a destructive UI element that uses the theme's destructive colors, e.g. a delete
   confirmation button/badge/callout.
4. Observe the destructive text is now black on the red background instead of white, and remains
   clearly legible.
5. Repeat in dark mode to confirm the same accessible pairing applies there.
6. In the Vault theme editor (`Settings -> Vault -> Themes`), start a new theme from the "Default"
   preset and confirm it also inherits the black destructive text.

---
## Commits
- 4fd2e3c9 Give the default theme an accessible destructive foreground
- 98e957ef Add tests for the accessible default theme destructive foreground

---
Created using [Ivy Tendril](https://ivy.app).
