### PR TITLE
[00207] Show Failure Reason When Agent Errors or Times Out

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Runtime/AgentFailureMessageTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/AgentFailureMessageTests.cs
@@ -1,0 +1,132 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Runtime;
+
+namespace Ivy.Tendril.Agents.Test.Runtime;
+
+public class AgentFailureMessageTests
+{
+    [Fact]
+    public void Describe_IdleTimeoutFiredWithFiveMinutes_MentionsMinutesAndIdleTimeout()
+    {
+        var message = AgentFailureMessage.Describe(
+            idleTimeoutFired: true,
+            idleTimeout: TimeSpan.FromMinutes(5),
+            abortReason: null,
+            exitCode: -1,
+            state: SessionState.Failed,
+            stderrTail: []);
+
+        Assert.NotNull(message);
+        Assert.Contains("5 minutes", message);
+        Assert.Contains("idle timeout", message);
+    }
+
+    [Fact]
+    public void Describe_IdleTimeoutFiredWithThirtySeconds_MentionsSeconds()
+    {
+        var message = AgentFailureMessage.Describe(
+            idleTimeoutFired: true,
+            idleTimeout: TimeSpan.FromSeconds(30),
+            abortReason: null,
+            exitCode: -1,
+            state: SessionState.Failed,
+            stderrTail: []);
+
+        Assert.NotNull(message);
+        Assert.Contains("30 seconds", message);
+    }
+
+    [Fact]
+    public void Describe_AbortReasonSet_WinsOverNonZeroExitCode()
+    {
+        var message = AgentFailureMessage.Describe(
+            idleTimeoutFired: false,
+            idleTimeout: null,
+            abortReason: "Agent execution timed out: total timeout limit of 15 minutes exceeded.",
+            exitCode: 1,
+            state: SessionState.Failed,
+            stderrTail: ["some stderr"]);
+
+        Assert.Equal("Agent execution timed out: total timeout limit of 15 minutes exceeded.", message);
+    }
+
+    [Fact]
+    public void Describe_SessionStopped_ReportsStoppedNotCrashed()
+    {
+        var message = AgentFailureMessage.Describe(
+            idleTimeoutFired: false,
+            idleTimeout: null,
+            abortReason: null,
+            exitCode: -1,
+            state: SessionState.Stopped,
+            stderrTail: []);
+
+        Assert.NotNull(message);
+        Assert.Contains("stopped", message);
+        Assert.DoesNotContain("crash", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Describe_NonZeroExitWithStderrTail_IncludesLastLineAndExitCode()
+    {
+        var message = AgentFailureMessage.Describe(
+            idleTimeoutFired: false,
+            idleTimeout: null,
+            abortReason: null,
+            exitCode: 1,
+            state: SessionState.Failed,
+            stderrTail: ["first line", "last line"]);
+
+        Assert.NotNull(message);
+        Assert.Contains("1", message);
+        Assert.Contains("last line", message);
+    }
+
+    [Fact]
+    public void Describe_NonZeroExitWithNoStderr_ReportsExitCodeOnly()
+    {
+        var message = AgentFailureMessage.Describe(
+            idleTimeoutFired: false,
+            idleTimeout: null,
+            abortReason: null,
+            exitCode: 1,
+            state: SessionState.Failed,
+            stderrTail: []);
+
+        Assert.NotNull(message);
+        Assert.Contains("1", message);
+        Assert.Contains("without reporting a result", message);
+    }
+
+    [Fact]
+    public void Describe_StderrLineLongerThan500Characters_IsTruncated()
+    {
+        var longLine = new string('x', 600);
+
+        var message = AgentFailureMessage.Describe(
+            idleTimeoutFired: false,
+            idleTimeout: null,
+            abortReason: null,
+            exitCode: 1,
+            state: SessionState.Failed,
+            stderrTail: [longLine]);
+
+        Assert.NotNull(message);
+        Assert.EndsWith("...", message);
+        Assert.True(message.Length < 600 + 50);
+    }
+
+    [Fact]
+    public void Describe_ExitCodeZeroWithNoFailureSignal_ReturnsNull()
+    {
+        var message = AgentFailureMessage.Describe(
+            idleTimeoutFired: false,
+            idleTimeout: null,
+            abortReason: null,
+            exitCode: 0,
+            state: SessionState.Completed,
+            stderrTail: []);
+
+        Assert.Null(message);
+    }
+}

--- a/src/Ivy.Tendril.Agents/Runtime/AgentFailureMessage.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/AgentFailureMessage.cs
@@ -1,0 +1,53 @@
+using Ivy.Tendril.Agents.Abstractions;
+
+namespace Ivy.Tendril.Agents.Runtime;
+
+internal static class AgentFailureMessage
+{
+    private const int MaxStderrLineLength = 500;
+
+    internal static string? Describe(
+        bool idleTimeoutFired,
+        TimeSpan? idleTimeout,
+        string? abortReason,
+        int exitCode,
+        SessionState state,
+        IReadOnlyList<string> stderrTail)
+    {
+        if (idleTimeoutFired && idleTimeout.HasValue)
+            return $"Agent timed out: no output received for {FormatDuration(idleTimeout.Value)} (idle timeout threshold exceeded).";
+
+        if (!string.IsNullOrWhiteSpace(abortReason))
+            return abortReason;
+
+        if (state == SessionState.Stopped)
+            return $"Agent process was stopped before it completed (exit code {exitCode}).";
+
+        if (exitCode != 0)
+        {
+            var lastStderrLine = stderrTail.LastOrDefault(l => !string.IsNullOrWhiteSpace(l));
+            return lastStderrLine is not null
+                ? $"Agent process exited with code {exitCode}: {Truncate(lastStderrLine)}"
+                : $"Agent process exited with code {exitCode} without reporting a result.";
+        }
+
+        return null;
+    }
+
+    private static string Truncate(string line)
+        => line.Length > MaxStderrLineLength
+            ? line[..MaxStderrLineLength] + "..."
+            : line;
+
+    internal static string FormatDuration(TimeSpan duration)
+    {
+        if (duration >= TimeSpan.FromMinutes(1))
+        {
+            var minutes = (int)duration.TotalMinutes;
+            return minutes == 1 ? "1 minute" : $"{minutes} minutes";
+        }
+
+        var seconds = (int)duration.TotalSeconds;
+        return seconds == 1 ? "1 second" : $"{seconds} seconds";
+    }
+}

--- a/src/Ivy.Tendril.Agents/Runtime/AgentRunner.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/AgentRunner.cs
@@ -220,10 +220,13 @@ public sealed class AgentRunner(ILogger<AgentRunner> logger, ConcurrencyOptions?
             }
             catch (OperationCanceledException)
             {
+                if (timeout.HasValue && !ct.IsCancellationRequested)
+                    session.MarkAborted($"Agent execution timed out: total timeout limit of {AgentFailureMessage.FormatDuration(timeout.Value)} exceeded.");
                 await session.KillAsync();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                session.MarkAborted($"Agent process failed: {ex.Message}");
                 await session.KillAsync();
             }
             finally

--- a/src/Ivy.Tendril.Agents/Runtime/AgentSession.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/AgentSession.cs
@@ -23,9 +23,18 @@ public sealed class AgentSession : IAgentSession
     private readonly CancellationTokenSource _cts = new();
     private readonly List<AgentEvent> _allEvents = [];
     private readonly List<string> _tempFiles = [];
+    private readonly Queue<string> _stderrTail = new();
+    private readonly object _stderrLock = new();
     private volatile SessionState _state = SessionState.NotStarted;
     private long _lastActivityTicks;
     private bool _idleTimeoutFired;
+
+    internal string? AbortReason { get; private set; }
+
+    internal void MarkAborted(string reason)
+    {
+        AbortReason ??= reason;
+    }
 
     public string SessionId { get; }
     public string AgentId { get; }
@@ -252,6 +261,16 @@ public sealed class AgentSession : IAgentSession
             {
                 MarkActivity();
                 _rawStderr.OnNext(line);
+
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    lock (_stderrLock)
+                    {
+                        _stderrTail.Enqueue(line);
+                        while (_stderrTail.Count > 20)
+                            _stderrTail.Dequeue();
+                    }
+                }
             }
         }
         catch (OperationCanceledException)
