### PR TITLE
feat(shell): move the Inbox app into the sidebar footer in beta mode

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/TendrilAppShellNavTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/TendrilAppShellNavTests.cs
@@ -1,0 +1,30 @@
+using Ivy.Tendril.AppShell;
+
+namespace Ivy.Tendril.Test.AppShell;
+
+public class TendrilAppShellNavTests
+{
+    private static readonly MenuItem[] Menu =
+    [
+        MenuItem.Default("Plans", "plans"),
+        MenuItem.Default("Inbox", "inbox"),
+        MenuItem.Default("Agent", "agent")
+    ];
+
+    [Fact]
+    public void BuildNavItems_ExcludesAgent_KeepsInboxByDefault()
+    {
+        var items = TendrilAppShell.BuildNavItems(Menu, activeAppId: "inbox");
+
+        Assert.Equal(["plans", "inbox"], items.Select(i => i.Id));
+        Assert.True(items.Single(i => i.Id == "inbox").IsActive);
+    }
+
+    [Fact]
+    public void BuildNavItems_ExcludesFooterApps_CaseInsensitively()
+    {
+        var items = TendrilAppShell.BuildNavItems(Menu, activeAppId: null, footerAppIds: ["INBOX"]);
+
+        Assert.Equal(["plans"], items.Select(i => i.Id));
+    }
+}

--- a/src/Ivy.Tendril.Widgets/ShellSettingsButton.cs
+++ b/src/Ivy.Tendril.Widgets/ShellSettingsButton.cs
@@ -10,6 +10,14 @@ public record ShellSettingsButton : WidgetBase<ShellSettingsButton>
 {
     [Prop] public string Label { get; init; } = "Settings";
 
+    /// <summary>Lucide icon name; the frontend bundles only the icons the sidebar footer hosts.</summary>
+    [Prop] public string Icon { get; init; } = "Settings";
+
+    /// <summary>When false the button is icon-only and shows its label as a tooltip.</summary>
+    [Prop] public bool ShowLabel { get; init; } = true;
+
+    [Prop] public bool IsActive { get; init; }
+
     [Event] public EventHandler<Event<ShellSettingsButton>>? OnClick { get; init; }
 }
 
