### PR TITLE
[00213] Configure Default Artifact Production for New Projects

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
+++ b/src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
@@ -92,6 +92,7 @@ Tendril ships with these built-in verification definitions. Wire them into proje
 | `Format` | Run the code formatter on changed files |
 | `Test` | Run tests scoped by the plan's test section |
 | `Lint` | Run the linter and fix any errors |
+| `Screenshots` | Capture UI screenshots into the plan's Artifacts folder |
 | `CheckResult` | Verify the implementation matches the plan |
 
 Stack-specific verifications (e.g. `DotnetBuild`, `NpmTest`) can be added as custom entries in `config.yaml`.

--- a/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
+++ b/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
@@ -609,6 +609,80 @@ public class SetupProjectPromptwareTests : IDisposable
         Assert.Contains("--browse", action.Command);
     }
 
+    // ==================== Artifact Production Tests ====================
+
+    [Fact]
+    public void BothProjectSetupPromptwares_DocumentScreenshotsVerification()
+    {
+        var promptwaresRoot = Path.GetFullPath(
+            Path.Combine(System.AppContext.BaseDirectory, "..", "..", "..", "..", "Ivy.Tendril", "Promptwares"));
+
+        foreach (var name in new[] { "AddProject", "SetupProject" })
+        {
+            var programFile = Path.Combine(promptwaresRoot, name, "Program.md");
+            Assert.True(File.Exists(programFile), $"Expected to find {programFile}");
+            var content = File.ReadAllText(programFile);
+
+            Assert.Contains("Screenshots", content);
+            Assert.Contains("Artifacts/screenshots", content);
+            Assert.Contains("add-verification", content);
+        }
+    }
+
+    [Fact]
+    public void ExampleConfig_ShipsScreenshotsVerificationDefinition()
+    {
+        var configFile = Path.Combine(System.AppContext.BaseDirectory, "example.config.yaml");
+        Assert.True(File.Exists(configFile), $"Expected to find {configFile}");
+        var content = File.ReadAllText(configFile);
+
+        Assert.Contains("- name: Screenshots", content);
+        Assert.Contains("Artifacts/screenshots", content);
+    }
+
+    [Fact]
+    public void ScreenshotsVerification_IsOrderedBeforeCheckResult()
+    {
+        var repoPath = CreateRepo("MyDotnetApp", "src/MyDotnetApp/MyDotnetApp.csproj", "src/MyDotnetApp/Program.cs");
+        WriteConfig($"""
+            projects:
+            - name: MyDotnetApp
+              repos:
+              - path: {repoPath}
+            verifications:
+            - name: CheckResult
+              prompt: Verify the implementation matches the plan.
+            codingAgent: claude
+            codingAgents:
+            - name: claude
+              profiles:
+              - name: deep
+                model: opus
+                effort: max
+            """);
+
+        var config = LoadConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "DotnetTest", Prompt = "Run `dotnet test` with filter from plan's Tests section." });
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "Screenshots", Prompt = "Capture UI screenshots into the plan's Artifacts folder." });
+        config.SaveSettings();
+
+        var config2 = LoadConfig();
+        var project = config2.Settings.Projects[0];
+        project.Verifications.Add(new ProjectVerificationRef { Name = "DotnetTest", Required = true });
+        project.Verifications.Add(new ProjectVerificationRef { Name = "Screenshots", Required = true });
+        project.Verifications.Add(new ProjectVerificationRef { Name = "CheckResult", Required = true });
+        config2.SaveSettings();
+
+        var result = LoadConfig();
+        var proj = result.Settings.Projects[0];
+        var testIndex = proj.Verifications.FindIndex(v => v.Name == "DotnetTest");
+        var screenshotsIndex = proj.Verifications.FindIndex(v => v.Name == "Screenshots");
+        var checkResultIndex = proj.Verifications.FindIndex(v => v.Name == "CheckResult");
+
+        Assert.True(screenshotsIndex > testIndex);
+        Assert.True(screenshotsIndex < checkResultIndex);
+    }
+
     private static readonly object ConsoleLock = new();
 
     private static string CaptureConsoleOutput(Action action)

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -226,7 +226,7 @@ public class ProjectAgentStepView(
                     Values = new Dictionary<string, string>
                     {
                         ["ProjectName"] = name,
-                        ["Instructions"] = "Setup verifications and review actions"
+                        ["Instructions"] = "Setup verifications, review actions, and artifact production"
                     }
                 }, notifyingStream);
 

