### PR TITLE
[00164] Replace Regular Tables in Dashboard KPI Breakdown Sheets with DataTables

### DIFF
--- a/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
+++ b/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
@@ -1,3 +1,5 @@
+using Ivy;
+using Ivy.Core;
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Models;
 
@@ -117,5 +119,60 @@ public class KpiBreakdownSheetTests
         Assert.NotNull(avgCostMonthSheet.Build());
         Assert.NotNull(forecastSheet.Build());
         Assert.NotNull(avgCostPlanSheet.Build());
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_PopulatedData_BuildsDataTables()
+    {
+        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", _stats, _activity, _prDays, _today, _fakeService);
+        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, _today, _fakeService);
+
+        var dailyPrsTable = ExtractTableContent(dailyPrsSheet.Build());
+        var avgCostMonthTable = ExtractTableContent(avgCostMonthSheet.Build());
+        var forecastTable = ExtractTableContent(forecastSheet.Build());
+        var avgCostPlanTable = ExtractTableContent(avgCostPlanSheet.Build());
+
+        Assert.NotNull(dailyPrsTable);
+        Assert.StartsWith("DataTableBuilder", dailyPrsTable.GetType().Name);
+
+        Assert.NotNull(avgCostMonthTable);
+        Assert.StartsWith("DataTableBuilder", avgCostMonthTable.GetType().Name);
+
+        Assert.NotNull(forecastTable);
+        Assert.StartsWith("DataTableBuilder", forecastTable.GetType().Name);
+
+        Assert.NotNull(avgCostPlanTable);
+        Assert.StartsWith("DataTableBuilder", avgCostPlanTable.GetType().Name);
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_EmptyData_ProducesCalloutPlaceholders()
+    {
+        var emptyStats = new DashboardModels(0, 0, 0, 0, 0, 0, 0m, [], []);
+        var emptyActivity = new DashboardActivityStats([], 0m);
+        var emptyService = new FakePlanReaderService();
+
+        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", emptyStats, emptyActivity, [], _today, emptyService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", emptyStats, emptyActivity, [], _today, emptyService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", emptyStats, emptyActivity, [], _today, emptyService);
+
+        var dailyPrsContent = ExtractTableContent(dailyPrsSheet.Build());
+        var forecastContent = ExtractTableContent(forecastSheet.Build());
+        var avgCostPlanContent = ExtractTableContent(avgCostPlanSheet.Build());
+
+        Assert.IsType<Callout>(dailyPrsContent);
+        Assert.IsType<Callout>(forecastContent);
+        Assert.IsType<Callout>(avgCostPlanContent);
+    }
+
+    private static object ExtractTableContent(object buildResult)
+    {
+        var layout = Assert.IsAssignableFrom<LayoutView>(buildResult);
+        var stack = Assert.IsAssignableFrom<IWidget>(layout.Build());
+        var innerLayout = Assert.IsAssignableFrom<LayoutView>(stack.Children[2]);
+        var innerStack = Assert.IsAssignableFrom<IWidget>(innerLayout.Build());
+        return innerStack.Children[1];
     }
 }

--- a/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
@@ -72,13 +72,22 @@ public class KpiBreakdownSheet(
                     MergedDate = p.MergedDate.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture),
                     Url = p.PrUrl
                 })
-                .ToTable()
+                .AsQueryable()
+                .ToDataTable(x => x.Url)
                 .Header(x => x.PlanId, "Plan")
                 .Header(x => x.Title, "Title")
                 .Header(x => x.Repository, "Repo")
                 .Header(x => x.MergedDate, "Merged")
                 .Header(x => x.Url, "PR URL")
-                .Width(Size.Full());
+                .Width(Size.Full())
+                .Height(Size.Px(360))
+                .Config(c =>
+                {
+                    c.AllowSorting = true;
+                    c.SelectionMode = SelectionModes.None;
+                    c.ShowIndexColumn = false;
+                    c.ShowSearch = false;
+                });
 
         return Layout.Vertical().Gap(4)
                | Callout.Info("Average Daily PRs measures pull request delivery throughput across a rolling 30-day window. Total merged pull requests from the last 30 calendar days are divided by 30.", "Throughput Metric")
