### PR TITLE
[00202] Restore Joel's Original Git Activity Heatmap Design

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.test.tsx
@@ -17,3 +17,65 @@ describe("ActivityGrid summary metrics", () => {
     expect(screen.getByText("Active weeks")).toBeInTheDocument();
   });
 });
+
+describe("ActivityGrid monthly columns", () => {
+  it("renders one column per month and one cell per non-zero week", () => {
+    const months = [
+      { label: "Jan", weeks: [0, 2, 0, 1] },
+      { label: "Feb", weeks: [3, 0, 0, 0] },
+    ];
+    const { container } = render(<ActivityGrid months={months} />);
+
+    expect(container.querySelectorAll(".tdb-activity-col")).toHaveLength(2);
+    expect(container.querySelectorAll(".tdb-activity-cell")).toHaveLength(3);
+  });
+
+  it("shades the highest week at the top ramp level relative to the range", () => {
+    const months = [{ label: "Jan", weeks: [1, 3] }];
+    const { container } = render(<ActivityGrid months={months} />);
+
+    const cells = container.querySelectorAll(".tdb-activity-cell");
+    expect(cells).toHaveLength(2);
+    const levels = Array.from(cells).map((cell) => cell.getAttribute("data-level"));
+    expect(levels).toContain("4");
+    expect(Number(levels[levels.indexOf("4") === 0 ? 1 : 0])).toBeLessThan(4);
+  });
+
+  it("renders the empty note when every week is zero", () => {
+    render(<ActivityGrid months={[{ label: "Jan", weeks: [0, 0] }]} />);
+    expect(screen.getByText("No merged pull requests yet")).toBeInTheDocument();
+  });
+
+  it("renders the empty note when months is empty", () => {
+    render(<ActivityGrid months={[]} />);
+    expect(screen.getByText("No merged pull requests yet")).toBeInTheDocument();
+  });
+
+  it("labels every month when there are 8 or fewer", () => {
+    const months = Array.from({ length: 8 }, (_, i) => ({
+      label: `M${i}`,
+      weeks: [1],
+    }));
+    render(<ActivityGrid months={months} />);
+
+    for (const month of months) {
+      expect(screen.getByText(month.label)).toBeInTheDocument();
+    }
+  });
+
+  it("labels every other month, always including the last, when more than 8 are supplied", () => {
+    const months = Array.from({ length: 9 }, (_, i) => ({
+      label: `M${i}`,
+      weeks: [1],
+    }));
+    const { container } = render(<ActivityGrid months={months} />);
+
+    const labels = Array.from(container.querySelectorAll(".tdb-activity-label")).map(
+      (el) => el.textContent,
+    );
+    // step = 2, last month (index 8) always labelled: (9-1-8) % 2 === 0
+    expect(labels[8]).toBe("M8");
+    expect(labels[7]).toBe("");
+    expect(labels.filter((l) => l !== "")).toHaveLength(5);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo, useRef } from "react";
+import React, { useMemo } from "react";
 import {
   computeActivityMetrics,
   DashboardActivityMonthDto,
@@ -10,206 +10,100 @@ interface ActivityGridProps {
   months: DashboardActivityMonthDto[];
 }
 
-interface DayCell {
-  date: string;
-  count: number;
-  dateObj: Date;
-}
+const parseIsoDate = (iso: string): Date => {
+  const [year, month, day] = iso.split("-").map(Number);
+  return new Date(year, month - 1, day);
+};
 
-interface WeekColumn {
-  monthLabel?: string;
-  days: (DayCell | null)[];
-}
+/**
+ * Monday of the calendar week for each week index in a month, derived from its daily breakdown
+ * (grouped the same way the backend groups `days` into `weeks`, see `BuildActivityMonths`).
+ * Returns an empty map when `days` isn't supplied — e.g. by the samples app — since the `weeks`
+ * array alone has no date information to recover.
+ */
+const weekStartDates = (month: DashboardActivityMonthDto): Map<number, Date> => {
+  const starts = new Map<number, Date>();
+  if (!month.days || month.days.length === 0) return starts;
 
-const WEEKDAYS = ["Mon", "", "Wed", "", "Fri", "", ""];
+  const firstDate = parseIsoDate(month.days[0].date);
+  const offset = (firstDate.getDay() + 6) % 7;
 
-/** GitHub-style contribution heatmap with 7 weekday rows, week columns,
-    month headers, and an intensity ramp legend. */
+  month.days.forEach((day, index) => {
+    const weekIndex = Math.floor((offset + index) / 7);
+    if (starts.has(weekIndex)) return;
+    const date = parseIsoDate(day.date);
+    const dayOfWeek = (date.getDay() + 6) % 7;
+    date.setDate(date.getDate() - dayOfWeek);
+    starts.set(weekIndex, date);
+  });
+
+  return starts;
+};
+
+/** One column per month; each week with activity renders as a cell stacked
+    from the bottom, shaded by that week's intensity relative to the range. */
 export const ActivityGrid: React.FC<ActivityGridProps> = ({ months }) => {
   const { wrapRef, tip, showTip, hideTip } = useHoverTip();
-  const scrollRef = useRef<HTMLDivElement>(null);
 
   const { totalPrs, activeWeeks } = useMemo(
     () => computeActivityMetrics(months),
     [months],
   );
 
-  // Extract all daily records across the months
-  const allDays = useMemo(() => {
-    const days = months.flatMap((m) => m.days ?? []);
-    if (days.length > 0) return days;
+  const maxWeek = useMemo(
+    () => Math.max(0, ...months.flatMap((m) => m.weeks)),
+    [months],
+  );
 
-    // Fallback if days were not supplied: synthesize days from months & weeks
-    const fallback: { date: string; count: number }[] = [];
-    const today = new Date();
-    for (let mi = 0; mi < months.length; mi++) {
-      const m = months[mi];
-      const monthOffset = months.length - 1 - mi;
-      const d = new Date(today.getFullYear(), today.getMonth() - monthOffset, 1);
-      const daysInMonth = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
-      for (let day = 1; day <= daysInMonth; day++) {
-        const curDate = new Date(d.getFullYear(), d.getMonth(), day);
-        const curIso = curDate.toISOString().slice(0, 10);
-        const weekIdx = Math.min(m.weeks.length - 1, Math.floor((day - 1) / 7));
-        const count = m.weeks[weekIdx] ?? 0;
-        fallback.push({ date: curIso, count });
-      }
-    }
-    return fallback;
-  }, [months]);
-
-  // Max daily count for the color ramp
-  const maxDay = useMemo(() => {
-    if (allDays.length === 0) return 0;
-    return Math.max(0, ...allDays.map((d) => d.count));
-  }, [allDays]);
-
-  // Build weekly columns (Monday=0 to Sunday=6)
-  const columns = useMemo<WeekColumn[]>(() => {
-    if (allDays.length === 0) return [];
-
-    const byDate = new Map<string, number>();
-    for (const d of allDays) {
-      byDate.set(d.date, d.count);
-    }
-
-    const firstDateStr = allDays[0].date;
-    const lastDateStr = allDays[allDays.length - 1].date;
-
-    const firstDate = new Date(firstDateStr + "T00:00:00");
-    const lastDate = new Date(lastDateStr + "T00:00:00");
-
-    // Align start to the Monday of the first week
-    const startMonday = new Date(firstDate);
-    const firstDayOfWeek = (firstDate.getDay() + 6) % 7;
-    startMonday.setDate(startMonday.getDate() - firstDayOfWeek);
-
-    const cols: WeekColumn[] = [];
-    const cur = new Date(startMonday);
-    let lastMonth = -1;
-
-    while (cur <= lastDate || (cur.getDay() + 6) % 7 !== 0) {
-      const weekDays: (DayCell | null)[] = [];
-      let monthLabelForWeek: string | undefined = undefined;
-
-      for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
-        const curDateStr = cur.toISOString().slice(0, 10);
-        if (cur < firstDate || cur > lastDate) {
-          weekDays.push(null);
-        } else {
-          const count = byDate.get(curDateStr) ?? 0;
-          weekDays.push({
-            date: curDateStr,
-            count,
-            dateObj: new Date(cur),
-          });
-
-          // Label month when month changes
-          const monthIdx = cur.getMonth();
-          if (monthIdx !== lastMonth && monthLabelForWeek === undefined) {
-            monthLabelForWeek = cur.toLocaleDateString("en-US", { month: "short" });
-            lastMonth = monthIdx;
-          }
-        }
-        cur.setDate(cur.getDate() + 1);
-      }
-
-      cols.push({
-        monthLabel: monthLabelForWeek,
-        days: weekDays,
-      });
-    }
-
-    return cols;
-  }, [allDays]);
-
-  // Auto-scroll to the end (most recent activity) on mount
-  useLayoutEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
-    }
-  }, [columns]);
-
-  if (months.length === 0) {
-    return (
-      <div className="tdb-empty-note">
-        No activity yet
-      </div>
-    );
+  if (months.length === 0 || maxWeek === 0) {
+    return <div className="tdb-empty-note">No merged pull requests yet</div>;
   }
+
+  // Label every other month when the range is long, always including the last.
+  const step = months.length > 8 ? 2 : 1;
 
   return (
     <div className="tdb-tip-wrap" ref={wrapRef}>
       <div className="tdb-activity-wrap">
-        <div className="tdb-activity-scroll" ref={scrollRef}>
-          <div className="tdb-activity-layout">
-            <div className="tdb-activity-weekdays">
-              {WEEKDAYS.map((wd, i) => (
-                <div key={i} className="tdb-activity-weekday">
-                  {wd}
-                </div>
-              ))}
-            </div>
-            <div className="tdb-activity-grid-body">
-              <div className="tdb-activity-months-row">
-                {columns.map((col, idx) => (
-                  <div key={idx} className="tdb-activity-month-col">
-                    {col.monthLabel && (
-                      <span className="tdb-activity-month-label">
-                        {col.monthLabel}
-                      </span>
-                    )}
-                  </div>
-                ))}
-              </div>
-              <div className="tdb-activity-weeks">
-                {columns.map((col, colIdx) => (
-                  <div key={colIdx} className="tdb-activity-week">
-                    {col.days.map((day, dayIdx) => {
-                      if (!day) {
-                        return (
-                          <div
-                            key={dayIdx}
-                            className="tdb-activity-cell tdb-cell-empty"
-                          />
-                        );
-                      }
-                      const dateText = day.dateObj.toLocaleDateString("en-US", {
-                        weekday: "short",
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      });
-                      const countText =
-                        day.count === 0
-                          ? "No pull requests merged"
-                          : `${day.count} pull request${day.count === 1 ? "" : "s"} merged`;
-
+        <div className="tdb-activity-scroll">
+          <div className="tdb-activity">
+            {months.map((month, monthIndex) => {
+              const starts = weekStartDates(month);
+              return (
+                <div className="tdb-activity-col" key={monthIndex}>
+                  {month.weeks
+                    .map((count, weekIndex) => ({ count, weekIndex }))
+                    .filter(({ count }) => count > 0)
+                    .map(({ count, weekIndex }) => {
+                      const weekStart = starts.get(weekIndex);
+                      const title = weekStart
+                        ? `Week of ${weekStart.toLocaleDateString("en-US", {
+                            weekday: "short",
+                            month: "short",
+                            day: "numeric",
+                          })}`
+                        : month.label;
+                      const body = `${count} pull request${count === 1 ? "" : "s"} merged`;
                       return (
                         <div
-                          key={dayIdx}
+                          key={weekIndex}
                           className="tdb-activity-cell"
-                          data-level={rampLevel(day.count, maxDay)}
-                          onMouseEnter={showTip(dateText, countText)}
+                          data-level={rampLevel(count, maxWeek)}
+                          onMouseEnter={showTip(title, body)}
                           onMouseLeave={hideTip}
                         />
                       );
                     })}
-                  </div>
-                ))}
-              </div>
-            </div>
+                </div>
+              );
+            })}
           </div>
-        </div>
-        <div className="tdb-activity-footer">
-          <div className="tdb-activity-legend">
-            <span>Less</span>
-            <div className="tdb-activity-cell" data-level={0} />
-            <div className="tdb-activity-cell" data-level={1} />
-            <div className="tdb-activity-cell" data-level={2} />
-            <div className="tdb-activity-cell" data-level={3} />
-            <div className="tdb-activity-cell" data-level={4} />
-            <span>More</span>
+          <div className="tdb-activity-labels">
+            {months.map((month, monthIndex) => (
+              <div className="tdb-activity-label" key={monthIndex}>
+                {(months.length - 1 - monthIndex) % step === 0 ? month.label : ""}
+              </div>
+            ))}
           </div>
         </div>
         <div className="tdb-activity-metrics">

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
@@ -137,6 +137,43 @@ describe("TendrilDashboard range and metric combinations", () => {
   });
 });
 
+describe("TendrilDashboard git activity and pull requests side cards", () => {
+  it("renders Git Activity and Pull Requests as two separate cards, not as tabs", () => {
+    const { container } = render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={vi.fn()}
+        activity={[{ label: "Jan", weeks: [1] }]}
+        pullRequests={[{ label: "Jan", value: 3 }]}
+      />,
+    );
+
+    const sideBlocks = container.querySelectorAll(".tdb-col-side .tdb-side-block");
+    const titles = Array.from(sideBlocks).map(
+      (block) => block.querySelector(".tdb-block-title")?.textContent,
+    );
+    expect(titles).toContain("Git Activity");
+    expect(titles).toContain("Pull Requests");
+
+    const sideTabs = container.querySelectorAll(".tdb-col-side .tdb-tabs");
+    expect(sideTabs).toHaveLength(0);
+  });
+
+  it("shows both the activity grid and the pull requests list at the same time", () => {
+    const { container } = render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={vi.fn()}
+        activity={[{ label: "Jan", weeks: [1] }]}
+        pullRequests={[{ label: "Jan", value: 3 }]}
+      />,
+    );
+
+    expect(container.querySelector(".tdb-activity-col")).toBeInTheDocument();
+    expect(container.querySelector(".tdb-bars")).toBeInTheDocument();
+  });
+});
+
 describe("TendrilDashboard KPI card interactions and accessibility", () => {
   const kpis = [
     { id: "dailyPrs", label: "Avg Daily PR count", value: "1.2", delta: "+10%" },

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -64,7 +64,6 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
   slots,
 }) => {
   const [tab, setTab] = useState<"cost" | "plans">("cost");
-  const [sideTab, setSideTab] = useState<"git" | "prs">("git");
 
   const fireEvent = (eventName: string) => {
     if (events.includes(eventName)) {
@@ -241,32 +240,15 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
           <div className="tdb-col tdb-col-side">
             <div className="tdb-update-slot">{slots?.UpdateNotice}</div>
             <div className="tdb-block tdb-side-block">
-              <div className="tdb-side-head">
-                <div className="tdb-tabs">
-                  <button
-                    type="button"
-                    className="tdb-tab"
-                    data-active={sideTab === "git"}
-                    onClick={() => setSideTab("git")}
-                  >
-                    Git Activity
-                  </button>
-                  <button
-                    type="button"
-                    className="tdb-tab"
-                    data-active={sideTab === "prs"}
-                    onClick={() => setSideTab("prs")}
-                  >
-                    Pull Requests
-                  </button>
-                </div>
-              </div>
+              <div className="tdb-block-title">Git Activity</div>
               <div className="tdb-side-body">
-                {sideTab === "git" ? (
-                  <ActivityGrid months={activity} />
-                ) : (
-                  <PillBars items={pullRequests} />
-                )}
+                <ActivityGrid months={activity} />
+              </div>
+            </div>
+            <div className="tdb-block tdb-side-block">
+              <div className="tdb-block-title">Pull Requests</div>
+              <div className="tdb-side-body">
+                <PillBars items={pullRequests} />
               </div>
             </div>
             {hasSlotContent(slots?.TunnelQr) && (

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -491,7 +491,7 @@
   min-height: 0;
 }
 
-/* ---------- Activity grid (GitHub-style daily contribution heatmap) ---------- */
+/* ---------- Activity grid ---------- */
 
 .tdb-activity-wrap {
   display: flex;
@@ -504,80 +504,29 @@
 .tdb-activity-scroll {
   overflow-x: auto;
   scrollbar-width: none;
-  padding-bottom: 4px;
+  padding-right: 16px;
 }
 
-.tdb-activity-layout {
+.tdb-activity {
   display: flex;
-  gap: 6px;
+  align-items: flex-end;
+  gap: 7px;
+  min-height: 166px;
 }
 
-.tdb-activity-weekdays {
+.tdb-activity-col {
   display: flex;
-  flex-direction: column;
-  gap: 3px;
-  padding-top: 18px; /* offset for month headers */
-}
-
-.tdb-activity-weekday {
-  height: 10px;
-  font-size: 9px;
-  line-height: 10px;
-  color: var(--tdb-muted);
-  width: 22px;
-  text-align: right;
-  padding-right: 4px;
-  user-select: none;
-}
-
-.tdb-activity-grid-body {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.tdb-activity-months-row {
-  display: flex;
-  gap: 3px;
-  height: 14px;
-}
-
-.tdb-activity-month-col {
-  width: 10px;
-  position: relative;
-}
-
-.tdb-activity-month-label {
-  position: absolute;
-  left: 0;
-  top: 0;
-  font-size: 10px;
-  line-height: 14px;
-  color: var(--tdb-muted);
-  white-space: nowrap;
-  user-select: none;
-}
-
-.tdb-activity-weeks {
-  display: flex;
-  gap: 3px;
-}
-
-.tdb-activity-week {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
+  flex-direction: column-reverse;
+  gap: 8px;
+  flex: 1 0 13px;
+  min-width: 13px;
 }
 
 .tdb-activity-cell {
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-  flex-shrink: 0;
-}
-
-.tdb-activity-cell.tdb-cell-empty {
-  visibility: hidden;
+  width: 100%;
+  max-width: 22px;
+  aspect-ratio: 1;
+  border-radius: 4px;
 }
 
 .tdb-activity-cell[data-level="0"] { background: color-mix(in srgb, var(--tdb-fg) 6%, transparent); }
@@ -586,25 +535,19 @@
 .tdb-activity-cell[data-level="3"] { background: var(--tdb-ramp-3); }
 .tdb-activity-cell[data-level="4"] { background: var(--tdb-ramp-4); }
 
-.tdb-activity-footer {
+.tdb-activity-labels {
   display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 4px;
-  font-size: 11px;
+  gap: 7px;
+  margin-top: 16px;
+}
+
+.tdb-activity-label {
+  flex: 1 0 13px;
+  min-width: 13px;
+  font-size: 12px;
   color: var(--tdb-muted);
-  margin-top: 4px;
-}
-
-.tdb-activity-legend {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-}
-
-.tdb-activity-legend .tdb-activity-cell {
-  width: 9px;
-  height: 9px;
+  text-align: left;
+  white-space: nowrap;
 }
 
 .tdb-activity-metrics {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -59,6 +59,16 @@ describe("dashboard.css side block and git activity layout", () => {
     expect(css).toMatch(/\.tdb-activity-metrics\s*\{[^}]*display:\s*flex;/);
     expect(css).toMatch(/\.tdb-activity-metrics\s*\{[^}]*border-top:\s*1px solid var\(--tdb-divider\);/);
   });
+
+  it("stacks monthly activity columns from the bottom", () => {
+    expect(css).toMatch(/\.tdb-activity-col\s*\{[^}]*flex-direction:\s*column-reverse;/);
+    expect(css).toMatch(/\.tdb-activity\s*\{[^}]*align-items:\s*flex-end;/);
+  });
+
+  it("no longer carries the daily contribution heatmap classes", () => {
+    expect(css).not.toContain(".tdb-activity-weekdays");
+    expect(css).not.toContain(".tdb-activity-months-row");
+  });
 });
 
 describe("dashboard.css rolling average curve and legend", () => {


### PR DESCRIPTION
Fixes #2429

# Summary

## Changes

Restored Joel Bystedt's original Git Activity design (commit `7dc51a72`) in place of the
GitHub-style daily contribution heatmap introduced by commit `2323cbc`. `ActivityGrid.tsx` now
renders one column per month, with one cell per active week stacked from the bottom of the
column and shaded by that week's merged-PR intensity, with month labels underneath (every other
month once the range exceeds eight months). `TendrilDashboard.tsx`'s single tabbed side card was
split back into two separate cards, "Git Activity" and "Pull Requests", removing the `sideTab`
state and the tab-switch markup. `dashboard.css` was updated to match, deleting the daily-heatmap
classes and restoring Joel's monthly-column rules. Two later improvements were deliberately kept:
hover tooltips now use the existing `HoverTip` component (with a "Week of Mon, Sep 1" title
derived from the month's daily breakdown when available, falling back to the month label
otherwise) instead of Joel's raw `title` attribute, and the `.tdb-activity-metrics` summary row
(PRs merged / Active weeks, added by Plan 00047) is unchanged. No C# changes were needed — the
backend already sends the per-week data this design consumes.

## API Changes

None. No public component props, DTOs, or C# APIs changed.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx`: Removed `sideTab`/`setSideTab` state and the tabbed side-block markup; replaced with two independent `.tdb-side-block` cards for Git Activity and Pull Requests.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx`: Rewritten to render monthly columns of bottom-stacked, intensity-shaded week cells with every-other-month labeling, using `HoverTip` for tooltips and keeping the metrics row.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`: Replaced the daily-heatmap section with Joel's monthly-column rules; kept `.tdb-activity-wrap` and the metrics rules; did not reintroduce `justify-content: flex-end`.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx`: Added tests asserting Git Activity and Pull Requests render as two separate cards, both visible at once, with no side tabs.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.test.tsx`: Added tests for column/cell counts, ramp shading, both empty states, and month-label stepping.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`: Added tests asserting the monthly bottom-stacking rules exist and the daily heatmap classes are gone.

## Manual Testing

1. Ran the samples app: `dotnet run --project src/Ivy.Tendril.Widgets/.samples/Ivy.Tendril.Widgets.Samples.csproj --find-available-port`.
2. Opened `tendril-dashboard/demo` in a browser.
3. Confirmed the side column now shows two separate cards: "Git Activity" (16 monthly columns, cells stacked from the bottom, every-other-month labels) and "Pull Requests" (bar list), followed by the Tunnel card — matching Joel's original stacking order.
4. Confirmed via Playwright hover automation that hovering a Git Activity cell shows a tooltip with the month label and a "N pull requests merged" body (the demo data has no `days`, so the tooltip title falls back to the month label as designed).


---
## Commits
- 6db35557 Restore monthly activity grid styles, drop daily heatmap CSS (Plan 00202)
- b68f8641 Rewrite ActivityGrid as monthly columns instead of daily heatmap (Plan 00202)
- bdf90c43 Split Git Activity and Pull Requests into separate side cards (Plan 00202)

---
Created using [Ivy Tendril](https://ivy.app).