@@ -17,6 +25,15 @@ public static class ShellSettingsButtonExtensions
 {
     public static ShellSettingsButton Label(this ShellSettingsButton w, string label) =>
         w with { Label = label };
+
+    public static ShellSettingsButton Icon(this ShellSettingsButton w, string icon) =>
+        w with { Icon = icon };
+
+    public static ShellSettingsButton ShowLabel(this ShellSettingsButton w, bool showLabel) =>
+        w with { ShowLabel = showLabel };
+
+    public static ShellSettingsButton IsActive(this ShellSettingsButton w, bool isActive) =>
+        w with { IsActive = isActive };
 
     public static ShellSettingsButton OnClick(this ShellSettingsButton w, Action handler) =>
         w with { OnClick = new(_ => { handler(); return ValueTask.CompletedTask; }) };

--- a/src/Ivy.Tendril.Widgets/TendrilShell.cs
+++ b/src/Ivy.Tendril.Widgets/TendrilShell.cs
@@ -18,7 +18,7 @@ public record TendrilShell : WidgetBase<TendrilShell>
     public TendrilShell(
         object? sidebarHeader = null,
         object?[]? sidebarBody = null,
-        object? sidebarFooter = null,
+        object?[]? sidebarFooter = null,
         object? content = null,
         object?[]? sessionContents = null,
         object? tabs = null,
@@ -28,12 +28,12 @@ public record TendrilShell : WidgetBase<TendrilShell>
     }
 
     private static object[] BuildSlots(
-        object? sidebarHeader, object?[]? sidebarBody, object? sidebarFooter,
+        object? sidebarHeader, object?[]? sidebarBody, object?[]? sidebarFooter,
         object? content, object?[]? sessionContents, object? tabs, object?[]? hidden) =>
     [
         sidebarHeader != null ? new Slot("SidebarHeader", sidebarHeader) : new Slot("SidebarHeader"),
         new Slot("SidebarBody", (sidebarBody ?? []).Where(c => c != null).Cast<object>().ToArray()),
-        sidebarFooter != null ? new Slot("SidebarFooter", sidebarFooter) : new Slot("SidebarFooter"),
+        new Slot("SidebarFooter", (sidebarFooter ?? []).Where(c => c != null).Cast<object>().ToArray()),
         content != null ? new Slot("Content", content) : new Slot("Content"),
         new Slot("SessionContents", (sessionContents ?? []).Where(c => c != null).Cast<object>().ToArray()),
         tabs != null ? new Slot("Tabs", tabs) : new Slot("Tabs"),

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSettingsButton.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSettingsButton.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ShellSettingsButton } from "./ShellSettingsButton";
+
+describe("ShellSettingsButton", () => {
+  it("renders the label and fires OnClick", () => {
+    const handler = vi.fn();
+    render(<ShellSettingsButton id="settings" events={["OnClick"]} eventHandler={handler} />);
+
+    const button = screen.getByRole("button", { name: "Settings" });
+    expect(button).toHaveTextContent("Settings");
+    expect(button).toHaveAttribute("data-icon-only", "false");
+    expect(button.querySelector("svg.lucide-settings")).not.toBeNull();
+
+    fireEvent.click(button);
+    expect(handler).toHaveBeenCalledWith("OnClick", "settings", []);
+  });
+
+  it("is icon-only with the label as accessible name when showLabel is false", () => {
+    render(
+      <ShellSettingsButton
+        id="inbox"
+        events={[]}
+        eventHandler={vi.fn()}
+        label="Inbox"
+        icon="Inbox"
+        showLabel={false}
+        isActive
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Inbox" });
+    expect(button).not.toHaveTextContent("Inbox");
+    expect(button).toHaveAttribute("data-icon-only", "true");
+    expect(button).toHaveAttribute("data-active", "true");
+    expect(button.querySelector("svg.lucide-inbox")).not.toBeNull();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSettingsButton.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSettingsButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Settings } from "lucide-react";
+import { Inbox, LucideIcon, Settings } from "lucide-react";
 import { useShell } from "./ShellContext";
 import { ShellWidgetProps } from "./types";
 import { ShellTooltip } from "./ShellTooltip";
@@ -7,29 +7,46 @@ import "./shell.css";
 
 interface ShellSettingsButtonProps extends ShellWidgetProps {
   label?: string;
+  icon?: string;
+  showLabel?: boolean;
+  isActive?: boolean;
 }
 
-/** Sidebar footer row. Fires OnClick when used standalone; when hosted as a
-    DropDownMenu trigger the framework intercepts the click to open the menu. */
+/* Only the icons the sidebar footer hosts are bundled; unknown names fall back
+   to the settings cog. */
+const footerIcons: Record<string, LucideIcon> = {
+  Settings,
+  Inbox,
+};
+
+/** Sidebar footer button. Fires OnClick when used standalone; when hosted as a
+    DropDownMenu trigger the framework intercepts the click to open the menu.
+    With the label hidden it is icon-only and names itself in a tooltip. */
 export const ShellSettingsButton: React.FC<ShellSettingsButtonProps> = ({
   id,
   events = [],
   eventHandler,
   label = "Settings",
+  icon = "Settings",
+  showLabel = true,
+  isActive = false,
 }) => {
   const { collapsed } = useShell();
+  const Icon = footerIcons[icon] ?? Settings;
 
   return (
-    <ShellTooltip content={label} enabled={collapsed} side="right">
+    <ShellTooltip content={label} enabled={collapsed || !showLabel} side={collapsed ? "right" : "top"}>
       <button
         className="tsh-settings"
+        data-icon-only={!showLabel}
+        data-active={isActive}
         aria-label={label}
         onClick={() => {
           if (events.includes("OnClick")) eventHandler("OnClick", id, []);
         }}
       >
-        <Settings size={16} />
-        <span className="tsh-settings-label">{label}</span>
+        <Icon size={16} />
+        {showLabel && <span className="tsh-settings-label">{label}</span>}
       </button>
     </ShellTooltip>
   );

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -1192,6 +1192,15 @@
   color: var(--tsh-row-active-fg);
 }
 
+/* Icon-only: square, so the hover/active background is a rounded square rather
+   than a tall rectangle around the icon. */
+.tsh-settings[data-icon-only="true"] {
+  justify-content: center;
+  width: 38px;
+  padding: 6px 0;
+  flex-shrink: 0;
+}
+
 .tsh-settings-label {
   font-size: 14px;
   font-weight: 400;
@@ -1206,6 +1215,10 @@
 .tsh-root[data-collapsed="true"] .tsh-settings {
   justify-content: center;
   padding: 6px 0;
+  width: 100%;
+}
+
+.tsh-root[data-collapsed="true"] .tsh-settings[data-icon-only="true"] {
   width: 100%;
 }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -147,13 +147,25 @@
 
 /* Hugs the 38px settings row (see .tsh-settings) rather than a fixed height, so
    the settings icon lines up with the session-tab icons across the content edge.
-   The top margin keeps the plan list from crowding it. */
+   The top margin keeps the plan list from crowding it. Several footer buttons
+   spread across the row; a lone one takes the full width. */
 .tsh-sidebar-footer {
   flex-shrink: 0;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
   margin-top: 8px;
+}
+
+.tsh-sidebar-footer > :only-child {
+  flex: 1;
+  min-width: 0;
+}
+
+.tsh-root[data-collapsed="true"] .tsh-sidebar-footer {
+  flex-direction: column;
+  align-items: stretch;
 }
 
 /* ---------- Content area ---------- */
@@ -1169,6 +1181,12 @@
 }
 
 .tsh-settings:hover {
+  opacity: 1;
+  background: var(--tsh-row-active);
+  color: var(--tsh-row-active-fg);
+}
+
+.tsh-settings[data-active="true"] {
   opacity: 1;
   background: var(--tsh-row-active);
   color: var(--tsh-row-active-fg);

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -119,6 +119,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
     // The Agent app id (and its menu-item Tag) collapses to "agent" via AppHelpers.GetApp.
     private const string AgentAppId = "agent";
+    private const string InboxAppId = "inbox";
 
     private static readonly HashSet<string> SidebarSectionAppIds = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -200,15 +201,18 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
     /// <summary>
     ///     Flattens the app menu into the sidebar nav rows. The agent entry is excluded — it is
-    ///     rendered as the dedicated agent button above the nav instead.
+    ///     rendered as the dedicated agent button above the nav instead — as are the apps in
+    ///     <paramref name="footerAppIds"/>, which get their own button in the sidebar footer.
     /// </summary>
-    internal static List<ShellNavItemDto> BuildNavItems(MenuItem[] menuItems, string? activeAppId)
+    internal static List<ShellNavItemDto> BuildNavItems(MenuItem[] menuItems, string? activeAppId,
+        IReadOnlyCollection<string>? footerAppIds = null)
     {
         var result = new List<ShellNavItemDto>();
 
         void AddLeaf(MenuItem item)
         {
             if (item.Tag is not string tag || tag == AgentAppId) return;
+            if (footerAppIds?.Contains(tag, StringComparer.OrdinalIgnoreCase) == true) return;
             result.Add(new ShellNavItemDto(
                 tag,
                 item.Label ?? tag,
@@ -742,16 +746,27 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .OnSearch(showPlanSearchDialog);
         }
 
+        // Beta: the inbox moves out of the nav into the footer, beside an icon-only settings button.
+        var inboxInFooter = isBeta && !isShareMode;
+        string[] footerAppIds = inboxInFooter ? [InboxAppId] : [];
+
         var nav = new ShellNav()
-            .Items(BuildNavItems(menuItems.Value, activeNavAppId))
+            .Items(BuildNavItems(menuItems.Value, activeNavAppId, footerAppIds))
             .ShowDivider(true)
             .OnSelect(appId => OpenApp(new NavigateArgs(appId)));
 
         var settingsMenu = new DropDownMenu(
                 DropDownMenu.DefaultSelectHandler(),
-                new ShellSettingsButton())
+                new ShellSettingsButton().ShowLabel(!inboxInFooter))
             .Top()
             .Items(settings.FooterMenuItemsTransformer(settingsMenuItems, navigator));
+
+        var inboxButton = new ShellSettingsButton()
+            .Icon(Icons.Inbox.ToString())
+            .Label("Inbox")
+            .ShowLabel(false)
+            .IsActive(string.Equals(activeNavAppId, InboxAppId, StringComparison.OrdinalIgnoreCase))
+            .OnClick(() => OpenApp(new NavigateArgs(InboxAppId)));
 
         // ----- Content + session tabs -----
 
@@ -801,11 +816,14 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var reviewerPersona = shareContext.Persona;
         var reviewerInitials = GetInitials(reviewerPersona);
 
-        object sidebarFooter = isShareMode
-            ? Layout.Horizontal().AlignContent(Align.Left).Height(Size.Auto()).Width(Size.Full())
+        object?[] sidebarFooter = isShareMode
+            ?
+            [
+                Layout.Horizontal().AlignContent(Align.Left).Height(Size.Auto()).Width(Size.Full())
                 | new Avatar(reviewerInitials).Small()
                 | Text.Block(reviewerPersona).Small().Bold().Overflow(Overflow.Ellipsis)
-            : settingsMenu;
+            ]
+            : inboxInFooter ? [settingsMenu, inboxButton] : [settingsMenu];
 
         // A shared link that points straight at one plan renders that plan alone, with no shell
         // chrome around it.


### PR DESCRIPTION
## Summary
- In beta mode the Inbox app is removed from the sidebar nav and rendered as an icon-only button at the right of the sidebar footer, beside the Settings button, which drops its label.
- `ShellSettingsButton` widget gains `Icon`, `ShowLabel` and `IsActive` props; `TendrilShell`'s `SidebarFooter` slot now accepts several children and lays them out as a space-between row (stacked in the collapsed rail; a lone child keeps full width).
- `BuildNavItems` skips apps hosted in the footer. Non-beta and share mode are unchanged.

## Verification
- `npx vitest run src/Shell`: 42 passed (new `ShellSettingsButton.test.tsx`)
- `dotnet test --filter FullyQualifiedName~TendrilAppShell`: 37 passed (new `TendrilAppShellNavTests`)
- Browser-checked with a scratch TENDRIL_HOME in beta (footer row, active state, tooltip, collapsed rail) and non-beta (unchanged labelled Settings button, Inbox in nav).

Generated with [Claude Code](https://claude.com/claude-code)