@@ -144,14 +153,23 @@ public class KpiBreakdownSheet(
             .ToList();
 
         var table = monthRows
-            .ToTable()
+            .AsQueryable()
+            .ToDataTable(x => x.Month)
             .Header(x => x.Month, "Month")
             .Header(x => x.Spend, "Spend")
             .Header(x => x.Tokens, "Tokens")
             .Header(x => x.PlansCreated, "Plans")
             .Header(x => x.PrsMerged, "PRs Merged")
             .Header(x => x.Status, "Divisor Status")
-            .Width(Size.Full());
+            .Width(Size.Full())
+            .Height(Size.Px(360))
+            .Config(c =>
+            {
+                c.AllowSorting = true;
+                c.SelectionMode = SelectionModes.None;
+                c.ShowIndexColumn = false;
+                c.ShowSearch = false;
+            });
 
         return Layout.Vertical().Gap(4)
                | Callout.Info("Average Cost/Month shows retrospective monthly spend across complete historical calendar months, strictly excluding the currently in-flight month to prevent partial-month bias.", "Retrospective Spend")
@@ -208,11 +226,20 @@ public class KpiBreakdownSheet(
         object tableContent = daily.Count == 0
             ? Callout.Info("No daily spend records found in the 30-day window.", "No Data")
             : daily
-                .ToTable()
+                .AsQueryable()
+                .ToDataTable(x => x.Date)
                 .Header(x => x.Date, "Date")
                 .Header(x => x.Spend, "Daily Spend")
                 .Header(x => x.Tokens, "Tokens")
-                .Width(Size.Full());
+                .Width(Size.Full())
+                .Height(Size.Px(360))
+                .Config(c =>
+                {
+                    c.AllowSorting = true;
+                    c.SelectionMode = SelectionModes.None;
+                    c.ShowIndexColumn = false;
+                    c.ShowSearch = false;
+                });
 
         return Layout.Vertical().Gap(4)
                | Callout.Info("Forecast This Month projects month-end spend using daily activity over the last 30 days. Dual projections indicate uncertainty: Calendar Basis assumes idle days continue at the observed rate, while Activity Basis projects from active spend days only.", "Dual Projections")
@@ -258,14 +285,23 @@ public class KpiBreakdownSheet(
                     Tokens = FormatHelper.FormatCount(p.Tokens),
                     Cost = p.Cost.HasValue ? FormatHelper.FormatCost(p.Cost.Value) : "Unpriced"
                 })
-                .ToTable()
+                .AsQueryable()
+                .ToDataTable(x => x.PlanId)
                 .Header(x => x.PlanId, "Plan")
                 .Header(x => x.Title, "Title")
                 .Header(x => x.State, "State")
                 .Header(x => x.CreatedDate, "Created")
                 .Header(x => x.Tokens, "Tokens")
                 .Header(x => x.Cost, "Total Cost")
-                .Width(Size.Full());
+                .Width(Size.Full())
+                .Height(Size.Px(360))
+                .Config(c =>
+                {
+                    c.AllowSorting = true;
+                    c.SelectionMode = SelectionModes.None;
+                    c.ShowIndexColumn = false;
+                    c.ShowSearch = false;
+                });
 
         return Layout.Vertical().Gap(4)
                | Callout.Info("Average Cost per Plan calculates the mean execution and promptware spend for plans created in the last 7 days that reached Completed, Failed, or Review state. Unpriced plans (e.g. subscription runs where cost is null) are excluded from the divisor so they do not artificially deflate the average.", "7-Day Rolling Average")


### PR DESCRIPTION
# Summary

## Changes

Replaced regular tables in `KpiBreakdownSheet` with fixed-height Ivy `DataTable` components across all four dashboard KPI breakdown views (`dailyPrs`, `avgCostMonth`, `forecastMonth`, and `avgCostPlan`). Each table now enables internal vertical scrolling with a fixed 360px height constraint and column sorting while disabling selection checkboxes, row indices, and search headers.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs`: Converted the four breakdown views to use `.AsQueryable().ToDataTable(...)` with `Height(Size.Px(360))` and sorting enabled.
- `src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs`: Added unit tests verifying DataTable instantiation on populated data and Callout placeholder preservation on empty data.

## Manual Testing

1. Launch Tendril: `tendril` (or run `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`).
2. Navigate to the Dashboard app.
3. Click on each of the four KPI cards (Average Daily PRs, Average Cost per Month, Forecast This Month, Average Cost per Plan) to open their slide-out breakdown sheets.
4. Verify each breakdown sheet displays a scrollable DataTable bounded to 360px height rather than expanding endlessly down the sheet.
5. Click column headers to verify column sorting functions correctly.

---
- 43c6551b Replace regular tables in KPI breakdown sheets with DataTables (00164)

---
Created using [Ivy Tendril](https://ivy.app).