@@ -271,7 +290,16 @@ public sealed class AgentSession : IAgentSession
     {
         CompletedAt = _timeProvider.GetUtcNow();
 
+        var finalState = overrideState ?? (exitCode == 0 ? SessionState.Completed : SessionState.Failed);
+
         var result = _parser.BuildResult(_allEvents, exitCode);
+
+        var failure = AgentFailureMessage.Describe(
+            _idleTimeoutFired, _idleTimeout, AbortReason, exitCode, finalState, StderrTailSnapshot());
+
+        if (result is not null && failure is not null && string.IsNullOrWhiteSpace(result.Error) && !result.IsSuccess)
+            result = result with { Error = failure };
+
         Result = result;
 
         if (result is not null)
@@ -280,7 +308,7 @@ public sealed class AgentSession : IAgentSession
             _events.OnNext(result);
         }
 
-        _state = overrideState ?? (exitCode == 0 ? SessionState.Completed : SessionState.Failed);
+        _state = finalState;
 
         var durationMs = (long)(CompletedAt.Value - StartedAt).TotalMilliseconds;
         AgentLogMessages.SessionCompleted(_logger, SessionId, _state, durationMs);
@@ -301,7 +329,16 @@ public sealed class AgentSession : IAgentSession
                 Kind = AgentEventKind.Result,
                 IsSuccess = false,
                 ExitCode = exitCode,
