### PR TITLE
[00166] Update Xterm Project References to Consolidated Ivy Package

### DIFF
--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -59,7 +59,6 @@
     <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.AnimatedStatusLabel/Ivy.Widgets.AnimatedStatusLabel.csproj" />
     <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.DiffView/Ivy.Widgets.DiffView.csproj" />
     <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj" />
-    <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
     <PackageReference Include="Ivy" Version="1.3.21" />

--- a/src/Ivy.Tendril/Ivy.Tendril.slnx
+++ b/src/Ivy.Tendril/Ivy.Tendril.slnx
@@ -9,7 +9,6 @@
   <Project Path="../Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj" />
   <Project Path="../Ivy.Tendril.Test/Ivy.Tendril.Test.csproj" />
   <Project Path="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
-  <Project Path="../../../Ivy-Framework/src/widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj" />
   <Project Path="../Ivy.Tendril.Agents.Test.End2End/Ivy.Tendril.Agents.Test.End2End.csproj" />
   <Project Path="../Ivy.Tendril.Agents/Ivy.Tendril.Agents.csproj" />
   <Project Path="../Ivy.Tendril.Agents.Test/Ivy.Tendril.Agents.Test.csproj" />


### PR DESCRIPTION
# Summary

## Changes

Removed obsolete project references to `Ivy.Widgets.Xterm.csproj` from `Ivy.Tendril.slnx` and `Ivy.Tendril.csproj`. This aligns Tendril with upstream Ivy-Framework where the Xterm widget was consolidated into the core `Ivy` assembly, resolving build errors when building against local framework sources.

## API Changes

None.

## Files Modified

- **Build / Solution Configuration:**
  - `src/Ivy.Tendril/Ivy.Tendril.slnx`: Removed `<Project>` reference to obsolete `Ivy.Widgets.Xterm.csproj`.
  - `src/Ivy.Tendril/Ivy.Tendril.csproj`: Removed `<ProjectReference>` to obsolete `Ivy.Widgets.Xterm.csproj` under the source build condition.

## Manual Testing

N/A - internal change with no user-facing behavior. Verified via build commands:
- `dotnet build src/Ivy.Tendril/Ivy.Tendril.slnx`
- `dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~ReviewActionAppTests"`
- `dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj -p:IvySource=false`

---
- 2334dd28 [00166] Update Xterm project references to consolidated Ivy package

---
Created using [Ivy Tendril](https://ivy.app).
