### PR TITLE
[00183] Remove Dead Ivy-Framework Project References From Ivy.Tendril.csproj

### DIFF
--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -51,14 +51,10 @@
     <PackageReference Include="YamlDotNet" Version="17.0.0" />
   </ItemGroup>
   <!-- Ivy Framework (source) -->
+  <!-- Ivy.Hooks.Pty and the Ivy.Widgets.* projects now compile into Ivy.csproj; do not re-add ProjectReferences to them -->
   <ItemGroup Condition="'$(IvySource)' == 'true'">
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Desktop/Ivy.Desktop.csproj" />
-    <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Hooks.Pty/Ivy.Hooks.Pty.csproj" />
-    <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.ActivityHeatmap/Ivy.Widgets.ActivityHeatmap.csproj" />
-    <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.AnimatedStatusLabel/Ivy.Widgets.AnimatedStatusLabel.csproj" />
-    <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.DiffView/Ivy.Widgets.DiffView.csproj" />
-    <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
     <PackageReference Include="Ivy" Version="1.3.21" />


### PR DESCRIPTION
# Summary

## Changes

Removed five dead `ProjectReference` entries from the `IvySource == 'true'` `ItemGroup` in
`Ivy.Tendril.csproj` (`Ivy.Hooks.Pty` and the four `Ivy.Widgets.*` projects), which no longer exist
upstream after being absorbed into `Ivy.csproj`. Added a one-line comment above the `ItemGroup`
explaining why they were removed so a future reader does not re-add them.

## API Changes

None. This is a build-file-only change with no source-code or public-API impact.

## Files Modified

- `src/Ivy.Tendril/Ivy.Tendril.csproj` — removed 5 dead `ProjectReference` lines, added 1 explanatory comment

## Manual Testing

N/A — internal build-configuration change with no user-facing behavior.

**Note for reviewer:** the fixed MSB9008 warning can only be reproduced from the original checkout
(`/Users/rorychatt/git/ivy-tendril`) with an `Ivy-Framework` sibling checkout present, since
`IvySource` auto-detection misses inside an isolated plan worktree. Verified in this execution:
```bash
dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj --configuration Release --warnaserror 2>&1 | grep -c MSB9008
```
returns `0` after the change (previously `1`, confirmed against the pre-change checkout).

---
## Commits
- 11256235 Remove dead Ivy-Framework ProjectReferences from Ivy.Tendril.csproj

---
Created using [Ivy Tendril](https://ivy.app).
