### PR TITLE
[00173] Remove Subtitle Text from Ports and Environment Files in Project Detail View

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -330,13 +330,11 @@ public class ProjectDetailView(
 
             // Section 5: Ports
             | Text.H4("Ports").Bold()
-            | Text.Muted("Named service ports. A plan's worktree takes the default port when it is free and falls back to a free one otherwise, so concurrent reviews do not collide.")
             | new ProjectPortsTableView(ports, name => showPortTrigger(name))
             | new Button("Add Port").Icon(Icons.Plus).Outline().OnClick(() => showPortTrigger(null))
 
             // Section 6: Environment Files
             | Text.H4("Environment Files").Bold()
-            | Text.Muted("Recreated inside every plan worktree, which starts without the untracked .env files the original checkout relies on. Values support ${ports.<name>}, ${env.<VAR>} and %VAR%.")
             | new ProjectEnvFilesTableView(envFiles, idx => showEnvFileTrigger(idx))
             | new Button("Add Environment File").Icon(Icons.Plus).Outline().OnClick(() => showEnvFileTrigger(null))
 


### PR DESCRIPTION
# Summary

## Changes

Removed descriptive Text.Muted subtitle callouts under Section 5 (Ports) and Section 6 (Environment Files) in ProjectDetailView. This ensures Section 5 and Section 6 match surrounding sections (like Verifications and Review Actions) by displaying only their H4 headers, table views, and action buttons.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs`: Removed Text.Muted subtitle elements under Ports and Environment Files sections.

## Manual Testing

1. Launch the Tendril desktop/web application:
   `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Navigate to Settings and open any project detail view.
3. Scroll down to Section 5 (Ports) and Section 6 (Environment Files).
4. Verify that neither section displays the muted descriptive subtitle below the section header.

---
## Commits
- `0aaac199`: 00173: Remove subtitle text from Ports and Environment Files in ProjectDetailView

---
Created using [Ivy Tendril](https://ivy.app).