### PR TITLE
[00188] Fix Pre-Existing Dotnet Format Whitespace Violations

### DIFF
--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -209,7 +209,7 @@ public class JobsAppRefreshGatingTests
         public List<JobItem> GetJobsForPlan(string planFile) => throw new NotSupportedException();
         public JobItem? GetJob(string id) => Jobs.FirstOrDefault(j => j.Id == id);
         public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => throw new NotSupportedException();
-        public void SetChatSessionId(string id, string chatSessionId) {}
+        public void SetChatSessionId(string id, string chatSessionId) { }
         public bool ReportJobFailure(string id, string message) => throw new NotSupportedException();
         public bool IsInboxFileTracked(string filePath) => false;
         public void Dispose()

--- a/src/Ivy.Tendril.Widgets/WebViewerProxy.cs
+++ b/src/Ivy.Tendril.Widgets/WebViewerProxy.cs
@@ -329,7 +329,11 @@ public static class WebViewerProxy
                 .Select(f => new { file = f.File, line = f.Line, col = f.Col, name = f.Name }),
             frames = resolved.Select(f => new
             {
-                file = f.File, line = f.Line, col = f.Col, name = f.Name, isThirdParty = f.IsThirdParty,
+                file = f.File,
+                line = f.Line,
+                col = f.Col,
+                name = f.Name,
+                isThirdParty = f.IsThirdParty,
             }),
         });
     }

--- a/src/Ivy.Tendril/Apps/Inbox/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/SidebarView.cs
@@ -46,7 +46,7 @@ public class SidebarView(
         {
             if (projects.Count == 0)
             {
-                rows.Add(SidebarListRow.BuildSubItem("No projects in settings", Icons.FolderClosed, () => {}, false));
+                rows.Add(SidebarListRow.BuildSubItem("No projects in settings", Icons.FolderClosed, () => { }, false));
             }
             else
             {

--- a/src/Ivy.Tendril/Apps/PullRequest/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequest/PullRequestApp.cs
@@ -108,13 +108,13 @@ public class PullRequestApp : ViewBase
             .Width(Size.Full())
             .Height(Size.Full())
             .Order(
-                e => e.Plan, 
-                e => e.Project, 
-                e => e.Status, 
-                e => e.Pr, 
-                e => e.Tokens, 
+                e => e.Plan,
+                e => e.Project,
+                e => e.Status,
+                e => e.Pr,
+                e => e.Tokens,
                 e => e.Cost,
-                e => e.Repository, 
+                e => e.Repository,
                 e => e.Branch)
             .Header(t => t.Project, "Project")
             .Header(t => t.Repository, "Repository")


### PR DESCRIPTION
# Summary

## Changes

Ran `dotnet format` across all three projects with pre-existing whitespace violations —
`Ivy.Tendril`, `Ivy.Tendril.Widgets`, and `Ivy.Tendril.Test` — clearing all 4 files' worth of
`WHITESPACE` errors so that an unscoped `dotnet format --verify-no-changes` now passes clean on the
whole repo. All changes are whitespace/line-break only; no behavior changed.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Inbox/SidebarView.cs` — `() => {}` → `() => { }`
- `src/Ivy.Tendril/Apps/PullRequest/PullRequestApp.cs` — trailing whitespace stripped from `.Order(...)` argument list
- `src/Ivy.Tendril.Widgets/WebViewerProxy.cs` — anonymous-object initializer members split onto separate lines
- `src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs` — `{}` → `{ }` on the `SetChatSessionId` test stub

## Manual Testing

N/A — internal change with no user-facing behavior. `dotnet format --verify-no-changes` passing
clean on all three projects is itself the regression check.

---
## Commits

- d5732ce0 Fix dotnet format whitespace violations in Ivy.Tendril
- 62dcdfa4 Fix dotnet format whitespace violation in Ivy.Tendril.Widgets
- 2fe6d9eb Fix dotnet format whitespace violation in Ivy.Tendril.Test

---
Created using [Ivy Tendril](https://ivy.app).