--- a/src/Ivy.Tendril/Promptwares/AddProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/AddProject/Program.md
@@ -115,7 +115,8 @@ Verifications run top-to-bottom during plan execution. The correct order is:
 1. **Linting/Formatting** — e.g. `DotnetFormat`, `NpmLint`, `RustClippy`, `GoFmt`, `FrameworkFrontendLint`, `VitePlusCheck`
 2. **Build** — e.g. `DotnetBuild`, `FrameworkDotnetBuild`, `NpmBuild`, `RustBuild`, `GoBuild`
 3. **Tests** — e.g. `DotnetTest`, `NpmTest`, `RustTest`, `GoTest`
-4. **CheckResult** — always last
+4. **Screenshots** — only when the project got a UI-launching review action (see Step 3.5)
+5. **CheckResult** — always last
 
 After adding all verifications, verify ordering with `tendril project get <project-name>` and fix with:
 ```bash
@@ -167,6 +168,31 @@ tendril project add-review-action <project-name> "<name>" \
   --command="<launch command>" \
   --condition="Test-Path \"Worktrees/<owner>/<repo>/<path>\""
 ```
+
+### 3.5. Setup Artifact Production
+
+Add this only when Step 3 created a review action that starts a UI. A library or CLI-only project with no launchable UI gets no `Screenshots` verification, keeping Step 2's "Keep it minimal" rule intact.
+
+1. Check `tendril verification list` for a `Screenshots` definition. If missing, create it with the long-prompt form (`--prompt=` is documented for inline text only):
+   ```bash
+   tendril verification add Screenshots --stdin <<'EOF'
+   Capture UI screenshots into the plan's Artifacts folder so the Review tab has visual evidence of the change.
+   1. Run `tendril project get "<project>"` and pick the first review action whose condition holds. Review action commands are relative to <TendrilPlanFolder>, so run them from the plan folder, not from the worktree.
+   2. If the project has no review action that starts a UI, write <TendrilPlanFolder>/Verification/Screenshots.md with `result: Skipped` plus the reason, and stop.
+   3. Start the app in the background with that command. Take the listening URL from its stdout, or fall back to `tendril plan env get <plan-id>` for the plan's allocated ports. Allow at most 120 seconds for the port to accept connections.
+   4. Capture one PNG per page into <TendrilPlanFolder>/Artifacts/screenshots/, named <NN>-<page>.png: the entry route, plus each route the plan's changes touch. Use the repo's own browser tooling if it has any, otherwise `npx --yes playwright screenshot --full-page --wait-for-timeout=2000 <url> <file>`.
+   5. Stop the app process you started.
+   6. Write <TendrilPlanFolder>/Verification/Screenshots.md with `result: Pass` and the list of captured files. If the tooling is unavailable (no Node, no browser download, offline), record `result: Skipped` with the reason instead. Never report Fail for missing tooling, and never spend more than 5 minutes in this verification.
+   EOF
+   ```
+2. Add it to the project, placed right before `CheckResult`:
+   ```bash
+   tendril project add-verification <project-name> Screenshots --required --after=<last test verification>
+   ```
+   When the project has no test verification, use `--after=<last build verification>` instead. Confirm ordering with `tendril project get <project-name>` and repair with:
+   ```bash
+   tendril project move-verification <project-name> CheckResult --after=Screenshots
+   ```
 
 ### 4. Set the Stack Hash
 
@@ -241,6 +267,7 @@ Include the following sections in `stack.md`:
 Print a summary of what was configured:
 - Verifications added
 - Review actions added
