### PR TITLE
[00203] Fix Chat Voice Input in Tesla Browser

### DIFF
--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -90,6 +90,7 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Prop] public string? ActiveSessionId { get; init; }
     [Prop] public string? StreamingSessionId { get; init; }
     [Prop] public string? UploadUrl { get; init; }
+    [Prop] public string TranscriptionUrl { get; init; } = "wss://tendril-api.ivy.app/transcribe/ws";
     [Prop] public List<ChatSessionDto> Sessions { get; init; } = new();
     [Prop] public List<AgentOptionDto> Agents { get; init; } = new();
     [Prop] public List<ModelOptionDto> Models { get; init; } = new();

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "@testing-library/jest-dom";
 
 vi.mock("pdfjs-dist", () => ({ GlobalWorkerOptions: {}, getDocument: vi.fn() }));
@@ -2021,5 +2021,247 @@ describe("ChatWidget redesign", () => {
     } finally {
       delete (HTMLElement.prototype as any).offsetTop;
     }
+  });
+});
+
+describe("ChatWidget voice input", () => {
+  /** A Web Speech stub whose behaviour on start() the test decides. */
+  class FakeRecognition {
+    static instances: FakeRecognition[] = [];
+    static onStart: ((recognition: FakeRecognition) => void) | null = null;
+
+    continuous = false;
+    interimResults = false;
+    onstart: (() => void) | null = null;
+    onend: (() => void) | null = null;
+    onerror: ((event: { error?: string }) => void) | null = null;
+    onresult: ((event: { results: ArrayLike<{ 0: { transcript: string } }> }) => void) | null = null;
+    stopped = false;
+
+    constructor() {
+      FakeRecognition.instances.push(this);
+    }
+
+    start() {
+      FakeRecognition.onStart?.(this);
+    }
+
+    stop() {
+      this.stopped = true;
+      this.onend?.();
+    }
+
+    emitResult(transcript: string) {
+      this.onstart?.();
+      this.onresult?.({ results: [{ 0: { transcript } }] });
+    }
+
+    emitError(error: string) {
+      this.onerror?.({ error });
+      // Real browsers always follow onerror with onend.
+      this.onend?.();
+    }
+  }
+
+  /** A WebSocket stub that records construction and lets the test push server messages. */
+  class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+    static readonly OPEN = 1;
+
+    readonly OPEN = 1;
+    readyState = 1;
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onerror: (() => void) | null = null;
+    onclose: ((event: { code: number; reason: string; wasClean: boolean }) => void) | null = null;
+    sent: unknown[] = [];
+
+    constructor(public url: string) {
+      FakeWebSocket.instances.push(this);
+    }
+
+    send(data: unknown) {
+      this.sent.push(data);
+    }
+
+    close() {
+      this.readyState = 3;
+    }
+
+    emitServerMessage(payload: unknown) {
+      this.onmessage?.({ data: JSON.stringify(payload) });
+    }
+  }
+
+  const stubMediaDevices = (value: unknown) => {
+    Object.defineProperty(global.navigator, "mediaDevices", { configurable: true, value });
+  };
+
+  const stubWorkingCaptureEnvironment = () => {
+    stubMediaDevices({ getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [] }) });
+    vi.stubGlobal("AudioWorkletNode", class {});
+    vi.stubGlobal(
+      "AudioContext",
+      class {
+        state = "running";
+        audioWorklet = { addModule: vi.fn().mockResolvedValue(undefined) };
+        close() {
+          return Promise.resolve();
+        }
+        resume() {
+          return Promise.resolve();
+        }
+        createMediaStreamSource() {
+          return { connect: vi.fn() };
+        }
+      },
+    );
+  };
+
+  const renderChat = () =>
+    render(<ChatWidget id="test-chat" transcriptionUrl="ws://transcribe-test" />);
+
+  const micButton = () => screen.getByRole("button", { name: /Voice input/i });
+  const errorBanner = () => document.querySelector(".chat-voice-error");
+
+  beforeEach(() => {
+    window.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as any;
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+    FakeRecognition.instances = [];
+    FakeRecognition.onStart = null;
+    FakeWebSocket.instances = [];
+
+    vi.stubGlobal("alert", vi.fn());
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    stubWorkingCaptureEnvironment();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    stubMediaDevices(undefined);
+  });
+
+  it("uses the Web Speech API alone when it produces results", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitResult("hello from web speech");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    const textarea = screen.getByPlaceholderText(/Ask/i) as HTMLTextAreaElement;
+    await waitFor(() => expect(textarea.value).toBe("hello from web speech"));
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(window.alert).not.toHaveBeenCalled();
+    expect(errorBanner()).toBeNull();
+  });
+
+  it("falls back to server transcription when Web Speech errors with 'network' before any result", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("network");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    expect(FakeWebSocket.instances[0].url).toBe("ws://transcribe-test");
+    expect(window.alert).not.toHaveBeenCalled();
+    expect(errorBanner()).toBeNull();
+  });
+
+  it("falls back to server transcription when Web Speech errors with 'service-not-allowed'", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("service-not-allowed");
+    vi.stubGlobal("webkitSpeechRecognition", FakeRecognition);
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    expect(errorBanner()).toBeNull();
+  });
+
+  it("opens a WebSocket directly when no SpeechRecognition constructor exists", async () => {
+    expect((window as any).SpeechRecognition).toBeUndefined();
+    expect((window as any).webkitSpeechRecognition).toBeUndefined();
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    expect(FakeWebSocket.instances[0].url).toBe("ws://transcribe-test");
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  it("shows the error banner and returns to idle when the fallback finds no mediaDevices", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("network");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+    stubMediaDevices(undefined);
+
+    renderChat();
+    const button = micButton();
+    fireEvent.click(button);
+
+    await waitFor(() => expect(errorBanner()?.textContent).toContain("not available in this window"));
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(button).toHaveClass("chat-voice-idle");
+  });
+
+  it("blames the connection when the page is not a secure context", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("network");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+    vi.stubGlobal("isSecureContext", false);
+    vi.stubGlobal("location", { hostname: "192.168.1.42", href: "http://192.168.1.42:5000/" });
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(errorBanner()?.textContent).toContain("secure connection"));
+    expect(errorBanner()?.textContent).toContain("HTTPS");
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it("reports a denied microphone without attempting the server fallback", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("not-allowed");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+
+    renderChat();
+    const button = micButton();
+    fireEvent.click(button);
+
+    await waitFor(() => expect(errorBanner()?.textContent).toContain("Microphone access was denied"));
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(button).toHaveClass("chat-voice-idle");
+  });
+
+  it("appends a server transcript to text already in the composer", async () => {
+    renderChat();
+
+    const textarea = screen.getByPlaceholderText(/Ask/i) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "look into" } });
+
+    fireEvent.click(micButton());
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    const socket = FakeWebSocket.instances[0];
+    socket.emitServerMessage({ type: "result", text: "the flaky test" });
+
+    await waitFor(() => expect(textarea.value).toBe("look into the flaky test"));
+  });
+
+  it("dismisses the error banner when the close button is clicked", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("not-allowed");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(errorBanner()).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Dismiss voice input error/i }));
+    expect(errorBanner()).toBeNull();
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -39,7 +39,7 @@ import {
 import { formatSystemEvent } from "./systemEvents";
 import { useAttachments } from "./useAttachments";
 import { useOutsideClick } from "./useOutsideClick";
-import { useSpeechInput } from "./useSpeechInput";
+import { DEFAULT_TRANSCRIPTION_URL, useSpeechInput } from "./useSpeechInput";
 import { useThreadScroll } from "./useThreadScroll";
 import type { ChatJobDto, ChatMessageDto, ChatQueuedMessageDto, ChatWidgetProps } from "./types";
 import "./chat-widget.css";
@@ -247,6 +247,7 @@ export function ChatWidget({
   activeSessionId,
   streamingSessionId: _streamingSessionId,
   uploadUrl,
+  transcriptionUrl = DEFAULT_TRANSCRIPTION_URL,
   sessions = [],
   agents = [],
   models = [],
@@ -322,7 +323,12 @@ export function ChatWidget({
     }
   }, []);
 
-  const { isRecording, toggle: toggleVoiceRecording } = useSpeechInput(promptText, setPromptText, adjustTextareaHeight);
+  const {
+    voiceStatus,
+    voiceError,
+    dismissVoiceError,
+    toggle: toggleVoiceRecording,
+  } = useSpeechInput(promptText, setPromptText, adjustTextareaHeight, transcriptionUrl);
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
   useOutsideClick(menuOpen, [menuRef], closeMenu);
@@ -1009,6 +1015,21 @@ export function ChatWidget({
               </div>
             )}
 
+            {voiceError && (
+              <div className="chat-voice-error" role="alert">
+                <span>{voiceError}</span>
+                <button
+                  type="button"
+                  className="chat-voice-error-close"
+                  title="Dismiss"
+                  aria-label="Dismiss voice input error"
+                  onClick={dismissVoiceError}
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            )}
+
             {attachments.length > 0 && (
               <div className="chat-attachments-row">
                 {attachments.map((att, idx) => (
@@ -1059,12 +1080,18 @@ export function ChatWidget({
 
                 <button
                   type="button"
-                  className={`chat-icon-btn chat-voice-btn ${isRecording ? "recording" : ""}`}
+                  className={`chat-icon-btn chat-voice-btn chat-voice-${voiceStatus}`}
                   title="Voice input"
                   aria-label="Voice input"
                   onClick={toggleVoiceRecording}
                 >
-                  <Mic size={20} />
+                  {voiceStatus === "connecting" || voiceStatus === "processing" ? (
+                    <LoaderCircle size={20} className="spin" />
+                  ) : voiceStatus === "recording" ? (
+                    <Square size={20} />
+                  ) : (
+                    <Mic size={20} />
+                  )}
                 </button>
 
                 {effectiveIsStreaming ? (

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -1046,10 +1046,53 @@ button.chat-system-event-plan {
   }
 }
 
-.chat-voice-btn.recording {
+.chat-voice-btn.chat-voice-recording {
   color: var(--tch-danger);
   opacity: 1;
   animation: chat-pulse 1.5s infinite;
+}
+
+/* Only reachable on the server-transcription fallback path — the Web Speech API
+   goes straight from idle to recording. */
+.chat-voice-btn.chat-voice-connecting,
+.chat-voice-btn.chat-voice-processing {
+  opacity: 1;
+}
+
+.chat-voice-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--tch-danger);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--tch-danger) 12%, transparent);
+  color: var(--tch-danger);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.chat-voice-error span {
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-voice-error-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.75;
+}
+
+.chat-voice-error-close:hover {
+  opacity: 1;
 }
 
 .chat-send-btn,

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
@@ -80,6 +80,8 @@ export interface ChatWidgetProps {
   activeSessionId?: string | null;
   streamingSessionId?: string | null;
   uploadUrl?: string;
+  /** WebSocket endpoint used to transcribe voice input when the Web Speech API cannot work here. */
+  transcriptionUrl?: string;
   sessions?: ChatSessionDto[];
   agents?: AgentOptionDto[];
   models?: ModelOptionDto[];

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/useSpeechInput.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/useSpeechInput.ts
@@ -1,7 +1,14 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { VoiceRecorder, type VoiceStatus } from "../voice-recorder";
+
+export const DEFAULT_TRANSCRIPTION_URL = "wss://tendril-api.ivy.app/transcribe/ws";
 
 interface SpeechRecognitionEventLike {
   results: ArrayLike<{ 0: { transcript: string } }>;
+}
+
+interface SpeechRecognitionErrorEventLike {
+  error?: string;
 }
 
 interface SpeechRecognitionLike {
@@ -9,7 +16,7 @@ interface SpeechRecognitionLike {
   interimResults: boolean;
   onstart: (() => void) | null;
   onend: (() => void) | null;
-  onerror: (() => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
   onresult: ((event: SpeechRecognitionEventLike) => void) | null;
   start(): void;
   stop(): void;
@@ -25,48 +32,123 @@ const getSpeechRecognition = (): SpeechRecognitionCtor | undefined => {
   return w.SpeechRecognition ?? w.webkitSpeechRecognition;
 };
 
-/** Dictation into the composer: the transcript is appended to whatever was typed before it started. */
+/**
+ * Error codes a Chromium build without Google's speech-service API keys produces. The constructor
+ * exists but never yields a result, which is how voice input silently does nothing in embedded
+ * browsers such as Tesla's. Both are grounds to retry on the server transcription path.
+ */
+const FALLBACK_ERROR_CODES = ["network", "service-not-allowed"];
+
+const MIC_PERMISSION_ERROR =
+  "Microphone access was denied. Allow microphone access for this browser, then try again.";
+
+const SPEECH_FAILED_ERROR = "Voice input could not start. Please try again.";
+
+/**
+ * Dictation into the composer: the transcript is appended to whatever was typed before it started.
+ *
+ * The Web Speech API is tried first, so browsers where it works (Safari, official Chrome builds)
+ * keep their live interim results and need no network round trip. Only when there is direct evidence
+ * Web Speech cannot work here — the constructor is missing, or it errors out before producing a
+ * single result — does this drop to {@link VoiceRecorder}, which streams mic audio to the
+ * transcription service over a WebSocket using baseline Chromium APIs.
+ */
 export function useSpeechInput(
   promptText: string,
   setPromptText: (text: string) => void,
   onTextApplied: () => void,
+  transcriptionUrl: string = DEFAULT_TRANSCRIPTION_URL,
 ) {
-  const [isRecording, setIsRecording] = useState(false);
+  const [voiceStatus, setVoiceStatus] = useState<VoiceStatus>("idle");
+  const [voiceError, setVoiceError] = useState<string | null>(null);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const recorderRef = useRef<VoiceRecorder | null>(null);
+  const hasReceivedSpeechResultRef = useRef(false);
   const initialPromptRef = useRef("");
 
+  const applyTranscript = useCallback(
+    (transcript: string) => {
+      const base = initialPromptRef.current.trim();
+      setPromptText(base ? `${base} ${transcript.trimStart()}` : transcript);
+      setTimeout(onTextApplied, 0);
+    },
+    [setPromptText, onTextApplied],
+  );
+
+  const startServerRecording = useCallback(() => {
+    const recorder = new VoiceRecorder({
+      endpoint: transcriptionUrl,
+      onStatusChange: (status) => setVoiceStatus(status),
+      onError: (message) => setVoiceError(message),
+      onResult: (transcript) => applyTranscript(transcript),
+    });
+    recorderRef.current = recorder;
+    void recorder.start();
+  }, [transcriptionUrl, applyTranscript]);
+
   const toggle = useCallback(() => {
+    if (voiceStatus !== "idle") {
+      recognitionRef.current?.stop();
+      recorderRef.current?.stop();
+      return;
+    }
+
+    setVoiceError(null);
+    initialPromptRef.current = promptText;
+
     const Recognition = getSpeechRecognition();
     if (!Recognition) {
-      alert("Speech recognition is not supported in this browser.");
+      // No Web Speech API at all — go straight to server transcription.
+      startServerRecording();
       return;
     }
 
-    if (isRecording) {
-      recognitionRef.current?.stop();
-      setIsRecording(false);
-      return;
-    }
-
-    initialPromptRef.current = promptText;
+    hasReceivedSpeechResultRef.current = false;
     const recognition = new Recognition();
     recognitionRef.current = recognition;
     recognition.continuous = true;
     recognition.interimResults = true;
-    recognition.onstart = () => setIsRecording(true);
-    recognition.onend = () => setIsRecording(false);
-    recognition.onerror = () => setIsRecording(false);
+    recognition.onstart = () => setVoiceStatus("recording");
+    recognition.onend = () => setVoiceStatus("idle");
+    recognition.onerror = (event) => {
+      const code = event?.error;
+      if (!hasReceivedSpeechResultRef.current && code && FALLBACK_ERROR_CODES.includes(code)) {
+        // Web Speech is present but non-functional in this browser. Retry on the server path
+        // silently — from the user's perspective the mic button should just keep working.
+        // Detach the handlers first: the `onend` that follows `onerror` would otherwise reset the
+        // status to "idle" on top of the recorder that is already connecting.
+        recognition.onstart = null;
+        recognition.onend = null;
+        recognition.onresult = null;
+        recognition.onerror = null;
+        recognitionRef.current = null;
+        startServerRecording();
+        return;
+      }
+      setVoiceError(code === "not-allowed" ? MIC_PERMISSION_ERROR : SPEECH_FAILED_ERROR);
+      setVoiceStatus("idle");
+    };
     recognition.onresult = (event) => {
+      hasReceivedSpeechResultRef.current = true;
       let transcript = "";
       for (let i = 0; i < event.results.length; i++) {
         transcript += event.results[i][0].transcript;
       }
-      const base = initialPromptRef.current.trim();
-      setPromptText(base ? `${base} ${transcript.trimStart()}` : transcript);
-      setTimeout(onTextApplied, 0);
+      applyTranscript(transcript);
     };
     recognition.start();
-  }, [isRecording, promptText, setPromptText, onTextApplied]);
+  }, [voiceStatus, promptText, startServerRecording, applyTranscript]);
 
-  return { isRecording, toggle };
+  // Never let a mic stream or recognition session outlive the widget.
+  useEffect(
+    () => () => {
+      recognitionRef.current?.stop();
+      recorderRef.current?.stop();
+    },
+    [],
+  );
+
+  const dismissVoiceError = useCallback(() => setVoiceError(null), []);
+
+  return { voiceStatus, voiceError, dismissVoiceError, toggle };
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
@@ -150,12 +150,14 @@ describe("ContentInput", () => {
       },
     });
 
-    // Stub AudioContext for jsdom
+    // Stub AudioContext and AudioWorkletNode for jsdom, so the environment check passes and the
+    // recorder actually reaches getUserMedia.
     vi.stubGlobal("AudioContext", class {
       state = "running";
       close() { return Promise.resolve(); }
       resume() { return Promise.resolve(); }
     });
+    vi.stubGlobal("AudioWorkletNode", class {});
 
     render(<ContentInput id="civ-1" value="" transcriptionUrl="ws://test" />);
 
@@ -165,6 +167,29 @@ describe("ContentInput", () => {
     await vi.waitFor(() => {
       const errorBanner = document.querySelector(".civ-error-banner");
       expect(errorBanner?.textContent).toContain("System Settings");
+    });
+  });
+
+  it("reports an unsupported browser when audio capture is unavailable", async () => {
+    Object.defineProperty(global.navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [] }),
+      },
+    });
+
+    // A browser without AudioWorklet support, which is also jsdom's own default.
+    vi.stubGlobal("AudioWorkletNode", undefined);
+    expect(typeof AudioWorkletNode).toBe("undefined");
+
+    render(<ContentInput id="civ-1" value="" transcriptionUrl="ws://test" />);
+
+    const micButton = screen.getByTitle("Voice input transcription");
+    fireEvent.click(micButton);
+
+    await vi.waitFor(() => {
+      const errorBanner = document.querySelector(".civ-error-banner");
+      expect(errorBanner?.textContent).toContain("cannot capture audio");
     });
   });
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import * as pdfjsLib from "pdfjs-dist";
 import pdfjsWorker from "pdfjs-dist/build/pdf.worker.mjs?url";
-import { VoiceRecorder, type VoiceStatus } from "./voice-recorder";
+import { VoiceRecorder, type VoiceStatus } from "../voice-recorder";
 import { isImageFile, processImageFile } from "../imageUtils";
 import "./content-input.css";
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import {
+  AUDIO_CAPTURE_UNSUPPORTED_ERROR,
+  INSECURE_CONTEXT_ERROR,
+  MEDIA_DEVICES_UNAVAILABLE_ERROR,
+  VoiceRecorder,
+  unsupportedEnvironmentError,
+} from "./voice-recorder";
+
+const stubMediaDevices = (value: unknown) => {
+  Object.defineProperty(global.navigator, "mediaDevices", { configurable: true, value });
+};
+
+const workingMediaDevices = { getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [] }) };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  stubMediaDevices(undefined);
+});
+
+describe("unsupportedEnvironmentError", () => {
+  it("names the secure connection as the fix on an insecure non-loopback origin", () => {
+    vi.stubGlobal("isSecureContext", false);
+    vi.stubGlobal("location", { hostname: "192.168.1.42", href: "http://192.168.1.42:5000/" });
+    stubMediaDevices(workingMediaDevices);
+    vi.stubGlobal("AudioWorkletNode", class {});
+
+    expect(unsupportedEnvironmentError()).toBe(INSECURE_CONTEXT_ERROR);
+    expect(INSECURE_CONTEXT_ERROR).toContain("HTTPS");
+  });
+
+  it("does not blame the connection on an insecure loopback origin", () => {
+    vi.stubGlobal("isSecureContext", false);
+    vi.stubGlobal("location", { hostname: "localhost", href: "http://localhost:3000/" });
+    stubMediaDevices(workingMediaDevices);
+    vi.stubGlobal("AudioWorkletNode", class {});
+
+    expect(unsupportedEnvironmentError()).toBeNull();
+  });
+
+  it("keeps the desktop-webview guidance when mediaDevices is missing in a secure context", () => {
+    stubMediaDevices(undefined);
+    vi.stubGlobal("AudioWorkletNode", class {});
+
+    expect(unsupportedEnvironmentError()).toBe(MEDIA_DEVICES_UNAVAILABLE_ERROR);
+    expect(MEDIA_DEVICES_UNAVAILABLE_ERROR).toContain("tendril --web");
+  });
+
+  it("reports an unsupported browser when AudioWorkletNode is absent", () => {
+    stubMediaDevices(workingMediaDevices);
+
+    expect(typeof AudioWorkletNode).toBe("undefined");
+    expect(unsupportedEnvironmentError()).toBe(AUDIO_CAPTURE_UNSUPPORTED_ERROR);
+  });
+
+  it("returns null when the environment can capture audio", () => {
+    stubMediaDevices(workingMediaDevices);
+    vi.stubGlobal("AudioWorkletNode", class {});
+
+    expect(unsupportedEnvironmentError()).toBeNull();
+  });
+});
+
+describe("VoiceRecorder.start", () => {
+  it("reports the environment error and stays idle without constructing an AudioContext", async () => {
+    stubMediaDevices(undefined);
+    const audioContext = vi.fn();
+    vi.stubGlobal("AudioContext", audioContext);
+    const webSocket = vi.fn();
+    vi.stubGlobal("WebSocket", webSocket);
+
+    const statuses: string[] = [];
+    const onError = vi.fn();
+    const recorder = new VoiceRecorder({
+      endpoint: "ws://test",
+      onStatusChange: (status) => statuses.push(status),
+      onResult: vi.fn(),
+      onError,
+    });
+
+    await recorder.start();
+
+    expect(onError).toHaveBeenCalledWith(MEDIA_DEVICES_UNAVAILABLE_ERROR);
+    expect(statuses).toEqual(["connecting", "idle"]);
+    expect(audioContext).not.toHaveBeenCalled();
+    expect(webSocket).not.toHaveBeenCalled();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.ts
@@ -1,5 +1,36 @@
 export type VoiceStatus = "idle" | "connecting" | "recording" | "processing";
 
+export const INSECURE_CONTEXT_ERROR =
+  "Voice input needs a secure connection. Open Tendril over HTTPS or on localhost, then try again.";
+
+export const MEDIA_DEVICES_UNAVAILABLE_ERROR =
+  "Voice input is not available in this window. On macOS, quit and reopen Ivy Tendril after updating, then allow microphone access when prompted. You can also run 'tendril --web' and use voice input in your browser.";
+
+export const AUDIO_CAPTURE_UNSUPPORTED_ERROR =
+  "This browser cannot capture audio for voice input.";
+
+/**
+ * Returns the reason voice capture cannot work in this environment, or null when it can.
+ * Ordered most-specific-cause first so the message names the actual fix.
+ */
+export function unsupportedEnvironmentError(): string | null {
+  const hostname = typeof window !== "undefined" ? window.location?.hostname : undefined;
+  const isLoopback = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+  if (typeof window !== "undefined" && window.isSecureContext === false && !isLoopback) {
+    return INSECURE_CONTEXT_ERROR;
+  }
+
+  if (typeof navigator === "undefined" || !navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== "function") {
+    return MEDIA_DEVICES_UNAVAILABLE_ERROR;
+  }
+
+  if (typeof AudioWorkletNode === "undefined") {
+    return AUDIO_CAPTURE_UNSUPPORTED_ERROR;
+  }
+
+  return null;
+}
+
 export interface VoiceRecorderOptions {
   endpoint: string;
   language?: string;
@@ -25,6 +56,16 @@ export class VoiceRecorder {
     console.log("[VoiceRecorder] start() initiated");
     this.options.onStatusChange("connecting");
 
+    // Feature-detect before constructing anything, so an unsupported browser is not
+    // left holding a dangling AudioContext.
+    const unsupported = unsupportedEnvironmentError();
+    if (unsupported) {
+      console.warn("[VoiceRecorder] Environment cannot capture audio:", unsupported);
+      this.options.onError(unsupported);
+      this.options.onStatusChange("idle");
+      return;
+    }
+
     try {
       // Initialize AudioContext synchronously within the user gesture event handler
       // to prevent modern browsers from blocking/suspending the audio context.
@@ -33,17 +74,6 @@ export class VoiceRecorder {
       if (this.audioContext.state === "suspended") {
         await this.audioContext.resume();
         console.log("[VoiceRecorder] AudioContext resumed, state:", this.audioContext.state);
-      }
-
-      // Feature-detect before touching the mic
-      if (typeof navigator === "undefined" || !navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== "function") {
-        this.options.onError("Voice input is not available in this window. On macOS, quit and reopen Ivy Tendril after updating, then allow microphone access when prompted. You can also run 'tendril --web' and use voice input in your browser.");
-        this.options.onStatusChange("idle");
-        if (this.audioContext) {
-          this.audioContext.close().catch(() => {});
-          this.audioContext = null;
-        }
-        return;
       }
 
       this.stream = await navigator.mediaDevices.getUserMedia({


### PR DESCRIPTION
Fixes #2395

# Summary

## Changes

The Chat app's mic button now falls back to Tendril's existing server transcription path
(`getUserMedia` + `AudioWorklet` + WebSocket) when the Web Speech API cannot work in the browser —
either its constructor is missing, or it errors with `network`/`service-not-allowed` before producing a
single result, which is exactly how it fails in a Tesla browser and any other Chromium build lacking
Google's speech-service API keys. Safari and official Chrome still take the Web Speech path first, so
their live interim results are unchanged. Voice errors now surface in a dismissible banner instead of
`alert()`, and the recorder's unsupported-environment messages name the actual cause (insecure origin
vs. missing `mediaDevices` vs. no `AudioWorklet`) rather than always giving macOS-desktop advice.

## API Changes

- **`ChatWidget.cs`** — new `[Prop] public string TranscriptionUrl { get; init; }`, defaulting to
  `wss://tendril-api.ivy.app/transcribe/ws`. No builder extension method (ChatWidget has none); the
  default means `Apps/Chat/ContentView.cs` needs no change.
- **`ChatWidgetProps`** (`ChatWidget/types.ts`) — new optional `transcriptionUrl?: string`.
- **`useSpeechInput`** — signature gains a fourth optional parameter `transcriptionUrl`. Its return
  value changes from `{ isRecording, toggle }` to
  `{ voiceStatus, voiceError, dismissVoiceError, toggle }`, where `voiceStatus` is
  `"idle" | "connecting" | "recording" | "processing"`. New export `DEFAULT_TRANSCRIPTION_URL`.
- **`voice-recorder.ts`** — moved from `frontend/src/ContentInput/` to `frontend/src/`, so the import
  path is now `"../voice-recorder"` from a subdirectory. New exports: `unsupportedEnvironmentError()`,
  `INSECURE_CONTEXT_ERROR`, `MEDIA_DEVICES_UNAVAILABLE_ERROR`, `AUDIO_CAPTURE_UNSUPPORTED_ERROR`.
- **CSS** — `.chat-voice-btn.recording` renamed to `.chat-voice-btn.chat-voice-recording`; added
  `.chat-voice-connecting`, `.chat-voice-processing`, `.chat-voice-error`, `.chat-voice-error-close`.

## Files Modified

**Voice capture (shared)**
- `src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.ts` (moved from `ContentInput/`; new
  environment-detection branches, `AudioContext` construction moved after them)
- `src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.test.ts` (new)

**Chat widget**
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/useSpeechInput.ts` (Web-Speech-first with server
  fallback; the bulk of the change)
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx` (mic button states, error banner)
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css`
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts`
- `src/Ivy.Tendril.Widgets/ChatWidget.cs`

**Tests**
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx` (new
  `describe("ChatWidget voice input")`, 9 cases)
- `src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx` (`AudioWorkletNode` stub
  for the permission-denial case; new unsupported-browser case)

## Note on the plan's line references

The plan cited `ChatWidget.tsx:361/379/1132/1155/1769`, but PR #2422 landed on `development` after the
plan was drafted and extracted voice input verbatim into `ChatWidget/useSpeechInput.ts`. The code and
the bug were unchanged, so the fix went into the hook. See `Verification/CheckResult.md`.

## Manual Testing

The core scenario needs a real Tesla browser and cannot be automated here.

1. **Tesla browser, HTTPS.** Serve Tendril over an HTTPS URL, open the Chat app in a Tesla browser,
   click the mic. Expect: a brief spinner (connecting), then the button turns into a red pulsing
   square while recording. Click again — spinner (processing), then the transcript is appended to
   whatever is already in the composer. Previously the button did nothing at all.
2. **Regression check in Safari.** Open the Chat app in Safari and click the mic. Expect exactly
   today's behaviour: it goes straight from `Mic` to the red square with no spinner, and words appear
   live as you speak (interim results), with no WebSocket to `tendril-api.ivy.app` in the Network tab.
   Same check in official Chrome.
3. **Insecure origin.** Run `tendril --web` and open it from another device over the LAN
   `http://192.168.x.x:<port>` (not `localhost`). Click the mic. Expect a red banner reading "Voice
   input needs a secure connection. Open Tendril over HTTPS or on localhost, then try again." — not
   silence. Click the × to dismiss it.
4. **Denied microphone.** Deny mic permission for the site, then click the mic. Expect a banner about
   allowing microphone access, the button back to its idle `Mic`, and no fallback attempt.
5. **Append, don't replace.** Type "look into" in the composer first, then dictate. Expect the
   transcript appended after your text, not replacing it — on both the Web Speech and fallback paths.

---
## Commits

- cf0506bf Share voice-recorder and make its unsupported-environment errors accurate (Plan 00203)
- 65801178 Fall back to server transcription when Web Speech cannot work (Plan 00203)

---
Created using [Ivy Tendril](https://ivy.app).