+                Error = failure,
             });
+    }
+
+    private List<string> StderrTailSnapshot()
+    {
+        lock (_stderrLock)
+        {
+            return [.. _stderrTail];
+        }
     }
 
     private void CleanupTempFiles()

--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -533,6 +533,8 @@ public class ChatExecutionServiceJobTrackingTests
 
         public void Emit(AgentEvent evt) => _events.OnNext(evt);
 
+        public void Complete(ResultEvent result) => _completion.TrySetResult(result);
+
         public async Task<ResultEvent> WaitForCompletionAsync(CancellationToken ct = default)
         {
             using var reg = ct.Register(() => _completion.TrySetCanceled(ct));
@@ -699,6 +701,76 @@ public class ChatExecutionServiceJobTrackingTests
             Assert.Contains("I found the main entry point.", assistantMsg.RawStream);
             // Appended cancellation message
             Assert.Contains("Execution was cancelled.", assistantMsg.RawStream);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_WhenResultHasErrorAndNoResponse_PersistsErrorInAssistantMessage()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilResultErrorTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var cancellableSession = new CancellableTestSession();
+            var agentRunner = new CancellableAgentRunner(TestAgentRunner.Create(), cancellableSession);
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            var sendTask = execService.SendMessageAsync(session.Id, "Run the deploy script");
+
+            var deadline = DateTime.UtcNow.AddSeconds(2);
+            while ((!execService.IsGenerating(session.Id) || !cancellableSession.HasObservers) && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(20);
+            }
+            Assert.True(execService.IsGenerating(session.Id));
+
+            cancellableSession.Complete(new ResultEvent
+            {
+                Kind = AgentEventKind.Result,
+                IsSuccess = false,
+                ExitCode = -1,
+                Error = "Agent timed out: no output received for 5 minutes (idle timeout threshold exceeded).",
+            });
+
+            deadline = DateTime.UtcNow.AddSeconds(2);
+            while (execService.IsGenerating(session.Id) && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(20);
+            }
+            Assert.False(execService.IsGenerating(session.Id));
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            var assistantMsg = updatedSession.Messages.FirstOrDefault(m => m.Role == "assistant");
+            Assert.NotNull(assistantMsg);
+            Assert.Equal(
+                "Agent timed out: no output received for 5 minutes (idle timeout threshold exceeded).",
+                assistantMsg.Content);
         }
         finally
         {

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/AgentViewer/SampleData.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/AgentViewer/SampleData.cs
@@ -58,4 +58,10 @@ static class SampleData
         """{"kind":"text","timestamp":"2026-05-22T10:00:13Z","text":"Build passes but 2 tests are failing. The project has 8 verifications configured covering .NET build, tests, formatting, frontend lint, visual verification, and a new-widget checklist.","delta":false}""",
         """{"kind":"result","timestamp":"2026-05-22T10:00:13Z","response":"Listed project verifications and ran checks. Build succeeds but 2 tests are failing.","is_success":true,"duration_ms":13000,"turn_count":4,"usage":{"input_tokens":8200,"output_tokens":1800,"cache_read_tokens":5000,"cache_write_tokens":800,"reasoning_tokens":0,"cost_usd":0.0520}}"""
     );
+
+    public static string TimedOutSession => string.Join("\n",
+        """{"kind":"session_init","timestamp":"2026-05-22T10:00:00Z","session_id":"sess_04","model":"claude-opus-4-6-20250514","tools":["Read","Write","Edit","Bash"]}""",
+        """{"kind":"tool_call","timestamp":"2026-05-22T10:00:02Z","tool_use_id":"tu_30","tool_name":"Bash","input":{"command":"npm run build"}}""",
+        """{"kind":"result","is_success":false,"exit_code":-1,"error":"Agent timed out: no output received for 5 minutes (idle timeout threshold exceeded)."}"""
+    );
 }

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/AgentViewer/TimeoutApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/AgentViewer/TimeoutApp.cs
@@ -1,0 +1,17 @@
+using Ivy;
+using Ivy.Tendril.Widgets;
+
+namespace WidgetSamples.Apps.AgentViewer;
+
+[App(title: "Timeout Case", icon: Icons.Clock, group: ["AgentViewer"])]
+class TimeoutApp : ViewBase
+{
+    public override object Build()
+    {
+        return new Ivy.Tendril.Widgets.AgentViewer()
+            .JsonStream(SampleData.TimedOutSession)
+            .AutoScroll(false)
+            .ShowStatusLabel(false)
+            .Height(Size.Full());
+    }
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -522,6 +522,12 @@
   margin: 6px 0;
 }
 