+- Screenshots verification added (or why it was skipped)
 - Stack hash configured
 - Project memory created (`stack.md`)
 

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -114,7 +114,8 @@ Verifications run top-to-bottom during plan execution. The correct order is:
 1. **Linting/Formatting** — e.g. `DotnetFormat`, `NpmLint`, `RustClippy`, `GoFmt`, `FrameworkFrontendLint`, `VitePlusCheck`
 2. **Build** — e.g. `DotnetBuild`, `FrameworkDotnetBuild`, `NpmBuild`, `RustBuild`, `GoBuild`
 3. **Tests** — e.g. `DotnetTest`, `NpmTest`, `RustTest`, `GoTest`
-4. **CheckResult** — always last
+4. **Screenshots** — only when the project got a UI-launching review action (see Step 3.5)
+5. **CheckResult** — always last
 
 After adding all verifications, verify ordering with `tendril project get <project-name>` and fix with:
 ```bash
@@ -166,6 +167,31 @@ tendril project add-review-action <project-name> "<name>" \
   --command="<launch command>" \
   --condition="Test-Path \"Worktrees/<owner>/<repo>/<path>\""
 ```
+
+### 3.5. Setup Artifact Production
+
+Add this only when Step 3 created a review action that starts a UI. A library or CLI-only project with no launchable UI gets no `Screenshots` verification, keeping Step 2's "Keep it minimal" rule intact.
+
+1. Check `tendril verification list` for a `Screenshots` definition. If missing, create it with the long-prompt form (`--prompt=` is documented for inline text only):
+   ```bash
+   tendril verification add Screenshots --stdin <<'EOF'
+   Capture UI screenshots into the plan's Artifacts folder so the Review tab has visual evidence of the change.
+   1. Run `tendril project get "<project>"` and pick the first review action whose condition holds. Review action commands are relative to <TendrilPlanFolder>, so run them from the plan folder, not from the worktree.
+   2. If the project has no review action that starts a UI, write <TendrilPlanFolder>/Verification/Screenshots.md with `result: Skipped` plus the reason, and stop.
+   3. Start the app in the background with that command. Take the listening URL from its stdout, or fall back to `tendril plan env get <plan-id>` for the plan's allocated ports. Allow at most 120 seconds for the port to accept connections.
+   4. Capture one PNG per page into <TendrilPlanFolder>/Artifacts/screenshots/, named <NN>-<page>.png: the entry route, plus each route the plan's changes touch. Use the repo's own browser tooling if it has any, otherwise `npx --yes playwright screenshot --full-page --wait-for-timeout=2000 <url> <file>`.
+   5. Stop the app process you started.
+   6. Write <TendrilPlanFolder>/Verification/Screenshots.md with `result: Pass` and the list of captured files. If the tooling is unavailable (no Node, no browser download, offline), record `result: Skipped` with the reason instead. Never report Fail for missing tooling, and never spend more than 5 minutes in this verification.
+   EOF
+   ```
+2. Add it to the project, placed right before `CheckResult`:
+   ```bash
+   tendril project add-verification <project-name> Screenshots --required --after=<last test verification>
+   ```
+   When the project has no test verification, use `--after=<last build verification>` instead. Confirm ordering with `tendril project get <project-name>` and repair with:
+   ```bash
+   tendril project move-verification <project-name> CheckResult --after=Screenshots
+   ```
 
 ### 4. Set the Stack Hash
 
@@ -240,6 +266,7 @@ Include the following sections in `stack.md`:
 Print a summary of what was configured:
 - Verifications added
 - Review actions added
+- Screenshots verification added (or why it was skipped)
 - Stack hash configured
 - Project memory created (`stack.md`)
 

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -537,7 +537,7 @@ internal class JobLauncher
         {
             values["ProjectName"] = addProjArgs.ProjectName;
             values["ReposJson"] = System.Text.Json.JsonSerializer.Serialize(addProjArgs.Repos);
-            values["Instructions"] = "Setup verifications and review actions for this project.";
+            values["Instructions"] = "Setup verifications, review actions, and artifact production for this project.";
             return (values, null, null);
         }
 

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -185,6 +185,15 @@ verifications:
     2. Review all commits made by this execution
     3. Compare the plan's Problem and Solution sections against the actual changes
     4. Write the verification report to `<TendrilPlanFolder>/verification/CheckResult.md`
+- name: Screenshots
+  prompt: >
+    Capture UI screenshots into the plan's Artifacts folder so the Review tab has visual evidence of the change.
+    1. Run `tendril project get "<project>"` and pick the first review action whose condition holds. Review action commands are relative to <TendrilPlanFolder>, so run them from the plan folder, not from the worktree.
+    2. If the project has no review action that starts a UI, write <TendrilPlanFolder>/Verification/Screenshots.md with `result: Skipped` plus the reason, and stop.
+    3. Start the app in the background with that command. Take the listening URL from its stdout, or fall back to `tendril plan env get <plan-id>` for the plan's allocated ports. Allow at most 120 seconds for the port to accept connections.
+    4. Capture one PNG per page into <TendrilPlanFolder>/Artifacts/screenshots/, named <NN>-<page>.png: the entry route, plus each route the plan's changes touch. Use the repo's own browser tooling if it has any, otherwise `npx --yes playwright screenshot --full-page --wait-for-timeout=2000 <url> <file>`.
+    5. Stop the app process you started.
+    6. Write <TendrilPlanFolder>/Verification/Screenshots.md with `result: Pass` and the list of captured files. If the tooling is unavailable (no Node, no browser download, offline), record `result: Skipped` with the reason instead. Never report Fail for missing tooling, and never spend more than 5 minutes in this verification.
 
 # Stack-specific verification examples (uncomment and customize for your stack):
 


### PR DESCRIPTION
Fixes #2394

## Changes

Added a stack-agnostic `Screenshots` verification that captures UI screenshots into a plan's
`Artifacts/` folder, and wired it into the `AddProject`/`SetupProject` project-setup promptwares so
every new project with a launchable UI gets visual review artifacts out of the box, with no manual
configuration. Projects without a launchable UI are unaffected.

## API Changes

- New verification definition `Screenshots` shipped in `example.config.yaml` (fresh installs only —
  existing `config.yaml` files are unaffected until `AddProject`/`SetupProject` is re-run for a
  given project).
- `AddProject`/`SetupProject` promptware documents gained a new `### 3.5. Setup Artifact Production`
  step and an updated verification-ordering list (now 5 steps, `Screenshots` before `CheckResult`).
- `JobLauncher`'s `Instructions` value for `AddProject` and `ProjectAgentStepView`'s `Instructions`
  value for `SetupProject` now mention artifact production.
- New built-in verification documented in `01_Setup.md`'s verification table.

## Files Modified

- `src/Ivy.Tendril/example.config.yaml` — `Screenshots` verification definition
- `src/Ivy.Tendril/Promptwares/AddProject/Program.md` — Setup Artifact Production step, ordering, summary bullet
- `src/Ivy.Tendril/Promptwares/SetupProject/Program.md` — same, mirrored
- `src/Ivy.Tendril/Services/Jobs/JobLauncher.cs` — `AddProject` launch instructions
- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs` — `SetupProject` launch instructions
- `src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md` — built-in verification table row
- `src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs` — 3 new tests

## Manual Testing

1. Run `tendril promptware run AddProject <plan-folder> --value ProjectName=<name> --value ReposJson=<json> --value Instructions="Setup verifications, review actions, and artifact production for this project."` against a repo with a launchable UI (e.g. a Vite or .NET web project).
2. Confirm the run creates a `Screenshots` verification definition (`tendril verification list`) and adds a project reference to it (`tendril project get <name>`), positioned between the last test/build verification and `CheckResult`.
3. Confirm a project with no launchable UI (a pure library/CLI repo) does not get a `Screenshots` verification.
4. Execute a plan for the configured project and confirm the `Screenshots` verification runs during ExecutePlan, producing `Artifacts/screenshots/*.png` (or a documented `Skipped` report when tooling/UI is unavailable).
5. Check the Review tab's Artifacts view shows the captured screenshots.

---

Commits:
- 1a727f23 Add Screenshots verification definition to example.config.yaml
- 4f37915d Teach AddProject and SetupProject to configure the Screenshots verification
- ca43b743 Mention artifact production in project-setup launch instructions
- bae6eb9d Document the Screenshots built-in verification
- 2fdc2ff4 Add tests for the Screenshots verification default

---
Created using [Ivy Tendril](https://ivy.app).