+.aov-result-error {
+  white-space: pre-wrap;
+  font-family: var(--aov-mono);
+  color: var(--aov-danger);
+}
+
 .aov-result-stats {
   display: flex;
   flex-wrap: wrap;

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ResultSummary } from "./result-summary";
+import type { ResultWire } from "./types";
+
+describe("ResultSummary", () => {
+  it("renders the error text when is_success is false and error is set", () => {
+    const wire: ResultWire = {
+      kind: "result",
+      timestamp: "2026-05-22T10:00:00Z",
+      is_success: false,
+      exit_code: -1,
+      error: "Agent timed out: no output received for 5 minutes (idle timeout threshold exceeded).",
+    };
+
+    render(<ResultSummary wire={wire} />);
+
+    expect(
+      screen.getByText("Agent timed out: no output received for 5 minutes (idle timeout threshold exceeded).")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the terminated/timed-out fallback when neither error nor response is present", () => {
+    const wire: ResultWire = {
+      kind: "result",
+      timestamp: "2026-05-22T10:00:00Z",
+      is_success: false,
+      exit_code: -1,
+    };
+
+    render(<ResultSummary wire={wire} />);
+
+    expect(screen.getByText("Agent process was terminated or timed out (exit code -1).")).toBeInTheDocument();
+  });
+
+  it("renders both the error and the response when both are present", () => {
+    const wire: ResultWire = {
+      kind: "result",
+      timestamp: "2026-05-22T10:00:00Z",
+      is_success: false,
+      exit_code: 1,
+      error: "Agent process exited with code 1: boom",
+      response: "Partial progress before the crash.",
+    };
+
+    render(<ResultSummary wire={wire} />);
+
+    expect(screen.getByText("Agent process exited with code 1: boom")).toBeInTheDocument();
+    expect(screen.getByText("Partial progress before the crash.")).toBeInTheDocument();
+  });
+
+  it("renders no error block when is_success is true and a response is present", () => {
+    const wire: ResultWire = {
+      kind: "result",
+      timestamp: "2026-05-22T10:00:00Z",
+      is_success: true,
+      response: "Task completed successfully.",
+    };
+
+    render(<ResultSummary wire={wire} />);
+
+    expect(screen.getByText("Task completed successfully.")).toBeInTheDocument();
+    expect(screen.queryByText(/terminated or timed out/)).not.toBeInTheDocument();
+    expect(screen.queryByText("❌ Error")).not.toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
@@ -38,6 +38,8 @@ export const ResultSummary: React.FC<ResultSummaryProps> = ({ wire }) => {
   }
 
   const hasResponse = Boolean(wire.response && wire.response.trim().length > 0);
+  const errorText = wire.error?.trim();
+  const hasError = Boolean(errorText);
 
   const plugins = getMarkdownPlugins(wire.response ?? "");
 
@@ -51,6 +53,11 @@ export const ResultSummary: React.FC<ResultSummaryProps> = ({ wire }) => {
       {isError && (
         <div className="aov-result-header">
           <span className="aov-result-title">❌ Error</span>
+        </div>
+      )}
+      {isError && (hasError || !hasResponse) && (
+        <div className="aov-result-body aov-result-error">
+          {hasError ? errorText : `Agent process was terminated or timed out (exit code ${wire.exit_code ?? "unknown"}).`}
         </div>
       )}
       {hasResponse && (

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -556,13 +556,15 @@ public sealed class ChatExecutionService : IChatExecutionService
                         fullRawStream = string.Join("\n", activeExec.RawLines);
                 }
 
+                var failureText = !string.IsNullOrWhiteSpace(result.Error)
+                    ? result.Error!
+                    : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown");
+
                 var responseContent = !string.IsNullOrWhiteSpace(result.Response)
                     ? result.Response
-                    : (!string.IsNullOrWhiteSpace(collectedText)
-                        ? collectedText
-                        : (result.IsSuccess
-                            ? "Task completed successfully."
-                            : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
+                    : !string.IsNullOrWhiteSpace(collectedText)
+                        ? (result.IsSuccess ? collectedText : $"{collectedText}\n\n{failureText}")
+                        : (result.IsSuccess ? "Task completed successfully." : failureText);
 
                 _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true);
 
@@ -598,6 +600,9 @@ public sealed class ChatExecutionService : IChatExecutionService
             {
                 string? fullRawStream = null;
                 string? collectedText = null;
+                var abortText = activeExec.IsInterrupted
+                    ? "Execution was cancelled."
+                    : $"Agent execution timed out: total timeout limit of {(int)totalTimeout.TotalMinutes} minutes exceeded.";
                 lock (activeExec.Lock)
                 {
                     collectedText = lastTextEvent ?? activeExec.LastText;
@@ -625,7 +630,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                     {
                         Kind = AgentEventKind.Text,
                         Timestamp = DateTimeOffset.UtcNow,
-                        Text = "Execution was cancelled.",
+                        Text = abortText,
                         IsDelta = false
                     };
                     var cancelJson = _serializer.Serialize(cancelEvt);
@@ -642,8 +647,8 @@ public sealed class ChatExecutionService : IChatExecutionService
                 }
 
                 var responseContent = !string.IsNullOrWhiteSpace(collectedText)
-                    ? $"{collectedText}\n\nExecution was cancelled."
-                    : "Execution was cancelled.";
+                    ? $"{collectedText}\n\n{abortText}"
+                    : abortText;
 
                 _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true);
             }


### PR DESCRIPTION
Fixes #2419

# Summary

## Changes

Agent execution failures (idle timeout, total timeout, and non-zero exit) now produce a
human-readable reason instead of a bare error badge. `AgentSession` synthesizes an `Error` message
from the idle-timeout duration, an abort reason from the total timeout, or the last stderr line;
`ChatExecutionService` surfaces that text in the chat message; and the AgentViewer widget renders
`wire.error` (or a generic fallback) in the result summary.

## API Changes

- New: `internal static class AgentFailureMessage` in `Ivy.Tendril.Agents.Runtime` with
  `Describe(bool, TimeSpan?, string?, int, SessionState, IReadOnlyList<string>)` and
  `FormatDuration(TimeSpan)`.
- New: `internal string? AgentSession.AbortReason { get; }` and
  `internal void AgentSession.MarkAborted(string reason)`.
- Changed: `AgentSession.Complete` now populates `ResultEvent.Error` on failure when no provider
  already set one.
- Changed: `ChatExecutionService`'s assistant-message fallback text now prefers `result.Error` over
  the generic "status code" message, and the total-timeout cancellation path reports "timed out"
  instead of "cancelled" when the user did not initiate the interruption.
- Changed: `ResultSummary` (React) renders an error/fallback body block when `wire.is_success` is
  `false`.

## Files Modified

- `src/Ivy.Tendril.Agents/Runtime/AgentFailureMessage.cs` (new) — message synthesis
- `src/Ivy.Tendril.Agents/Runtime/AgentSession.cs` — stderr tail, abort reason, `Complete` wiring
- `src/Ivy.Tendril.Agents/Runtime/AgentRunner.cs` — marks abort reason on total timeout / launch failure
- `src/Ivy.Tendril/Services/ChatExecutionService.cs` — forwards `result.Error`, distinguishes timeout vs cancel
- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx` / `agent-output.css` — renders the error text
- `src/Ivy.Tendril.Widgets/.samples/Apps/AgentViewer/SampleData.cs` / `TimeoutApp.cs` (new) — manual verification sample
- Tests: `AgentFailureMessageTests.cs` (new), `ChatExecutionServiceJobTrackingTests.cs`, `result-summary.test.tsx` (new)

## Manual Testing

1. Run the Tendril app (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`).
2. Open the Widgets samples app and navigate to **AgentViewer → Timeout Case**.
3. Observe the result panel shows "❌ Error" followed by the text "Agent timed out: no output
   received for 5 minutes (idle timeout threshold exceeded)." instead of a bare error badge.
4. For a live end-to-end check: start a chat session, let an agent idle past its configured idle
   timeout (or trigger a non-zero exit), and confirm the chat message body contains the specific
   failure reason rather than "Agent execution completed with status code -1".

---
Commits:
- a7220b93 Synthesize agent failure reason on idle timeout, total timeout, and non-zero exit
- 9088584d Forward result.Error and distinguish timeout from user cancellation in chat
- 9990f9a4 Render wire.error in the AgentViewer result summary
- 41de1a7c Add timeout sample for AgentViewer manual verification

---
Created using [Ivy Tendril](https://ivy.app).
