### PR TITLE
Merge the Chat app and the PTY Agent app behind one Chat button

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/AppShellRouterTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/AppShellRouterTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Ivy.Core.Apps;
 using Ivy.Tendril.AppShell;
+using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Apps.Review;
 using Ivy.Tendril.Services;
 using static Ivy.Tendril.AppShell.TendrilAppShell;
@@ -142,6 +143,44 @@ public class AppShellRouterTests
             Descriptor("agent", allowDuplicateTabs: true));
 
         Assert.Equal(AppShellRouter.RouteAction.CreateNewTab, result.Action);
+    }
+
+    [Fact]
+    public void RouteHybrid_AgentArgsForOpenTerminalSession_SwitchesToItsPane()
+    {
+        var tabs = ImmutableArray.Create(
+            new TabState("review-tab", "review-action", "#1 Tendril", null!, null, "k1"),
+            new TabState("sess-42", "agent", "Fix login", null!, null, "k2"));
+        var router = new AppShellRouter();
+
+        var result = router.Route(
+            new NavigateArgs("agent", new AgentAppArgs(SessionId: "sess-42")),
+            AppShellNavigation.Tabs,
+            null,
+            tabs,
+            Descriptor("agent", allowDuplicateTabs: true));
+
+        Assert.Equal(AppShellRouter.RouteAction.SwitchToExistingTab, result.Action);
+        Assert.Equal(1, result.TabIndex);
+        Assert.Equal("sess-42", result.TabId);
+    }
+
+    [Fact]
+    public void RouteHybrid_AgentArgsForClosedTerminalSession_CreatesNewTab()
+    {
+        var tabs = ImmutableArray.Create(
+            new TabState("sess-1", "agent", "Other", null!, null, "k1"));
+        var router = new AppShellRouter();
+
+        var result = router.Route(
+            new NavigateArgs("agent", new AgentAppArgs(SessionId: "sess-42")),
+            AppShellNavigation.Tabs,
+            null,
+            tabs,
+            Descriptor("agent", allowDuplicateTabs: true));
+
+        Assert.Equal(AppShellRouter.RouteAction.CreateNewTab, result.Action);
+        Assert.Equal("agent", result.EffectiveAppId);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/AppShell/TendrilAppShellNavTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/TendrilAppShellNavTests.cs
@@ -8,11 +8,12 @@ public class TendrilAppShellNavTests
     [
         MenuItem.Default("Plans", "plans"),
         MenuItem.Default("Inbox", "inbox"),
+        MenuItem.Default("Chat", "chat"),
         MenuItem.Default("Agent", "agent")
     ];
 
     [Fact]
-    public void BuildNavItems_ExcludesAgent_KeepsInboxByDefault()
+    public void BuildNavItems_ExcludesAgentAndChat_KeepsInboxByDefault()
     {
         var items = TendrilAppShell.BuildNavItems(Menu, activeAppId: "inbox");
 

--- a/src/Ivy.Tendril.Test/Apps/Agent/AgentAppHeaderKeyTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Agent/AgentAppHeaderKeyTests.cs
@@ -1,0 +1,30 @@
+using System;
+using Ivy.Tendril.Apps.Agent;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Agent;
+
+public class AgentAppHeaderKeyTests
+{
+    private static ChatSessionModel Session(string title) =>
+        new("sess", title, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "opus", [], Kind: ChatSessionKinds.Terminal);
+
+    private static JobItem Job(JobStatus status, string? message = null, string? planTitle = null) =>
+        new() { Id = "job-1", Type = "CreatePlan", Status = status, StatusMessage = message, ReportedPlanTitle = planTitle };
+
+    [Fact]
+    public void HeaderKey_ChangesWhenTheHeaderContentChanges()
+    {
+        var baseline = AgentApp.HeaderKey(Session("Fix login"), [Job(JobStatus.Running, "cloning")]);
+
+        Assert.Equal(baseline, AgentApp.HeaderKey(Session("Fix login"), [Job(JobStatus.Running, "cloning")]));
+        Assert.NotEqual(baseline, AgentApp.HeaderKey(Session("Renamed"), [Job(JobStatus.Running, "cloning")]));
+        Assert.NotEqual(baseline, AgentApp.HeaderKey(Session("Fix login"), [Job(JobStatus.Completed, "cloning")]));
+        Assert.NotEqual(baseline, AgentApp.HeaderKey(Session("Fix login"), [Job(JobStatus.Running, "building")]));
+        Assert.NotEqual(baseline, AgentApp.HeaderKey(Session("Fix login"), [Job(JobStatus.Running, "cloning", "Plan 12")]));
+        Assert.NotEqual(baseline, AgentApp.HeaderKey(Session("Fix login"), []));
+        Assert.NotEqual(baseline, AgentApp.HeaderKey(null, [Job(JobStatus.Running, "cloning")]));
+    }
+}

--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs
@@ -8,8 +8,8 @@ namespace Ivy.Tendril.Test.Apps.Chat;
 
 public class ChatAppSidebarListTests
 {
-    private static ChatSessionModel Session(string id, string title) =>
-        new(id, title, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "opus", []);
+    private static ChatSessionModel Session(string id, string title, string? kind = null) =>
+        new(id, title, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "opus", [], Kind: kind);
 
     [Fact]
     public void BuildSidebarList_MapsSessionsToRowsAndRoutesSelectionThroughChatArgs()
@@ -33,6 +33,28 @@ public class ChatAppSidebarListTests
 
         list.OnSearch!();
         Assert.True(searched);
+        Assert.Null(list.OnNew);
+        Assert.Null(list.NewLabel);
+    }
+
+    [Fact]
+    public void BuildSidebarList_MarksTerminalSessionsAndExposesNewChat()
+    {
+        var sessions = new List<ChatSessionModel>
+        {
+            Session("chat", "Chat", ChatSessionKinds.Chat),
+            Session("term", "Terminal", ChatSessionKinds.Terminal)
+        };
+        var started = false;
+
+        var list = ChatApp.BuildSidebarList(sessions, null, new HashSet<string>(), new HashSet<string>(), () => { }, () => started = true);
+
+        Assert.Collection(list.Items,
+            item => Assert.Null(item.Icon),
+            item => Assert.Equal("Terminal", item.Icon));
+        Assert.Equal("New chat", list.NewLabel);
+        list.OnNew!();
+        Assert.True(started);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Linq;
+using Ivy.Tendril.Apps.Agent;
+using Ivy.Tendril.Apps.Chat;
+using Ivy.Tendril.Services;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Chat;
+
+public class ChatLauncherTests
+{
+    private static ConfigService Config(string chatMode, string? tempDir = null) =>
+        new(new TendrilSettings { CodingAgent = "codex", ChatMode = chatMode }, tempDir);
+
+    [Fact]
+    public void TargetFor_ChatMode_OpensChatAppWithPrompt()
+    {
+        var (app, args) = ChatLauncher.TargetFor(Config(ChatModes.Chat), "Discuss plan", "#7");
+
+        Assert.Equal(typeof(ChatApp), app);
+        var chatArgs = Assert.IsType<ChatAppArgs>(args);
+        Assert.Equal("Discuss plan", chatArgs.Prompt);
+        Assert.Null(chatArgs.SessionId);
+    }
+
+    [Fact]
+    public void TargetFor_TerminalMode_OpensAgentAppWithPromptAndTitle()
+    {
+        var (app, args) = ChatLauncher.TargetFor(Config(ChatModes.Terminal), "Discuss plan", "#7");
+
+        Assert.Equal(typeof(AgentApp), app);
+        var agentArgs = Assert.IsType<AgentAppArgs>(args);
+        Assert.Equal(("Discuss plan", "#7", null), (agentArgs.Prompt, agentArgs.Title, agentArgs.SessionId));
+    }
+
+    [Fact]
+    public void NewSessionTarget_ChatMode_CreatesChatSessionAndSelectsIt()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilLauncherTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = Config(ChatModes.Chat, tempDir);
+            var chats = new ChatHistoryService(config);
+
+            var (app, args) = ChatLauncher.NewSessionTarget(config, chats, TestAgentRunner.Create());
+
+            Assert.Equal(typeof(ChatApp), app);
+            var chatArgs = Assert.IsType<ChatAppArgs>(args);
+            var session = Assert.Single(chats.GetSessions());
+            Assert.Equal(session.Id, chatArgs.SessionId);
+            Assert.False(session.IsTerminal());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NewSessionTarget_TerminalMode_DefersSessionCreationToTheShell()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilLauncherTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = Config(ChatModes.Terminal, tempDir);
+            var chats = new ChatHistoryService(config);
+
+            var (app, args) = ChatLauncher.NewSessionTarget(config, chats, TestAgentRunner.Create());
+
+            Assert.Equal(typeof(AgentApp), app);
+            var agentArgs = Assert.IsType<AgentAppArgs>(args);
+            Assert.Null(agentArgs.SessionId);
+            Assert.Empty(chats.GetSessions());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
@@ -58,6 +58,36 @@ public class ChatLauncherTests
         }
     }
 
+    private static ChatSessionModel Session(string id, string title, string? kind, int minutesAgo) =>
+        new(id, title, DateTimeOffset.UtcNow.AddMinutes(-minutesAgo), DateTimeOffset.UtcNow.AddMinutes(-minutesAgo), "claude", "opus", [], Kind: kind);
+
+    [Fact]
+    public void LatestTerminalSessionId_PicksTheMostRecentlyUpdatedTerminal()
+    {
+        var sessions = new[]
+        {
+            Session("chat-new", "Chat", ChatSessionKinds.Chat, 0),
+            Session("term-old", "Old", ChatSessionKinds.Terminal, 60),
+            Session("term-new", "New", ChatSessionKinds.Terminal, 5)
+        };
+
+        Assert.Equal("term-new", ChatLauncher.LatestTerminalSessionId(sessions));
+        Assert.Null(ChatLauncher.LatestTerminalSessionId([sessions[0]]));
+    }
+
+    [Fact]
+    public void SessionListSignature_ChangesOnlyWithIdsAndTitles()
+    {
+        var a = Session("a", "First", null, 0);
+        var b = Session("b", "Second", null, 0);
+
+        var before = ChatLauncher.SessionListSignature([a, b]);
+
+        Assert.Equal(before, ChatLauncher.SessionListSignature([a with { UpdatedAt = DateTimeOffset.UtcNow.AddHours(1) }, b]));
+        Assert.NotEqual(before, ChatLauncher.SessionListSignature([a with { Title = "Renamed" }, b]));
+        Assert.NotEqual(before, ChatLauncher.SessionListSignature([a]));
+    }
+
     [Fact]
     public void NewSessionTarget_TerminalMode_DefersSessionCreationToTheShell()
     {

--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Ivy.Tendril.Apps.Agent;
@@ -76,16 +77,20 @@ public class ChatLauncherTests
     }
 
     [Fact]
-    public void SessionListSignature_ChangesOnlyWithIdsAndTitles()
+    public void SessionListSignature_TracksIdsTitlesKindAndWorkingState()
     {
         var a = Session("a", "First", null, 0);
         var b = Session("b", "Second", null, 0);
+        var none = new HashSet<string>();
 
-        var before = ChatLauncher.SessionListSignature([a, b]);
+        var before = ChatLauncher.SessionListSignature([a, b], none, none);
 
-        Assert.Equal(before, ChatLauncher.SessionListSignature([a with { UpdatedAt = DateTimeOffset.UtcNow.AddHours(1) }, b]));
-        Assert.NotEqual(before, ChatLauncher.SessionListSignature([a with { Title = "Renamed" }, b]));
-        Assert.NotEqual(before, ChatLauncher.SessionListSignature([a]));
+        Assert.Equal(before, ChatLauncher.SessionListSignature([a with { UpdatedAt = DateTimeOffset.UtcNow.AddHours(1) }, b], none, none));
+        Assert.NotEqual(before, ChatLauncher.SessionListSignature([a with { Title = "Renamed" }, b], none, none));
+        Assert.NotEqual(before, ChatLauncher.SessionListSignature([a with { Kind = ChatSessionKinds.Terminal }, b], none, none));
+        Assert.NotEqual(before, ChatLauncher.SessionListSignature([a, b], new HashSet<string> { "a" }, none));
+        Assert.NotEqual(before, ChatLauncher.SessionListSignature([a, b], none, new HashSet<string> { "b" }));
+        Assert.NotEqual(before, ChatLauncher.SessionListSignature([a], none, none));
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -25,7 +25,7 @@ public class DeleteSessionDialogTests
 
         public IReadOnlyList<ChatSessionModel> GetSessions() => Sessions;
         public ChatSessionModel? GetSession(string id) => Sessions.Find(s => s.Id == id);
-        public ChatSessionModel CreateSession(string agentId, string modelId, string? title = null, string? effort = null)
+        public ChatSessionModel CreateSession(string agentId, string modelId, string? title = null, string? effort = null, string? kind = null)
         {
             var session = new ChatSessionModel(Guid.NewGuid().ToString(), title ?? "New Chat", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, agentId, modelId, [], effort);
             Sessions.Add(session);

--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -187,6 +187,28 @@ public class DeleteSessionDialogTests
     }
 
     [Fact]
+    public async Task Dialog_DeleteButton_WithoutActiveSessionState_StillDeletesSession()
+    {
+        var service = new FakeChatHistoryService();
+        var session = new ChatSessionModel("sess-1", "Terminal", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "opus", [], Kind: ChatSessionKinds.Terminal);
+        service.Sessions.Add(session);
+
+        var deletingSessionId = new TestState<string?>("sess-1");
+        var sessionVersion = new TestState<int>(1);
+
+        var dialog = new DeleteSessionDialog(deletingSessionId, session, service, null, sessionVersion);
+        var result = Assert.IsType<Dialog>(dialog.Build());
+        var footer = Assert.IsType<DialogFooter>(result.Children[2]);
+        var deleteBtn = Assert.IsType<Button>(footer.Children[1]);
+
+        await deleteBtn.OnClick!.Invoke(new Event<Button>("click", deleteBtn));
+
+        Assert.Empty(service.Sessions);
+        Assert.Null(deletingSessionId.Value);
+        Assert.Equal(2, sessionVersion.Value);
+    }
+
+    [Fact]
     public async Task Dialog_DeleteButton_DeletesSession_IncrementsVersion_UpdatesActiveSession()
     {
         var service = new FakeChatHistoryService();

--- a/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
@@ -263,6 +263,48 @@ public class ChatExecutionIntegrationTest
         }
     }
 
+    private sealed class RecordingNamingService : IChatSessionNamingService
+    {
+        public List<(string SessionId, string Prompt)> Calls { get; } = [];
+
+        public Task GenerateAndSetTitleAsync(string sessionId, string userPrompt, string? agentId = null, string? modelId = null, CancellationToken ct = default)
+        {
+            Calls.Add((sessionId, userPrompt));
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ChatExecutionService_SendMessageAsync_NamesTheSessionFromItsFirstPromptOnly()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatNamingTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var configService = new ConfigService(new TendrilSettings { CodingAgent = "codex" }, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var naming = new RecordingNamingService();
+            var execService = new ChatExecutionService(configService, chatService, TestAgentRunner.Create(), naming, new JsonEventSerializer());
+
+            var sess = chatService.CreateSession("codex", "gpt-5.6-sol");
+            _ = execService.SendMessageAsync(sess.Id, "Fix the login bug");
+            await execService.CancelAsync(sess.Id);
+            _ = execService.SendMessageAsync(sess.Id, "And add a test");
+            await execService.CancelAsync(sess.Id);
+
+            var call = Assert.Single(naming.Calls);
+            Assert.Equal((sess.Id, "Fix the login bug"), call);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
     [Fact]
     public async Task ChatExecutionService_CancelAsync_ClearsGeneratingStateAndClosesStream()
     {

--- a/src/Ivy.Tendril.Test/ChatModesTests.cs
+++ b/src/Ivy.Tendril.Test/ChatModesTests.cs
@@ -1,0 +1,38 @@
+using System;
+using Ivy.Tendril.Services;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class ChatModesTests
+{
+    [Theory]
+    [InlineData(null, ChatModes.Chat)]
+    [InlineData("", ChatModes.Chat)]
+    [InlineData("chat", ChatModes.Chat)]
+    [InlineData("terminal", ChatModes.Terminal)]
+    [InlineData("Terminal", ChatModes.Terminal)]
+    [InlineData("pty", ChatModes.Chat)]
+    public void Normalize_FallsBackToChatForAnythingButTerminal(string? mode, string expected)
+    {
+        Assert.Equal(expected, ChatModes.Normalize(mode));
+    }
+
+    [Fact]
+    public void TendrilSettings_DefaultsToChatMode()
+    {
+        Assert.Equal(ChatModes.Chat, new TendrilSettings().ChatMode);
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("chat", false)]
+    [InlineData("terminal", true)]
+    [InlineData("TERMINAL", true)]
+    public void ChatSessionKinds_IsTerminal_ReadsTheSessionKind(string? kind, bool expected)
+    {
+        var session = new ChatSessionModel("id", "t", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "opus", [], Kind: kind);
+
+        Assert.Equal(expected, session.IsTerminal());
+    }
+}

--- a/src/Ivy.Tendril.Test/ChatSessionNamingServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatSessionNamingServiceTests.cs
@@ -64,15 +64,14 @@ public class ChatSessionNamingServiceTests
     }
 
     [Fact]
-    public void BuildPrompt_FormatsPromptWithUserAndAssistantMessages()
+    public void BuildPrompt_FormatsPromptWithUserMessageOnly()
     {
         var userPrompt = "How do I fix the database connection?";
-        var assistantResponse = "You need to update the connection string in config.yaml.";
 
-        var prompt = ChatSessionNamingService.BuildPrompt(userPrompt, assistantResponse);
+        var prompt = ChatSessionNamingService.BuildPrompt(userPrompt);
 
         Assert.Contains("How do I fix the database connection?", prompt);
-        Assert.Contains("You need to update the connection string in config.yaml.", prompt);
+        Assert.DoesNotContain("Assistant:", prompt);
         Assert.Contains("short 3 to 6 word title", prompt);
     }
 
@@ -148,7 +147,6 @@ public class ChatSessionNamingServiceTests
             await namingService.GenerateAndSetTitleAsync(
                 session.Id,
                 "How do I configure Redis cache?",
-                "You can configure Redis in settings.",
                 "claude",
                 "sonnet");
 
@@ -189,7 +187,6 @@ public class ChatSessionNamingServiceTests
             await namingService.GenerateAndSetTitleAsync(
                 session.Id,
                 "How do I configure Redis cache?",
-                "You can configure Redis in settings.",
                 "claude",
                 "sonnet");
 
@@ -231,7 +228,6 @@ public class ChatSessionNamingServiceTests
             await namingService.GenerateAndSetTitleAsync(
                 session.Id,
                 "Prompt",
-                "Response",
                 "claude",
                 "sonnet");
 
@@ -271,7 +267,6 @@ public class ChatSessionNamingServiceTests
             await namingService.GenerateAndSetTitleAsync(
                 session.Id,
                 "Prompt",
-                "Response",
                 "claude",
                 "sonnet");
 

--- a/src/Ivy.Tendril.Widgets/ShellDtos.cs
+++ b/src/Ivy.Tendril.Widgets/ShellDtos.cs
@@ -9,6 +9,6 @@ public record ShellBadgeDto(string Label, string Kind = "neutral")
     public static ShellBadgeDto Warning(string label) => new(label, "warning");
 }
 
-public record ShellSectionItemDto(string Id, string Title, string? Tag = null, List<ShellBadgeDto>? Badges = null);
+public record ShellSectionItemDto(string Id, string Title, string? Tag = null, List<ShellBadgeDto>? Badges = null, string? Icon = null);
 
 public record ShellTabDto(string Id, string Title);

--- a/src/Ivy.Tendril.Widgets/ShellSidebarSection.cs
+++ b/src/Ivy.Tendril.Widgets/ShellSidebarSection.cs
@@ -14,9 +14,11 @@ public record ShellSidebarSection : WidgetBase<ShellSidebarSection>
     [Prop] public bool Searchable { get; init; }
     [Prop] public string? SearchLabel { get; init; }
     [Prop] public string? EmptyText { get; init; }
+    [Prop] public string? NewLabel { get; init; }
 
     [Event] public EventHandler<Event<ShellSidebarSection, string>>? OnSelectItem { get; init; }
     [Event] public EventHandler<Event<ShellSidebarSection>>? OnSearch { get; init; }
+    [Event] public EventHandler<Event<ShellSidebarSection>>? OnNew { get; init; }
 }
 
 public static class ShellSidebarSectionExtensions
@@ -44,4 +46,10 @@ public static class ShellSidebarSectionExtensions
 
     public static ShellSidebarSection OnSearch(this ShellSidebarSection w, Action handler) =>
         w with { OnSearch = new(_ => { handler(); return ValueTask.CompletedTask; }) };
+
+    public static ShellSidebarSection NewLabel(this ShellSidebarSection w, string? newLabel) =>
+        w with { NewLabel = newLabel };
+
+    public static ShellSidebarSection OnNew(this ShellSidebarSection w, Action? handler) =>
+        handler == null ? w : w with { OnNew = new(_ => { handler(); return ValueTask.CompletedTask; }) };
 }

--- a/src/Ivy.Tendril.Widgets/TerminalSessionHeader.cs
+++ b/src/Ivy.Tendril.Widgets/TerminalSessionHeader.cs
@@ -16,7 +16,6 @@ public record TerminalSessionHeader : WidgetBase<TerminalSessionHeader>
     [Event] public EventHandler<Event<TerminalSessionHeader, string[]>>? OnRenameSession { get; init; }
     [Event] public EventHandler<Event<TerminalSessionHeader, string>>? OnDeleteSession { get; init; }
     [Event] public EventHandler<Event<TerminalSessionHeader>>? OnCreateSession { get; init; }
-    [Event] public EventHandler<Event<TerminalSessionHeader, string>>? OnOpenPlan { get; init; }
     [Event] public EventHandler<Event<TerminalSessionHeader>>? OnReviewJobs { get; init; }
 }
 
@@ -49,9 +48,6 @@ public static class TerminalSessionHeaderExtensions
 
     public static TerminalSessionHeader OnCreateSession(this TerminalSessionHeader w, Action handler) =>
         w with { OnCreateSession = new(_ => { handler(); return ValueTask.CompletedTask; }) };
-
-    public static TerminalSessionHeader OnOpenPlan(this TerminalSessionHeader w, Action<string> handler) =>
-        w with { OnOpenPlan = new(e => { handler(e.Value); return ValueTask.CompletedTask; }) };
 
     public static TerminalSessionHeader OnReviewJobs(this TerminalSessionHeader w, Action handler) =>
         w with { OnReviewJobs = new(_ => { handler(); return ValueTask.CompletedTask; }) };

--- a/src/Ivy.Tendril.Widgets/TerminalSessionHeader.cs
+++ b/src/Ivy.Tendril.Widgets/TerminalSessionHeader.cs
@@ -1,0 +1,58 @@
+namespace Ivy.Tendril.Widgets;
+
+[ExternalWidget(
+    "frontend/dist/ivy-tendril-widgets.js",
+    StylePath = "frontend/dist/ivy-tendril-widgets.css",
+    ExportName = "TerminalSessionHeader",
+    GlobalName = "IvyTendrilWidgets"
+)]
+public record TerminalSessionHeader : WidgetBase<TerminalSessionHeader>
+{
+    [Prop] public string SessionId { get; init; } = "";
+    [Prop] public string Title { get; init; } = "New Chat";
+    [Prop] public List<ChatJobDto> Jobs { get; init; } = new();
+    [Prop] public bool Spawned { get; init; }
+
+    [Event] public EventHandler<Event<TerminalSessionHeader, string[]>>? OnRenameSession { get; init; }
+    [Event] public EventHandler<Event<TerminalSessionHeader, string>>? OnDeleteSession { get; init; }
+    [Event] public EventHandler<Event<TerminalSessionHeader>>? OnCreateSession { get; init; }
+    [Event] public EventHandler<Event<TerminalSessionHeader, string>>? OnOpenPlan { get; init; }
+    [Event] public EventHandler<Event<TerminalSessionHeader>>? OnReviewJobs { get; init; }
+}
+
+public static class TerminalSessionHeaderExtensions
+{
+    public static TerminalSessionHeader SessionId(this TerminalSessionHeader w, string sessionId) =>
+        w with { SessionId = sessionId };
+
+    public static TerminalSessionHeader Title(this TerminalSessionHeader w, string title) =>
+        w with { Title = title };
+
+    public static TerminalSessionHeader Jobs(this TerminalSessionHeader w, List<ChatJobDto> jobs) =>
+        w with { Jobs = jobs };
+
+    public static TerminalSessionHeader Spawned(this TerminalSessionHeader w, bool spawned) =>
+        w with { Spawned = spawned };
+
+    public static TerminalSessionHeader OnRenameSession(this TerminalSessionHeader w, Action<string, string> handler) =>
+        w with
+        {
+            OnRenameSession = new(e =>
+            {
+                if (e.Value is { Length: >= 2 }) handler(e.Value[0], e.Value[1]);
+                return ValueTask.CompletedTask;
+            })
+        };
+
+    public static TerminalSessionHeader OnDeleteSession(this TerminalSessionHeader w, Action<string> handler) =>
+        w with { OnDeleteSession = new(e => { handler(e.Value); return ValueTask.CompletedTask; }) };
+
+    public static TerminalSessionHeader OnCreateSession(this TerminalSessionHeader w, Action handler) =>
+        w with { OnCreateSession = new(_ => { handler(); return ValueTask.CompletedTask; }) };
+
+    public static TerminalSessionHeader OnOpenPlan(this TerminalSessionHeader w, Action<string> handler) =>
+        w with { OnOpenPlan = new(e => { handler(e.Value); return ValueTask.CompletedTask; }) };
+
+    public static TerminalSessionHeader OnReviewJobs(this TerminalSessionHeader w, Action handler) =>
+        w with { OnReviewJobs = new(_ => { handler(); return ValueTask.CompletedTask; }) };
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.test.tsx
@@ -51,7 +51,7 @@ describe("AssistantTurn", () => {
       { kind: "tool_call", timestamp: "t1", tool_use_id: "a", tool_name: "Read", input: { file_path: "/a.ts" } },
     ]);
     const { rerender } = render(<AssistantTurn stream={stream} live />);
-    expect(screen.getByText("Reading a.ts")).toBeInTheDocument();
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /1 tool call$/ })).toBeInTheDocument();
 
     const finished = wire([
@@ -74,9 +74,9 @@ describe("AssistantTurn", () => {
     expect(screen.getByText("$0.042")).toBeInTheDocument();
   });
 
-  it("renders an empty live stream as the starting status only", () => {
+  it("renders an empty live stream as the Thinking status only", () => {
     const { container } = render(<AssistantTurn stream="" live />);
-    expect(screen.getByText("Starting…")).toBeInTheDocument();
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
     expect(container.querySelector(".chat-tools")).toBeNull();
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.tsx
@@ -164,7 +164,7 @@ export interface AssistantTurnProps {
 export const AssistantTurn: React.FC<AssistantTurnProps> = ({ stream, live = false }) => {
   const events = useMemo(() => (stream ? parseEventWireStream(stream) : []), [stream]);
   const turn = useMemo(() => summarizeTurn(events), [events]);
-  const status = useMemo(() => deriveStatus(events), [events]);
+  const complete = useMemo(() => deriveStatus(events).complete, [events]);
 
   return (
     <div className="chat-turn">
@@ -180,7 +180,7 @@ export const AssistantTurn: React.FC<AssistantTurnProps> = ({ stream, live = fal
           </div>
         ),
       )}
-      {live && !status.complete && (
+      {live && !complete && (
         <div className="aov-shell chat-turn-status">
           <AnimatedStatus statusText="Thinking" isComplete={false} />
         </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.tsx
@@ -182,7 +182,7 @@ export const AssistantTurn: React.FC<AssistantTurnProps> = ({ stream, live = fal
       )}
       {live && !status.complete && (
         <div className="aov-shell chat-turn-status">
-          <AnimatedStatus statusText={status.text} isComplete={false} />
+          <AnimatedStatus statusText="Thinking" isComplete={false} />
         </div>
       )}
       {!live && turn.result && <TurnMeta wire={turn.result} />}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
@@ -1,0 +1,293 @@
+import React, { useCallback, useRef, useState } from "react";
+import {
+  Activity,
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  Cpu,
+  Ellipsis,
+  LoaderCircle,
+  MessageSquarePlus,
+  Pencil,
+  Sparkles,
+  Trash2,
+  X,
+  XCircle,
+} from "lucide-react";
+import { useOutsideClick } from "./useOutsideClick";
+import type { ChatJobDto } from "./types";
+
+const isRunningJob = (job: ChatJobDto) => job.status === "Running" || job.status === "Pending";
+const isCompletedJob = (job: ChatJobDto) => job.status === "Completed";
+const isFailedJob = (job: ChatJobDto) => job.status === "Failed" || job.status === "Timeout";
+
+const jobsLabel = (count: number) => `${count} job${count === 1 ? "" : "s"}`;
+
+interface JobsMenuProps {
+  jobs: ChatJobDto[];
+  spawned: boolean;
+  onReview: () => void;
+}
+
+const JobsMenu: React.FC<JobsMenuProps> = ({ jobs, spawned, onReview }) => {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useOutsideClick(open, [wrapRef], close);
+
+  const runningCount = jobs.filter(isRunningJob).length;
+  const completedCount = jobs.filter(isCompletedJob).length;
+  const failedCount = jobs.filter(isFailedJob).length;
+  const allFinished = runningCount === 0 && jobs.length > 0;
+  const state = runningCount > 0 ? "running" : failedCount > 0 ? "has-failed" : "all-completed";
+
+  return (
+    <div className="chat-jobs-badge-container" ref={wrapRef}>
+      <button
+        type="button"
+        className={`chat-jobs-badge ${state}`}
+        onClick={() => setOpen((value) => !value)}
+        title={runningCount > 0 ? `${runningCount} job(s) running` : "View jobs"}
+        aria-label="View running jobs"
+        aria-expanded={open}
+      >
+        {runningCount > 0 ? (
+          <>
+            <LoaderCircle size={16} className="spin" />
+            <span className="chat-jobs-badge-text">{runningCount} running</span>
+            <span className="chat-jobs-pulse-dot" />
+          </>
+        ) : failedCount > 0 ? (
+          <>
+            <XCircle size={16} />
+            <span className="chat-jobs-badge-text">
+              {jobsLabel(jobs.length)} ({failedCount} failed)
+            </span>
+          </>
+        ) : (
+          <>
+            <Activity size={16} />
+            <span className="chat-jobs-badge-text">{jobsLabel(jobs.length)}</span>
+          </>
+        )}
+        <ChevronDown size={16} className={`chat-jobs-badge-chevron ${open ? "open" : ""}`} />
+      </button>
+
+      {open && (
+        <div className="chat-jobs-dropdown-menu">
+          <div className="chat-jobs-dropdown-header">
+            <div className="chat-jobs-dropdown-title">
+              <Cpu size={14} />
+              <span>
+                {spawned ? "Spawned Jobs" : "Running Jobs"} ({jobs.length})
+              </span>
+            </div>
+            <div className="chat-jobs-dropdown-chips">
+              {runningCount > 0 && (
+                <span className="chat-job-chip chip-running">
+                  <LoaderCircle size={10} className="spin" />
+                  {runningCount} running
+                </span>
+              )}
+              {completedCount > 0 && (
+                <span className="chat-job-chip chip-completed">
+                  <Check size={10} />
+                  {completedCount} completed
+                </span>
+              )}
+              {failedCount > 0 && (
+                <span className="chat-job-chip chip-failed">
+                  <X size={10} />
+                  {failedCount} failed
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="chat-jobs-dropdown-list">
+            {jobs.map((job) => (
+              <div key={job.id} className={`chat-jobs-dropdown-item ${job.status.toLowerCase()}`}>
+                <div className="chat-job-status-indicator">
+                  {isRunningJob(job) && <LoaderCircle size={13} className="spin" />}
+                  {isCompletedJob(job) && <CheckCircle2 size={13} />}
+                  {isFailedJob(job) && <XCircle size={13} />}
+                  {!isRunningJob(job) && !isCompletedJob(job) && !isFailedJob(job) && <span className="chat-job-dot" />}
+                </div>
+                <div className="chat-job-details">
+                  <div className="chat-job-meta">
+                    <span className="chat-job-type">{job.type}</span>
+                    <span className="chat-job-id">{job.id}</span>
+                    {job.planTitle && (
+                      <span className="chat-job-plan-title" title={job.planTitle}>
+                        {job.planTitle}
+                      </span>
+                    )}
+                  </div>
+                  {job.statusMessage && (
+                    <div className="chat-job-message" title={job.statusMessage}>
+                      {job.statusMessage}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {allFinished && (
+            <div className="chat-jobs-dropdown-footer">
+              <button
+                type="button"
+                className="chat-spawned-jobs-review-btn"
+                onClick={() => {
+                  setOpen(false);
+                  onReview();
+                }}
+              >
+                <Sparkles size={13} />
+                Ask agent to review outcomes
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export interface ChatHeaderProps {
+  title: string;
+  /** Shows the options menu (rename/delete). False while no session is selected. */
+  editable: boolean;
+  jobs?: ChatJobDto[];
+  spawned?: boolean;
+  variant?: "default" | "terminal";
+  onRename?: (title: string) => void;
+  onDelete?: () => void;
+  onNewChat: () => void;
+  onReviewJobs?: () => void;
+  onOpenPlan?: (planId: string) => void;
+}
+
+/**
+ * The chat thread's header: title (with inline rename), a new-chat button, the
+ * options menu (rename/delete), and the jobs pill. Keyed by session id from
+ * ChatWidget so a session switch remounts it and resets editing/menu state.
+ */
+export const ChatHeader: React.FC<ChatHeaderProps> = ({
+  title,
+  editable,
+  jobs = [],
+  spawned = false,
+  variant = "default",
+  onRename,
+  onDelete,
+  onNewChat,
+  onReviewJobs,
+  onOpenPlan: _onOpenPlan,
+}) => {
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [editingTitleText, setEditingTitleText] = useState("");
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+  useOutsideClick(menuOpen, [menuRef], closeMenu);
+
+  const startTitleEdit = () => {
+    setEditingTitleText(title);
+    setIsEditingTitle(true);
+  };
+
+  const saveTitleEdit = () => {
+    const trimmed = editingTitleText.trim();
+    if (trimmed && trimmed !== title) {
+      onRename?.(trimmed);
+    }
+    setIsEditingTitle(false);
+  };
+
+  return (
+    <div className={`chat-header ${variant === "terminal" ? "chat-header--terminal" : ""}`.trim()}>
+      <div className="chat-header-title-wrap">
+        {isEditingTitle ? (
+          <input
+            type="text"
+            className="chat-title-input"
+            aria-label="Chat name"
+            value={editingTitleText}
+            onChange={(e) => setEditingTitleText(e.target.value)}
+            onBlur={saveTitleEdit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") saveTitleEdit();
+              if (e.key === "Escape") setIsEditingTitle(false);
+            }}
+            autoFocus
+          />
+        ) : (
+          <h1 className="chat-title" title={title}>
+            {title}
+          </h1>
+        )}
+      </div>
+      <div className="chat-header-actions">
+        <div className="chat-header-icons">
+          <button
+            type="button"
+            className="chat-icon-btn"
+            title="New chat"
+            aria-label="New chat"
+            onClick={onNewChat}
+          >
+            <MessageSquarePlus size={16} />
+          </button>
+          {editable && (
+            <div className="chat-menu-wrap" ref={menuRef}>
+              <button
+                type="button"
+                className="chat-icon-btn"
+                title="Chat options"
+                aria-label="Chat options"
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                onClick={() => setMenuOpen((value) => !value)}
+              >
+                <Ellipsis size={16} />
+              </button>
+              {menuOpen && (
+                <div className="chat-menu" role="menu" aria-label="Chat options">
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="chat-menu-item"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      startTitleEdit();
+                    }}
+                  >
+                    <Pencil size={14} />
+                    Edit name
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="chat-menu-item chat-menu-item--danger"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onDelete?.();
+                    }}
+                  >
+                    <Trash2 size={14} />
+                    Delete chat
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        {editable && jobs.length > 0 && (
+          <JobsMenu jobs={jobs} spawned={spawned} onReview={() => onReviewJobs?.()} />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
@@ -165,7 +165,6 @@ export interface ChatHeaderProps {
   onDelete?: () => void;
   onNewChat: () => void;
   onReviewJobs?: () => void;
-  onOpenPlan?: (planId: string) => void;
 }
 
 /**
@@ -183,7 +182,6 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   onDelete,
   onNewChat,
   onReviewJobs,
-  onOpenPlan: _onOpenPlan,
 }) => {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editingTitleText, setEditingTitleText] = useState("");

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -1035,8 +1035,8 @@ describe("ChatWidget File Uploads and Attachments", () => {
     expect(screen.getByRole("button", { name: /Stop/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Queue/i })).toBeInTheDocument();
 
-    // Immediately shows the Starting... status indicator
-    expect(screen.getByText("Starting…")).toBeInTheDocument();
+    // Immediately shows the Thinking status indicator
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
 
     // Clicking Stop cancels optimistic stream
     const stopBtn = screen.getByRole("button", { name: /Stop/i });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -1,16 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
-  Activity,
   ArrowRight,
   Check,
   CheckCheck,
-  CheckCircle2,
   ChevronDown,
-  Cpu,
-  Ellipsis,
   ListPlus,
   LoaderCircle,
-  MessageSquarePlus,
   Mic,
   Paperclip,
   Pencil,
@@ -30,6 +25,7 @@ import type {
 import { BlockMarkdown } from "../BlockMarkdown";
 import { AgentPicker } from "./AgentPicker";
 import { AssistantTurn } from "./AssistantTurn";
+import { ChatHeader } from "./ChatHeader";
 import {
   ComposerAttachmentCard,
   MessageAttachmentChip,
@@ -38,10 +34,9 @@ import {
 } from "./attachments";
 import { formatSystemEvent } from "./systemEvents";
 import { useAttachments } from "./useAttachments";
-import { useOutsideClick } from "./useOutsideClick";
 import { DEFAULT_TRANSCRIPTION_URL, useSpeechInput } from "./useSpeechInput";
 import { useThreadScroll } from "./useThreadScroll";
-import type { ChatJobDto, ChatMessageDto, ChatQueuedMessageDto, ChatWidgetProps } from "./types";
+import type { ChatMessageDto, ChatQueuedMessageDto, ChatWidgetProps } from "./types";
 import "./chat-widget.css";
 
 export type {
@@ -56,12 +51,6 @@ export type {
   ModelOptionDto,
 } from "./types";
 export { MAX_PAYLOAD_BYTES, formatFileSize } from "./attachments";
-
-const isRunningJob = (job: ChatJobDto) => job.status === "Running" || job.status === "Pending";
-const isCompletedJob = (job: ChatJobDto) => job.status === "Completed";
-const isFailedJob = (job: ChatJobDto) => job.status === "Failed" || job.status === "Timeout";
-
-const jobsLabel = (count: number) => `${count} job${count === 1 ? "" : "s"}`;
 
 const newOptimisticMessage = (content: string, agentId: string, modelId: string): ChatMessageDto => ({
   id: `opt-${Date.now()}-${Math.random()}`,
@@ -111,137 +100,6 @@ const SystemEventRow: React.FC<{ message: ChatMessageDto; onOpenPlan?: (planId: 
   );
 };
 
-interface JobsMenuProps {
-  jobs: ChatJobDto[];
-  spawned: boolean;
-  onReview: () => void;
-}
-
-const JobsMenu: React.FC<JobsMenuProps> = ({ jobs, spawned, onReview }) => {
-  const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement>(null);
-  const close = useCallback(() => setOpen(false), []);
-  useOutsideClick(open, [wrapRef], close);
-
-  const runningCount = jobs.filter(isRunningJob).length;
-  const completedCount = jobs.filter(isCompletedJob).length;
-  const failedCount = jobs.filter(isFailedJob).length;
-  const allFinished = runningCount === 0 && jobs.length > 0;
-  const state = runningCount > 0 ? "running" : failedCount > 0 ? "has-failed" : "all-completed";
-
-  return (
-    <div className="chat-jobs-badge-container" ref={wrapRef}>
-      <button
-        type="button"
-        className={`chat-jobs-badge ${state}`}
-        onClick={() => setOpen((value) => !value)}
-        title={runningCount > 0 ? `${runningCount} job(s) running` : "View jobs"}
-        aria-label="View running jobs"
-        aria-expanded={open}
-      >
-        {runningCount > 0 ? (
-          <>
-            <LoaderCircle size={16} className="spin" />
-            <span className="chat-jobs-badge-text">{runningCount} running</span>
-            <span className="chat-jobs-pulse-dot" />
-          </>
-        ) : failedCount > 0 ? (
-          <>
-            <XCircle size={16} />
-            <span className="chat-jobs-badge-text">
-              {jobsLabel(jobs.length)} ({failedCount} failed)
-            </span>
-          </>
-        ) : (
-          <>
-            <Activity size={16} />
-            <span className="chat-jobs-badge-text">{jobsLabel(jobs.length)}</span>
-          </>
-        )}
-        <ChevronDown size={16} className={`chat-jobs-badge-chevron ${open ? "open" : ""}`} />
-      </button>
-
-      {open && (
-        <div className="chat-jobs-dropdown-menu">
-          <div className="chat-jobs-dropdown-header">
-            <div className="chat-jobs-dropdown-title">
-              <Cpu size={14} />
-              <span>
-                {spawned ? "Spawned Jobs" : "Running Jobs"} ({jobs.length})
-              </span>
-            </div>
-            <div className="chat-jobs-dropdown-chips">
-              {runningCount > 0 && (
-                <span className="chat-job-chip chip-running">
-                  <LoaderCircle size={10} className="spin" />
-                  {runningCount} running
-                </span>
-              )}
-              {completedCount > 0 && (
-                <span className="chat-job-chip chip-completed">
-                  <Check size={10} />
-                  {completedCount} completed
-                </span>
-              )}
-              {failedCount > 0 && (
-                <span className="chat-job-chip chip-failed">
-                  <X size={10} />
-                  {failedCount} failed
-                </span>
-              )}
-            </div>
-          </div>
-
-          <div className="chat-jobs-dropdown-list">
-            {jobs.map((job) => (
-              <div key={job.id} className={`chat-jobs-dropdown-item ${job.status.toLowerCase()}`}>
-                <div className="chat-job-status-indicator">
-                  {isRunningJob(job) && <LoaderCircle size={13} className="spin" />}
-                  {isCompletedJob(job) && <CheckCircle2 size={13} />}
-                  {isFailedJob(job) && <XCircle size={13} />}
-                  {!isRunningJob(job) && !isCompletedJob(job) && !isFailedJob(job) && <span className="chat-job-dot" />}
-                </div>
-                <div className="chat-job-details">
-                  <div className="chat-job-meta">
-                    <span className="chat-job-type">{job.type}</span>
-                    <span className="chat-job-id">{job.id}</span>
-                    {job.planTitle && (
-                      <span className="chat-job-plan-title" title={job.planTitle}>
-                        {job.planTitle}
-                      </span>
-                    )}
-                  </div>
-                  {job.statusMessage && (
-                    <div className="chat-job-message" title={job.statusMessage}>
-                      {job.statusMessage}
-                    </div>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {allFinished && (
-            <div className="chat-jobs-dropdown-footer">
-              <button
-                type="button"
-                className="chat-spawned-jobs-review-btn"
-                onClick={() => {
-                  setOpen(false);
-                  onReview();
-                }}
-              >
-                <Sparkles size={13} />
-                Ask agent to review outcomes
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
-
 export function ChatWidget({
   id,
   activeSessionId,
@@ -266,9 +124,6 @@ export function ChatWidget({
   eventHandler,
 }: ChatWidgetProps) {
   const [promptText, setPromptText] = useState("");
-  const [isEditingTitle, setIsEditingTitle] = useState(false);
-  const [editingTitleText, setEditingTitleText] = useState("");
-  const [menuOpen, setMenuOpen] = useState(false);
   const [queuedMessages, setQueuedMessages] = useState<ChatQueuedMessageDto[]>(queuedMessagesProp || []);
   const [collapsedQueue, setCollapsedQueue] = useState(false);
   const [editingQueuedId, setEditingQueuedId] = useState<string | null>(null);
@@ -281,7 +136,6 @@ export function ChatWidget({
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
 
   const {
     containerRef: messagesContainerRef,
@@ -329,9 +183,6 @@ export function ChatWidget({
     dismissVoiceError,
     toggle: toggleVoiceRecording,
   } = useSpeechInput(promptText, setPromptText, adjustTextareaHeight, transcriptionUrl);
-
-  const closeMenu = useCallback(() => setMenuOpen(false), []);
-  useOutsideClick(menuOpen, [menuRef], closeMenu);
 
   const activeSession = sessions.find((s) => s.id === activeSessionId);
 
@@ -401,8 +252,6 @@ export function ChatWidget({
   useEffect(() => {
     setOptimisticStreaming(null);
     setQueuedMessages(queuedMessagesProp || []);
-    setMenuOpen(false);
-    setIsEditingTitle(false);
     clearPin();
     isAtBottomRef.current = true;
     scrollToBottom("auto");
@@ -539,22 +388,6 @@ export function ChatWidget({
       draftStoresRef.current.set(messageId, store);
     }
     return store;
-  };
-
-  const startHeaderTitleEdit = () => {
-    if (!activeSession) return;
-    setEditingTitleText(activeSession.title || "New Chat");
-    setIsEditingTitle(true);
-  };
-
-  const saveHeaderTitleEdit = () => {
-    if (activeSession && editingTitleText.trim() && editingTitleText.trim() !== activeSession.title) {
-      const newTitle = editingTitleText.trim();
-      setPendingRenames((prev) => ({ ...prev, [activeSession.id]: newTitle }));
-      // One array argument: the host maps a single argument onto the event's string[] value.
-      emit("OnRenameSession", [activeSession.id, newTitle]);
-    }
-    setIsEditingTitle(false);
   };
 
   const handleSendMessage = () => {
@@ -731,98 +564,29 @@ export function ChatWidget({
     <div className="chat-widget-root">
       <input ref={fileInputRef} type="file" multiple style={{ display: "none" }} onChange={handleFileSelect} />
 
-      <div className="chat-header">
-        <div className="chat-header-title-wrap">
-          {isEditingTitle ? (
-            <input
-              type="text"
-              className="chat-title-input"
-              aria-label="Chat name"
-              value={editingTitleText}
-              onChange={(e) => setEditingTitleText(e.target.value)}
-              onBlur={saveHeaderTitleEdit}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") saveHeaderTitleEdit();
-                if (e.key === "Escape") setIsEditingTitle(false);
-              }}
-              autoFocus
-            />
-          ) : (
-            <h1 className="chat-title" title={title}>
-              {title}
-            </h1>
-          )}
-        </div>
-        <div className="chat-header-actions">
-          <div className="chat-header-icons">
-            <button
-              type="button"
-              className="chat-icon-btn"
-              title="New chat"
-              aria-label="New chat"
-              onClick={() => emit("OnCreateSession")}
-            >
-              <MessageSquarePlus size={16} />
-            </button>
-            {activeSession && (
-              <div className="chat-menu-wrap" ref={menuRef}>
-                <button
-                  type="button"
-                  className="chat-icon-btn"
-                  title="Chat options"
-                  aria-label="Chat options"
-                  aria-haspopup="menu"
-                  aria-expanded={menuOpen}
-                  onClick={() => setMenuOpen((value) => !value)}
-                >
-                  <Ellipsis size={16} />
-                </button>
-                {menuOpen && (
-                  <div className="chat-menu" role="menu" aria-label="Chat options">
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className="chat-menu-item"
-                      onClick={() => {
-                        setMenuOpen(false);
-                        startHeaderTitleEdit();
-                      }}
-                    >
-                      <Pencil size={14} />
-                      Edit name
-                    </button>
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className="chat-menu-item chat-menu-item--danger"
-                      onClick={() => {
-                        setMenuOpen(false);
-                        emit("OnDeleteSession", activeSession.id);
-                      }}
-                    >
-                      <Trash2 size={14} />
-                      Delete chat
-                    </button>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-          {activeSession && headerJobs.length > 0 && (
-            <JobsMenu
-              jobs={headerJobs}
-              spawned={sessionSpawnedJobs.length > 0}
-              onReview={() =>
-                emit("OnSendMessage", {
-                  prompt: "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.",
-                  attachments: [],
-                  sessionId: activeSession.id,
-                })
-              }
-            />
-          )}
-        </div>
-      </div>
+      <ChatHeader
+        key={activeSessionId ?? "none"}
+        title={title}
+        editable={!!activeSession}
+        jobs={headerJobs}
+        spawned={sessionSpawnedJobs.length > 0}
+        onRename={(t) => {
+          if (!activeSession) return;
+          setPendingRenames((prev) => ({ ...prev, [activeSession.id]: t }));
+          // One array argument: the host maps a single argument onto the event's string[] value.
+          emit("OnRenameSession", [activeSession.id, t]);
+        }}
+        onDelete={() => activeSession && emit("OnDeleteSession", activeSession.id)}
+        onNewChat={() => emit("OnCreateSession")}
+        onReviewJobs={() =>
+          activeSession &&
+          emit("OnSendMessage", {
+            prompt: "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.",
+            attachments: [],
+            sessionId: activeSession.id,
+          })
+        }
+      />
 
       <div ref={messagesContainerRef} className="chat-messages-container">
         <div className="chat-thread" data-empty={!hasThreadContent}>

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/TerminalSessionHeader.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/TerminalSessionHeader.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { TerminalSessionHeader } from "./TerminalSessionHeader";
+
+describe("TerminalSessionHeader", () => {
+  it("renames the session and emits OnRenameSession with one array argument", () => {
+    const handleEvent = vi.fn();
+    render(
+      <TerminalSessionHeader
+        id="term-header"
+        sessionId="sess-1"
+        title="My Session"
+        events={["OnRenameSession"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Chat options/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Edit name/i }));
+
+    const input = screen.getByRole("textbox", { name: /Chat name/i });
+    fireEvent.change(input, { target: { value: "Renamed Session" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(handleEvent).toHaveBeenCalledWith("OnRenameSession", "term-header", [["sess-1", "Renamed Session"]]);
+  });
+
+  it("deletes the session and emits OnDeleteSession", () => {
+    const handleEvent = vi.fn();
+    render(
+      <TerminalSessionHeader
+        id="term-header"
+        sessionId="sess-2"
+        title="My Session"
+        events={["OnDeleteSession"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Chat options/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Delete chat/i }));
+
+    expect(handleEvent).toHaveBeenCalledWith("OnDeleteSession", "term-header", ["sess-2"]);
+  });
+
+  it("emits OnCreateSession from the new chat button", () => {
+    const handleEvent = vi.fn();
+    render(
+      <TerminalSessionHeader
+        id="term-header"
+        sessionId="sess-3"
+        events={["OnCreateSession"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /New chat/i }));
+    expect(handleEvent).toHaveBeenCalledWith("OnCreateSession", "term-header", []);
+  });
+
+  it("renders the terminal variant host and header classes", () => {
+    const { container } = render(<TerminalSessionHeader id="term-header" sessionId="sess-4" />);
+    expect(container.querySelector(".chat-header-host.chat-header-host--terminal")).toBeInTheDocument();
+    expect(container.querySelector(".chat-header.chat-header--terminal")).toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/TerminalSessionHeader.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/TerminalSessionHeader.tsx
@@ -41,13 +41,12 @@ export const TerminalSessionHeader: React.FC<TerminalSessionHeaderProps> = ({
       <ChatHeader
         variant="terminal"
         title={title}
-        editable
+        editable={!!sessionId}
         jobs={jobs}
         spawned={spawned}
         onRename={(newTitle) => emit("OnRenameSession", [sessionId, newTitle])}
         onDelete={() => emit("OnDeleteSession", sessionId)}
         onNewChat={() => emit("OnCreateSession")}
-        onOpenPlan={(planId) => emit("OnOpenPlan", planId)}
         onReviewJobs={() => emit("OnReviewJobs")}
       />
     </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/TerminalSessionHeader.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/TerminalSessionHeader.tsx
@@ -1,0 +1,55 @@
+import React, { useCallback } from "react";
+import { ChatHeader } from "./ChatHeader";
+import type { ChatJobDto, IvyEventHandler } from "./types";
+import "./chat-widget.css";
+
+export interface TerminalSessionHeaderProps {
+  id: string;
+  events?: string[];
+  eventHandler?: IvyEventHandler;
+  sessionId: string;
+  title?: string;
+  jobs?: ChatJobDto[];
+  spawned?: boolean;
+}
+
+/**
+ * Standalone chat header for a terminal-hosted session: always the black
+ * `chat-header--terminal` variant, wired directly to session events without
+ * ChatWidget's optimistic-rename bookkeeping.
+ */
+export const TerminalSessionHeader: React.FC<TerminalSessionHeaderProps> = ({
+  id,
+  events = [],
+  eventHandler,
+  sessionId,
+  title = "New Chat",
+  jobs = [],
+  spawned = false,
+}) => {
+  const emit = useCallback(
+    (eventName: string, ...args: unknown[]) => {
+      if (eventHandler && events.includes(eventName)) {
+        eventHandler(eventName, id, args);
+      }
+    },
+    [eventHandler, events, id],
+  );
+
+  return (
+    <div className="chat-header-host chat-header-host--terminal">
+      <ChatHeader
+        variant="terminal"
+        title={title}
+        editable
+        jobs={jobs}
+        spawned={spawned}
+        onRename={(newTitle) => emit("OnRenameSession", [sessionId, newTitle])}
+        onDelete={() => emit("OnDeleteSession", sessionId)}
+        onNewChat={() => emit("OnCreateSession")}
+        onOpenPlan={(planId) => emit("OnOpenPlan", planId)}
+        onReviewJobs={() => emit("OnReviewJobs")}
+      />
+    </div>
+  );
+};

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -4,7 +4,8 @@
    literals are only fallbacks for a widget rendered outside a themed host. */
 
 .chat-widget-root,
-.chat-agent-layer {
+.chat-agent-layer,
+.chat-header-host {
   --tch-bg: var(--background, #ffffff);
   --tch-fg: var(--foreground, #000000);
   --tch-fg-title: var(--foreground, #202221);
@@ -31,7 +32,8 @@
 }
 
 .dark .chat-widget-root,
-.dark .chat-agent-layer {
+.dark .chat-agent-layer,
+.dark .chat-header-host {
   --tch-surface: color-mix(in srgb, var(--foreground, #f8f8f8) 7%, var(--background, #000000));
   --tch-surface-hover: color-mix(in srgb, var(--foreground, #f8f8f8) 11%, var(--background, #000000));
   --tch-shadow: 0 12px 30px -4px rgba(0, 0, 0, 0.6), 0 4px 12px -2px rgba(0, 0, 0, 0.4);
@@ -50,6 +52,18 @@
 
 .chat-widget-root *,
 .chat-agent-layer * {
+  box-sizing: border-box;
+}
+
+.chat-header-host {
+  width: 100%;
+  flex-shrink: 0;
+  font-family: var(--font-sans, "Geist", sans-serif);
+  font-size: 14px;
+  color: var(--tch-fg);
+}
+
+.chat-header-host * {
   box-sizing: border-box;
 }
 
@@ -78,6 +92,27 @@
   height: 48px;
   padding: 0 8px 0 20px;
   border-bottom: 1px solid var(--tch-border);
+}
+
+/* The terminal-hosted header is always black, regardless of the host theme:
+   override the chat tokens it draws from rather than hard-coding colors on
+   individual rules below, so the jobs pill/dropdown pick it up too. */
+.chat-header-host--terminal {
+  --tch-bg: #000;
+  --tch-fg: #fff;
+  --tch-fg-title: #fff;
+  --tch-muted: rgba(255, 255, 255, 0.6);
+  --tch-faint: rgba(255, 255, 255, 0.4);
+  --tch-border: #262626;
+  --tch-surface: rgba(255, 255, 255, 0.08);
+  --tch-surface-hover: rgba(255, 255, 255, 0.14);
+  --tch-popover: #141414;
+  --tch-shadow: 0 12px 30px -4px rgba(0, 0, 0, 0.7), 0 4px 12px -2px rgba(0, 0, 0, 0.5);
+}
+
+.chat-header--terminal {
+  background: #000;
+  color: #fff;
 }
 
 .chat-header-title-wrap {

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
@@ -242,6 +242,94 @@ describe("ShellSidebarSection", () => {
     vi.useRealTimers();
   });
 
+  it("renders a new-chat button that fires OnNew when newLabel is set", () => {
+    const eventHandler = vi.fn();
+    render(
+      <ShellSidebarSection
+        id="sec-1"
+        title="Chats"
+        items={mockItems}
+        newLabel="New chat"
+        events={["OnNew"]}
+        eventHandler={eventHandler}
+      />,
+    );
+
+    const newBtn = screen.getByRole("button", { name: "New chat" });
+    expect(newBtn).toHaveClass("tsh-section-new");
+
+    fireEvent.click(newBtn);
+    expect(eventHandler).toHaveBeenCalledWith("OnNew", "sec-1", []);
+  });
+
+  it("does not render a new-chat button without newLabel", () => {
+    render(
+      <ShellSidebarSection id="sec-1" title="Chats" items={mockItems} eventHandler={vi.fn()} />,
+    );
+
+    expect(screen.queryByRole("button", { name: "New chat" })).not.toBeInTheDocument();
+  });
+
+  it("uses the title header instead of the full-width Search button when newLabel is set and the list is empty", () => {
+    render(
+      <ShellSidebarSection
+        id="sec-1"
+        title="Chats"
+        items={[]}
+        searchable={true}
+        newLabel="New chat"
+        events={["OnSearch", "OnNew"]}
+        eventHandler={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Chats")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /search plans/i })).toHaveClass("tsh-section-search");
+    expect(screen.queryByRole("button", { name: /^Search$/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the new-chat button on the collapsed rail", () => {
+    const eventHandler = vi.fn();
+    render(
+      <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+        <ShellSidebarSection
+          id="sec-1"
+          title="Chats"
+          items={mockItems}
+          newLabel="New chat"
+          events={["OnNew"]}
+          eventHandler={eventHandler}
+        />
+      </ShellContext.Provider>,
+    );
+
+    const railNewBtn = screen.getByRole("button", { name: "New chat" });
+    expect(railNewBtn).toHaveClass("tsh-rail-new");
+
+    fireEvent.click(railNewBtn);
+    expect(eventHandler).toHaveBeenCalledWith("OnNew", "sec-1", []);
+  });
+
+  it("renders the mapped icon for an item with icon: Terminal", () => {
+    const itemsWithIcon: ShellSectionItemDto[] = [{ id: "term-1", title: "Terminal Session", icon: "Terminal" }];
+    const { container } = render(
+      <ShellSidebarSection id="sec-1" title="Chats" items={itemsWithIcon} eventHandler={vi.fn()} />,
+    );
+
+    const iconWrap = container.querySelector(".tsh-section-item-icon");
+    expect(iconWrap).toBeInTheDocument();
+    expect(iconWrap?.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders no icon for an item without a recognized icon name", () => {
+    const itemsWithoutIcon: ShellSectionItemDto[] = [{ id: "plain-1", title: "Plain Item" }];
+    const { container } = render(
+      <ShellSidebarSection id="sec-1" title="Chats" items={itemsWithoutIcon} eventHandler={vi.fn()} />,
+    );
+
+    expect(container.querySelector(".tsh-section-item-icon")).not.toBeInTheDocument();
+  });
+
   it("displays custom tooltip with plan title and badges when hovering collapsed rail plan item", () => {
     vi.useFakeTimers();
     const itemsWithBadges: ShellSectionItemDto[] = [

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from "react";
-import { Search } from "lucide-react";
+import { Plus, Search, SquareTerminal } from "lucide-react";
 import { useShell } from "./ShellContext";
 import {
   ShellSectionItemDto,
@@ -13,6 +13,11 @@ import "./shell.css";
 
 const SEARCH_SHORTCUT_KEY = "K";
 
+/** Maps a `ShellSectionItemDto.icon` name to its lucide component; unknown names render nothing. */
+const sectionItemIcons: Record<string, React.FC<{ size?: number }>> = {
+  Terminal: SquareTerminal,
+};
+
 interface ShellSidebarSectionProps extends ShellWidgetProps {
   title?: string;
   items?: ShellSectionItemDto[];
@@ -21,6 +26,8 @@ interface ShellSidebarSectionProps extends ShellWidgetProps {
   /** The search icon's tooltip and accessible name; the section defaults to plans. */
   searchLabel?: string;
   emptyText?: string;
+  /** Shows a "+" button in the header (e.g. "New chat"); fires OnNew. */
+  newLabel?: string;
 }
 
 /**
@@ -41,6 +48,7 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
   searchable = false,
   searchLabel = "Search plans",
   emptyText,
+  newLabel,
 }) => {
   const select = (itemId: string) => {
     if (events.includes("OnSelectItem")) eventHandler("OnSelectItem", id, [itemId]);
@@ -48,6 +56,10 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
 
   const openSearch = useCallback(() => {
     if (events.includes("OnSearch")) eventHandler("OnSearch", id, []);
+  }, [events, eventHandler, id]);
+
+  const createNew = useCallback(() => {
+    if (events.includes("OnNew")) eventHandler("OnNew", id, []);
   }, [events, eventHandler, id]);
 
   useEffect(() => {
@@ -72,11 +84,18 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
   const shortcutHint = `${modKeyLabel()}+${SEARCH_SHORTCUT_KEY}`;
 
   const hasHeader = !!title || searchable;
-  const showSearchButton = searchable && (!title || items.length === 0);
+  const showSearchButton = searchable && (!title || (items.length === 0 && !newLabel));
 
   if (collapsed) {
     return (
       <div className="tsh-section tsh-section-rail">
+        {newLabel && (
+          <ShellTooltip content={newLabel} side="right">
+            <button className="tsh-rail-new" onClick={createNew} aria-label={newLabel}>
+              <Plus size={16} />
+            </button>
+          </ShellTooltip>
+        )}
         {searchable && (
           <ShellTooltip content={searchLabel} shortcut={shortcutHint} side="right">
             <button className="tsh-rail-search" onClick={openSearch} aria-label={searchLabel}>
@@ -148,39 +167,56 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
       {hasHeader && !showSearchButton && (
         <div className="tsh-section-header">
           <span className="tsh-section-title">{title}</span>
-          {searchable && (
-            <ShellTooltip content={searchLabel} shortcut={shortcutHint} side="right">
-              <button className="tsh-section-search" onClick={openSearch} aria-label={searchLabel}>
-                <Search size={16} />
-              </button>
-            </ShellTooltip>
-          )}
+          <span className="tsh-section-header-actions">
+            {newLabel && (
+              <ShellTooltip content={newLabel} side="right">
+                <button className="tsh-section-new" onClick={createNew} aria-label={newLabel}>
+                  <Plus size={16} />
+                </button>
+              </ShellTooltip>
+            )}
+            {searchable && (
+              <ShellTooltip content={searchLabel} shortcut={shortcutHint} side="right">
+                <button className="tsh-section-search" onClick={openSearch} aria-label={searchLabel}>
+                  <Search size={16} />
+                </button>
+              </ShellTooltip>
+            )}
+          </span>
         </div>
       )}
       <div className="tsh-section-list">
         {items.length === 0 && emptyText && <div className="tsh-section-empty">{emptyText}</div>}
-        {items.map((item) => (
-          <button
-            key={item.id}
-            className="tsh-section-item"
-            data-selected={item.id === selectedId}
-            onClick={() => select(item.id)}
-          >
-            <span className="tsh-section-item-top">
-              <span className="tsh-section-item-title">{item.title}</span>
-              {item.tag && <span className="tsh-section-item-tag">{item.tag}</span>}
-            </span>
-            {item.badges && item.badges.length > 0 && (
-              <span className="tsh-section-item-badges">
-                {item.badges.map((badge, i) => (
-                  <span key={i} className="tsh-badge" data-kind={badge.kind}>
-                    {badge.label}
+        {items.map((item) => {
+          const ItemIcon = item.icon ? sectionItemIcons[item.icon] : undefined;
+          return (
+            <button
+              key={item.id}
+              className="tsh-section-item"
+              data-selected={item.id === selectedId}
+              onClick={() => select(item.id)}
+            >
+              <span className="tsh-section-item-top">
+                {ItemIcon && (
+                  <span className="tsh-section-item-icon">
+                    <ItemIcon size={14} />
                   </span>
-                ))}
+                )}
+                <span className="tsh-section-item-title">{item.title}</span>
+                {item.tag && <span className="tsh-section-item-tag">{item.tag}</span>}
               </span>
-            )}
-          </button>
-        ))}
+              {item.badges && item.badges.length > 0 && (
+                <span className="tsh-section-item-badges">
+                  {item.badges.map((badge, i) => (
+                    <span key={i} className="tsh-badge" data-kind={badge.kind}>
+                      {badge.label}
+                    </span>
+                  ))}
+                </span>
+              )}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/brandIcons.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/brandIcons.tsx
@@ -2,7 +2,7 @@
 // (ClaudeCode, Antigravity, OpenCode, IvyCorner) and Simple Icons (OpenAI, Gemini,
 // Copilot, Anthropic) so the shell bundle does not depend on react-icons.
 import React from "react";
-import { ChevronUp, Terminal } from "lucide-react";
+import { ChevronUp, MessageCircle, Terminal } from "lucide-react";
 
 interface BrandIconProps {
   size?: number;
@@ -64,6 +64,10 @@ const TerminalIcon = ({ size = 16, className }: BrandIconProps) => (
   <Terminal size={size} className={className} />
 );
 
+const MessageCircleIcon = ({ size = 16, className }: BrandIconProps) => (
+  <MessageCircle size={size} className={className} />
+);
+
 /** Maps the C# Icons enum name (from AgentBranding.IconFor) to a component. */
 const brandIcons: Record<string, React.FC<BrandIconProps>> = {
   ClaudeCode: ClaudeCodeIcon,
@@ -76,6 +80,7 @@ const brandIcons: Record<string, React.FC<BrandIconProps>> = {
   Anthropic: AnthropicIcon,
   ChevronUp: ChevronUpIcon,
   Terminal: TerminalIcon,
+  MessageCircle: MessageCircleIcon,
 };
 
 export const BrandIcon: React.FC<{ name?: string; size?: number; className?: string }> = ({

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -740,7 +740,8 @@
   align-items: stretch;
 }
 
-.tsh-rail-search {
+.tsh-rail-search,
+.tsh-rail-new {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -758,7 +759,8 @@
     background-color 150ms ease;
 }
 
-.tsh-rail-search:hover {
+.tsh-rail-search:hover,
+.tsh-rail-new:hover {
   opacity: 1;
   background: var(--tsh-row-active);
   color: var(--tsh-row-active-fg);
@@ -972,7 +974,14 @@
   white-space: nowrap;
 }
 
-.tsh-section-search {
+.tsh-section-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.tsh-section-search,
+.tsh-section-new {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -990,7 +999,8 @@
     background-color 150ms ease;
 }
 
-.tsh-section-search:hover {
+.tsh-section-search:hover,
+.tsh-section-new:hover {
   opacity: 1;
   background: var(--tsh-row-active);
   color: var(--tsh-row-active-fg);
@@ -1093,6 +1103,12 @@
   justify-content: space-between;
   gap: 8px;
   width: 100%;
+}
+
+.tsh-section-item-icon {
+  flex-shrink: 0;
+  opacity: 0.7;
+  display: flex;
 }
 
 .tsh-section-item-title {

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/types.ts
@@ -25,6 +25,8 @@ export interface ShellSectionItemDto {
   title: string;
   tag?: string;
   badges?: ShellBadgeDto[];
+  /** A lucide icon name (see ShellSidebarSection's icon map), rendered left of the title. */
+  icon?: string;
 }
 
 export interface ShellTabDto {

--- a/src/Ivy.Tendril.Widgets/frontend/src/index.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/index.ts
@@ -7,6 +7,7 @@ import { ContentInput } from "./ContentInput/ContentInput";
 import { BadgeSelect } from "./BadgeSelect";
 import { PlanDiffView } from "./PlanDiffView/PlanDiffView";
 import { ChatWidget } from "./ChatWidget/ChatWidget";
+import { TerminalSessionHeader } from "./ChatWidget/TerminalSessionHeader";
 import { WebViewer } from "./WebViewer";
 import { TendrilShell } from "./Shell/TendrilShell";
 import { ShellSidebarHeader } from "./Shell/ShellSidebarHeader";
@@ -30,6 +31,7 @@ if (typeof window !== "undefined") {
     BadgeSelect,
     PlanDiffView,
     ChatWidget,
+    TerminalSessionHeader,
     WebViewer,
     TendrilShell,
     ShellSidebarHeader,
@@ -54,6 +56,7 @@ export {
   BadgeSelect,
   PlanDiffView,
   ChatWidget,
+  TerminalSessionHeader,
   WebViewer,
   TendrilShell,
   ShellSidebarHeader,

--- a/src/Ivy.Tendril/AppShell/AppShellRouter.cs
+++ b/src/Ivy.Tendril/AppShell/AppShellRouter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using Ivy.Core.Apps;
+using Ivy.Tendril.Apps.Agent;
 
 namespace Ivy.Tendril.AppShell;
 
@@ -87,6 +88,22 @@ internal class AppShellRouter
 
         if (appDescriptor?.AllowDuplicateTabs == true)
         {
+            // A terminal session's pane is keyed by its chat session id; reopening the same
+            // session reveals the existing pane instead of spawning a second agent.
+            if (navigateArgs.AppArgs is AgentAppArgs { SessionId: { Length: > 0 } sessionId })
+            {
+                var existingIndex = FindTabIndex(sessionTabs, sessionId);
+                if (existingIndex >= 0)
+                {
+                    return new RouteResult
+                    {
+                        Action = RouteAction.SwitchToExistingTab,
+                        TabIndex = existingIndex,
+                        TabId = sessionId
+                    };
+                }
+            }
+
             return new RouteResult
             {
                 Action = RouteAction.CreateNewTab,

--- a/src/Ivy.Tendril/AppShell/ShellSidebarListSignal.cs
+++ b/src/Ivy.Tendril/AppShell/ShellSidebarListSignal.cs
@@ -22,7 +22,9 @@ public record ShellSidebarListState(
     Func<string, object?> BuildSelectArgs,
     bool Searchable = true,
     Action? OnSearch = null,
-    string? SearchLabel = null);
+    string? SearchLabel = null,
+    Action? OnNew = null,
+    string? NewLabel = null);
 
 [Signal(BroadcastType.AppShell)]
 public class ShellSidebarListSignal : AbstractSignal<ShellSidebarListState, Unit> { }

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -344,6 +344,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             {
                 sessionsVersion.Set(v => v + 1);
                 CloseTabsOfDeletedSessions();
+                if (selectedIndex.Value is { } active && CheckTabExists(active) && IsAgentTab(tabs.Value[active]))
+                    SetTabTitle(tabs.Value[active]);
             }
 
             chatService.SessionsChanged += OnSessionsChanged;

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -7,6 +7,8 @@ using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Agent;
+using Ivy.Tendril.Apps.Chat;
+using Ivy.Tendril.Apps.Chat.Dialogs;
 using Ivy.Tendril.Apps.Icebox;
 using Ivy.Tendril.Apps.Onboarding;
 using Ivy.Tendril.Apps.PullRequest;
@@ -119,6 +121,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
     // The Agent app id (and its menu-item Tag) collapses to "agent" via AppHelpers.GetApp.
     private const string AgentAppId = "agent";
+    private const string ChatAppId = "chat";
     private const string InboxAppId = "inbox";
 
     private static readonly HashSet<string> SidebarSectionAppIds = new(StringComparer.OrdinalIgnoreCase)
@@ -200,8 +203,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
     }
 
     /// <summary>
-    ///     Flattens the app menu into the sidebar nav rows. The agent entry is excluded — it is
-    ///     rendered as the dedicated agent button above the nav instead — as are the apps in
+    ///     Flattens the app menu into the sidebar nav rows. The agent and chat entries are excluded — they
+    ///     are reached through the dedicated Chat button above the nav instead — as are the apps in
     ///     <paramref name="footerAppIds"/>, which get their own button in the sidebar footer.
     /// </summary>
     internal static List<ShellNavItemDto> BuildNavItems(MenuItem[] menuItems, string? activeAppId,
@@ -211,7 +214,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
         void AddLeaf(MenuItem item)
         {
-            if (item.Tag is not string tag || tag == AgentAppId) return;
+            if (item.Tag is not string tag || tag == AgentAppId || tag == ChatAppId) return;
             if (footerAppIds?.Contains(tag, StringComparer.OrdinalIgnoreCase) == true) return;
             result.Add(new ShellNavItemDto(
                 tag,
@@ -261,6 +264,9 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var sidebarListSignal = Context.UseSignal<ShellSidebarListSignal, ShellSidebarListState, Unit>();
         var navigator = UseNavigation();
         var jobService = UseService<IJobService>();
+        var chatService = UseService<IChatHistoryService>();
+        Context.TryUseService<IChatSessionNamingService>(out var namingService);
+        var sessionsVersion = UseState(0);
         Context.TryUseService<DesktopWindow>(out var desktopWindow);
         Context.TryUseService<TendrilArgs>(out var tendrilArgs);
 
@@ -274,6 +280,13 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         {
             if (!isOpen.Value) return null;
             return new PlanSearchDialog(isOpen);
+        });
+
+        var (chatSearchDialog, showChatSearchDialog) = UseTrigger((isOpen) =>
+        {
+            if (!isOpen.Value) return null;
+            return new ChatSearchDialog(isOpen, chatService,
+                sessionId => navigator.Navigate(typeof(ChatApp), new ChatAppArgs(SessionId: sessionId)));
         });
 
         var isShareMode = shareContext.IsShareMode;
@@ -320,6 +333,21 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             }
             config.SettingsReloaded += OnSettingsReloaded;
             return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);
+        });
+
+        // Terminal panes are keyed by their chat session: when a session is deleted (from the
+        // pane's own header or the chat app) the pane closes with it. Renames re-render the
+        // Chats list the shell draws while a terminal pane is visible.
+        UseEffect(() =>
+        {
+            void OnSessionsChanged(object? sender, EventArgs e)
+            {
+                sessionsVersion.Set(v => v + 1);
+                CloseTabsOfDeletedSessions();
+            }
+
+            chatService.SessionsChanged += OnSessionsChanged;
+            return Disposable.Create(() => chatService.SessionsChanged -= OnSessionsChanged);
         });
 
         UseEffect(() =>
@@ -406,6 +434,12 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             client.Redirect(navigateArgs.GetUrl(includeArgs: settings.IncludeArgsInUrl), replaceHistory, tabId);
         }
 
+        bool IsTerminalSession(string? sessionId) =>
+            !string.IsNullOrEmpty(sessionId) && chatService.GetSession(sessionId)?.IsTerminal() == true;
+
+        static bool IsAgentTab(TabState tab) =>
+            string.Equals(tab.AppId, AgentAppId, StringComparison.OrdinalIgnoreCase);
+
         void OpenApp(NavigateArgs navigateArgs, bool replaceHistory = false)
         {
             try
@@ -413,6 +447,14 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 if (isShareMode && navigateArgs.AppId != null && !ShareAllowedAppIds.Contains(navigateArgs.AppId))
                 {
                     navigateArgs = navigateArgs with { AppId = "review" };
+                }
+
+                // The Chats list holds terminal sessions too; picking one opens its pane, not the chat page.
+                if (string.Equals(navigateArgs.AppId, ChatAppId, StringComparison.OrdinalIgnoreCase)
+                    && navigateArgs.AppArgs is ChatAppArgs { SessionId: { Length: > 0 } chatSessionId }
+                    && IsTerminalSession(chatSessionId))
+                {
+                    navigateArgs = navigateArgs with { AppId = AgentAppId, AppArgs = new AgentAppArgs(SessionId: chatSessionId) };
                 }
 
                 var router = new AppShellRouter();
@@ -504,17 +546,46 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 RedirectToAppIfNotError(effectiveNavigateArgs, replaceHistory);
         }
 
+        void SetTabTitle(TabState tab)
+        {
+            if (!IsAgentTab(tab))
+            {
+                SetAppTitle(tab.AppId);
+                return;
+            }
+            var session = chatService.GetSession(tab.Id);
+            client.SetTitle(session != null ? ChatApp.DisplayTitle(session) : tab.Title, serverArgs.Metadata.Title);
+        }
+
         void HandleSwitchToExistingTab(NavigateArgs navigateArgs, int tabIndex,
             string tabId, bool replaceHistory)
         {
             var previousSelectedIndex = selectedIndex.Value;
             selectedIndex.Set(tabIndex);
             lastSessionIndex.Value = tabIndex;
-            var tab = tabs.Value[tabIndex];
-            SetAppTitle(tab.AppId);
+            SetTabTitle(tabs.Value[tabIndex]);
 
             if (navigateArgs.HistoryOp is HistoryOp.Push && previousSelectedIndex != tabIndex)
                 RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
+        }
+
+        // A terminal pane is backed by a chat session (Kind = terminal) so it lists beside the
+        // chats; the session is created here, on first open, so the pane and its sidebar row share
+        // the id. The initial prompt is kept as the session's first message and names the session.
+        ChatSessionModel EnsureTerminalSession(AgentAppArgs agentArgs)
+        {
+            if (!string.IsNullOrEmpty(agentArgs.SessionId) && chatService.GetSession(agentArgs.SessionId) is { } existing)
+                return existing;
+
+            var agent = config.Settings.CodingAgent ?? "claude";
+            var session = chatService.CreateSession(agent, "default", title: agentArgs.Title, kind: ChatSessionKinds.Terminal);
+            if (!string.IsNullOrWhiteSpace(agentArgs.Prompt))
+            {
+                chatService.AddMessage(session.Id, "user", agentArgs.Prompt, agent);
+                if (namingService != null && ChatSessionNamingService.IsDefaultTitle(session.Title))
+                    _ = namingService.GenerateAndSetTitleAsync(session.Id, agentArgs.Prompt, agent);
+            }
+            return session;
         }
 
         void HandleCreateNewTab(NavigateArgs navigateArgs, string effectiveAppId,
@@ -522,19 +593,40 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         {
             if (navigateArgs.HistoryOp is not HistoryOp.Push) return;
 
-            var tabId = Guid.NewGuid().ToString();
-            var appHost = navigateArgs.ToAppHost(args.ConnectionId);
             var app = appRepository.GetAppOrDefault(effectiveAppId);
             var (tabTitle, tabIcon) = BrandedAppDisplay(app);
-            tabTitle = ResolveArgsTabTitle(navigateArgs.AppArgs) ?? tabTitle;
+            var tabId = Guid.NewGuid().ToString();
 
-            var newTabs = tabs.Value.Add(new TabState(tabId, app.Id, tabTitle, appHost,
-                tabIcon, Guid.NewGuid().ToString()));
+            if (app.Id == AgentAppId)
+            {
+                var agentArgs = navigateArgs.AppArgs as AgentAppArgs ?? new AgentAppArgs();
+                var session = EnsureTerminalSession(agentArgs);
+                navigateArgs = navigateArgs with { AppArgs = agentArgs with { SessionId = session.Id } };
+                tabId = session.Id;
+                tabTitle = ChatApp.DisplayTitle(session);
+            }
+            else
+            {
+                tabTitle = ResolveArgsTabTitle(navigateArgs.AppArgs) ?? tabTitle;
+            }
+
+            var appHost = navigateArgs.ToAppHost(args.ConnectionId);
+            var newTab = new TabState(tabId, app.Id, tabTitle, appHost, tabIcon, Guid.NewGuid().ToString());
+            var newTabs = tabs.Value.Add(newTab);
             tabs.Set(newTabs);
             selectedIndex.Set(newTabs.Length - 1);
             lastSessionIndex.Value = newTabs.Length - 1;
-            SetAppTitle(app.Id);
+            SetTabTitle(newTab);
             RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
+        }
+
+        void CloseTabsOfDeletedSessions()
+        {
+            for (var i = tabs.Value.Length - 1; i >= 0; i--)
+            {
+                var tab = tabs.Value[i];
+                if (IsAgentTab(tab) && chatService.GetSession(tab.Id) == null) OnTabClose(i);
+            }
         }
 
         bool CheckTabExists(int tabIndex)
@@ -557,7 +649,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             selectedIndex.Set(tabIndex);
             lastSessionIndex.Value = tabIndex;
             var tab = tabs.Value[tabIndex];
-            SetAppTitle(tab.AppId);
+            SetTabTitle(tab);
             RedirectToAppIfNotError(new NavigateArgs(tab.AppId), tabId: tab.Id);
         }
 
@@ -594,7 +686,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             if (newIndex is { } idx)
             {
                 var tab = newTabs[idx];
-                SetAppTitle(tab.AppId);
+                SetTabTitle(tab);
                 RedirectToAppIfNotError(new NavigateArgs(tab.AppId), tabId: tab.Id);
             }
             else if (currentApp.Value is { } page)
@@ -699,34 +791,71 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .OnClick(() => open())
         ));
 
-        // While a session pane is visible the agent row is the selected item, so the
+        // While a session pane is visible the chat row is the selected item, so the
         // nav must not keep highlighting the page app behind it.
         var sessionIsActive = selectedIndex.Value is { } activeSession && CheckTabExists(activeSession);
         var activeNavAppId = sessionIsActive ? null : currentApp.Value?.AppId;
+        var activeTerminalTab = sessionIsActive && IsAgentTab(tabs.Value[selectedIndex.Value!.Value])
+            ? tabs.Value[selectedIndex.Value!.Value]
+            : null;
+        var chatIsActive = activeTerminalTab != null
+                           || (!sessionIsActive && string.Equals(currentApp.Value?.AppId, ChatAppId, StringComparison.OrdinalIgnoreCase));
 
-        var (agentLabel, _) = AgentBranding.For(config.Settings.CodingAgent, agentRunner, config);
-        var agentButton = new ShellAgentButton()
-            .IsActive(sessionIsActive)
-            .Label(agentLabel)
-            .Icon(AgentBranding.IconFor(config.Settings.CodingAgent, config).ToString())
-            .OnOpen(() =>
+        int? LatestTerminalTabIndex()
+        {
+            if (lastSessionIndex.Value is { } last && CheckTabExists(last) && IsAgentTab(tabs.Value[last])) return last;
+            for (var i = tabs.Value.Length - 1; i >= 0; i--)
+                if (IsAgentTab(tabs.Value[i])) return i;
+            return null;
+        }
+
+        // The Chat row opens the configured session kind: the chat page, or (chatMode: terminal)
+        // the latest terminal pane. The chord always starts a fresh session of that kind.
+        void OpenChat()
+        {
+            if (!ChatLauncher.UsesTerminal(config))
             {
-                if (tabs.Value.Length == 0)
-                {
-                    OpenApp(new NavigateArgs(AgentAppId));
-                    return;
-                }
-                var latest = lastSessionIndex.Value is { } last && CheckTabExists(last)
-                    ? last
-                    : tabs.Value.Length - 1;
+                OpenApp(new NavigateArgs(ChatAppId));
+                return;
+            }
+            if (LatestTerminalTabIndex() is { } latest)
+            {
                 SelectSession(latest);
-            })
-            .OnNewChat(() => OpenApp(new NavigateArgs(AgentAppId)));
+                return;
+            }
+            OpenApp(new NavigateArgs(AgentAppId));
+        }
+
+        void StartNewChat() => ChatLauncher.StartNew(navigator, config, chatService, agentRunner);
+
+        var chatButton = new ShellAgentButton()
+            .IsActive(chatIsActive)
+            .Label("Chat")
+            .Icon(Icons.MessageCircle.ToString())
+            .OnOpen(OpenChat)
+            .OnNewChat(StartNewChat);
 
         // Plan search is always reachable from the sidebar: apps without a list (and lists
         // with no rows) get the section's full-width Search button in place of the title.
+        // A visible terminal pane shows the Chats list with its own row selected, whatever
+        // page sits behind it.
+        _ = sessionsVersion.Value;
+        var list = sidebarList.Value is { } published && UsesSidebarList(published.AppId, currentApp.Value?.AppId)
+            ? published
+            : null;
+        if (activeTerminalTab != null)
+        {
+            list = ChatApp.BuildSidebarList(
+                chatService.GetSessions(),
+                activeTerminalTab.Id,
+                chatService.GetGeneratingSessionIds(),
+                chatService.GetCompletedSessionIds(),
+                showChatSearchDialog,
+                StartNewChat);
+        }
+
         ShellSidebarSection section;
-        if (sidebarList.Value is { } list && UsesSidebarList(list.AppId, currentApp.Value?.AppId))
+        if (list != null)
         {
             var capturedList = list;
             section = new ShellSidebarSection()
@@ -735,9 +864,11 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .SelectedId(list.SelectedId)
                 .Searchable(list.Searchable)
                 .SearchLabel(list.SearchLabel)
+                .NewLabel(list.NewLabel)
                 .OnSelectItem(itemId =>
                     OpenApp(new NavigateArgs(capturedList.AppId, capturedList.BuildSelectArgs(itemId))))
-                .OnSearch(list.OnSearch ?? showPlanSearchDialog);
+                .OnSearch(list.OnSearch ?? showPlanSearchDialog)
+                .OnNew(list.OnNew);
         }
         else
         {
@@ -780,12 +911,15 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             .Select(t => (object?)t.AppHost.Key(StringHelper.GetShortHash(t.Id + t.RefreshToken)))
             .ToArray();
 
+        // Terminal panes are reached from the Chats list, so the strip only shows the other
+        // session tabs (review actions).
+        var stripTabs = tabs.Value.Where(t => !IsAgentTab(t)).ToList();
         var tabsWidget = new ShellTabs()
-            .Tabs(tabs.Value.Select(t => new ShellTabDto(t.Id, t.Title)).ToList())
+            .Tabs(stripTabs.Select(t => new ShellTabDto(t.Id, t.Title)).ToList())
             .SelectedId(selectedIndex.Value is { } si && CheckTabExists(si) ? tabs.Value[si].Id : null)
             .OnSelect(tabId => SelectSession(FindTabIndexById(tabId)))
             .OnClose(tabId => OnTabClose(FindTabIndexById(tabId)))
-            .OnNew(() => OpenApp(new NavigateArgs(AgentAppId)));
+            .OnNew(StartNewChat);
 
         // Cmd+W (Ctrl+W on Windows) closes the active session tab, matching desktop-app convention.
         // ShortcutKey is the only shortcut API Ivy exposes, so the binding lives on a zero-width
@@ -848,14 +982,14 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 sidebarHeader: sidebarHeader,
                 sidebarBody: isShareMode
                     ? [nav, section]
-                    : [newPlanButton, agentButton, nav, section],
+                    : [newPlanButton, chatButton, nav, section],
                 sidebarFooter: sidebarFooter,
                 content: pageContent,
                 sessionContents: sessionContents,
                 tabs: tabsWidget,
                 hidden: [selectInputWarmup, closeTabShortcut])
             .Collapsed(!sidebarOpen.Value)
-            .HasTabs(tabs.Value.Length > 0)
+            .HasTabs(stripTabs.Count > 0)
             .ActiveSessionIndex(selectedIndex.Value)
             .OnCollapsedChanged(collapsed =>
             {
@@ -865,7 +999,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         return new Fragment(
             shell,
             updateDialog,
-            planSearchDialog
+            planSearchDialog,
+            chatSearchDialog
         );
     }
 

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -203,8 +203,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
     }
 
     /// <summary>
-    ///     Flattens the app menu into the sidebar nav rows. The agent and chat entries are excluded — they
-    ///     are reached through the dedicated Chat button above the nav instead — as are the apps in
+    ///     Flattens the app menu into the sidebar nav rows. The agent and chat entries are excluded (they
+    ///     are reached through the dedicated Chat button above the nav instead), as are the apps in
     ///     <paramref name="footerAppIds"/>, which get their own button in the sidebar footer.
     /// </summary>
     internal static List<ShellNavItemDto> BuildNavItems(MenuItem[] menuItems, string? activeAppId,
@@ -267,6 +267,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var chatService = UseService<IChatHistoryService>();
         Context.TryUseService<IChatSessionNamingService>(out var namingService);
         var sessionsVersion = UseState(0);
+        var sessionsSignature = UseRef<string?>(null);
         Context.TryUseService<DesktopWindow>(out var desktopWindow);
         Context.TryUseService<TendrilArgs>(out var tendrilArgs);
 
@@ -340,8 +341,14 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         // Chats list the shell draws while a terminal pane is visible.
         UseEffect(() =>
         {
+            // SessionsChanged also fires for every persisted message chunk; only a change in the
+            // set of sessions or their titles concerns the shell.
             void OnSessionsChanged(object? sender, EventArgs e)
             {
+                var signature = ChatLauncher.SessionListSignature(chatService.GetSessions());
+                if (signature == sessionsSignature.Value) return;
+                sessionsSignature.Value = signature;
+
                 sessionsVersion.Set(v => v + 1);
                 CloseTabsOfDeletedSessions();
                 if (selectedIndex.Value is { } active && CheckTabExists(active) && IsAgentTab(tabs.Value[active]))
@@ -386,6 +393,16 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                     targetAppId = defaultAppId;
 
                 var appArgs = args.GetArgs<object>();
+
+                // Args are hidden from the URL, so a reloaded terminal pane has no session: resume
+                // the latest terminal session instead of persisting a fresh one on every refresh.
+                if (string.Equals(targetAppId, AgentAppId, StringComparison.OrdinalIgnoreCase) && appArgs == null)
+                {
+                    var resumed = ChatLauncher.LatestTerminalSessionId(chatService.GetSessions());
+                    if (resumed != null) appArgs = new AgentAppArgs(SessionId: resumed);
+                    else targetAppId = defaultAppId;
+                }
+
                 OpenApp(new NavigateArgs(targetAppId, appArgs), true);
             }
             else
@@ -825,7 +842,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 SelectSession(latest);
                 return;
             }
-            OpenApp(new NavigateArgs(AgentAppId));
+            var resumed = ChatLauncher.LatestTerminalSessionId(chatService.GetSessions());
+            OpenApp(new NavigateArgs(AgentAppId, resumed != null ? new AgentAppArgs(SessionId: resumed) : null));
         }
 
         void StartNewChat() => ChatLauncher.StartNew(navigator, config, chatService, agentRunner);

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -342,10 +342,11 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         UseEffect(() =>
         {
             // SessionsChanged also fires for every persisted message chunk; only a change in the
-            // set of sessions or their titles concerns the shell.
+            // sessions, their titles or their working state concerns the shell's Chats list.
             void OnSessionsChanged(object? sender, EventArgs e)
             {
-                var signature = ChatLauncher.SessionListSignature(chatService.GetSessions());
+                var signature = ChatLauncher.SessionListSignature(
+                    chatService.GetSessions(), chatService.GetGeneratingSessionIds(), chatService.GetCompletedSessionIds());
                 if (signature == sessionsSignature.Value) return;
                 sessionsSignature.Value = signature;
 
@@ -356,7 +357,12 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             }
 
             chatService.SessionsChanged += OnSessionsChanged;
-            return Disposable.Create(() => chatService.SessionsChanged -= OnSessionsChanged);
+            chatService.GeneratingSessionsChanged += OnSessionsChanged;
+            return Disposable.Create(() =>
+            {
+                chatService.SessionsChanged -= OnSessionsChanged;
+                chatService.GeneratingSessionsChanged -= OnSessionsChanged;
+            });
         });
 
         UseEffect(() =>
@@ -396,11 +402,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
                 // Args are hidden from the URL, so a reloaded terminal pane has no session: resume
                 // the latest terminal session instead of persisting a fresh one on every refresh.
-                if (string.Equals(targetAppId, AgentAppId, StringComparison.OrdinalIgnoreCase) && appArgs == null)
+                if (string.Equals(targetAppId, AgentAppId, StringComparison.OrdinalIgnoreCase) && appArgs == null
+                    && ChatLauncher.LatestTerminalSessionId(chatService.GetSessions()) is { } resumed)
                 {
-                    var resumed = ChatLauncher.LatestTerminalSessionId(chatService.GetSessions());
-                    if (resumed != null) appArgs = new AgentAppArgs(SessionId: resumed);
-                    else targetAppId = defaultAppId;
+                    appArgs = new AgentAppArgs(SessionId: resumed);
                 }
 
                 OpenApp(new NavigateArgs(targetAppId, appArgs), true);

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -136,7 +136,7 @@ public class AgentApp : ViewBase
             .Closed(ptyHandle.Closed)
             .AllowClipboard()
             .Loading($"Starting {agentLabel}...")
-            .Height(Size.Grow());
+            .Height(Size.Full());
 
         var pane = Layout.Vertical().Gap(0).Full().RemoveParentPadding()
                    | header

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -74,7 +74,10 @@ public class AgentApp : ViewBase
         {
             void Refresh()
             {
-                var key = HeaderKey(chatService, jobService, args?.SessionId);
+                var sessionId = args?.SessionId;
+                var key = string.IsNullOrEmpty(sessionId)
+                    ? ""
+                    : HeaderKey(chatService.GetSession(sessionId), SessionJobs(jobService, sessionId));
                 if (key == headerKey.Value) return;
                 headerKey.Value = key;
                 sessionVersion.Set(v => v + 1);
@@ -114,7 +117,7 @@ public class AgentApp : ViewBase
             .SessionId(session?.Id ?? "")
             .Title(title)
             .Jobs(jobs)
-            .Spawned(session?.SpawnedJobIds is { Count: > 0 })
+            .Spawned(jobs.Count > 0)
             .OnRenameSession((id, newTitle) =>
             {
                 chatService.RenameSession(id, newTitle);
@@ -145,13 +148,8 @@ public class AgentApp : ViewBase
     private static IEnumerable<JobItem> SessionJobs(IJobService? jobService, string sessionId) =>
         jobService?.GetJobs().Where(j => string.Equals(j.ChatSessionId, sessionId, StringComparison.OrdinalIgnoreCase)) ?? [];
 
-    internal static string HeaderKey(IChatHistoryService chatService, IJobService? jobService, string? sessionId)
-    {
-        if (string.IsNullOrEmpty(sessionId)) return "";
-        var session = chatService.GetSession(sessionId);
-        var jobs = string.Join(",", SessionJobs(jobService, sessionId).Select(j => j.Id + ":" + j.Status));
-        return $"{session?.Title}|{session?.SpawnedJobIds?.Count ?? 0}|{jobs}";
-    }
+    internal static string HeaderKey(ChatSessionModel? session, IEnumerable<JobItem> jobs) =>
+        $"{session?.Title}|" + string.Join(",", jobs.Select(j => $"{j.Id}:{j.Status}:{j.StatusMessage}:{j.ReportedPlanId}:{j.ReportedPlanTitle}"));
 
     private static Dictionary<string, string> BuildEnvironment(IConfigService config, string? sessionId)
     {

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 using Ivy.Hooks.Pty;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
-using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps.Chat;
 using Ivy.Tendril.Apps.Chat.Dialogs;
 using Ivy.Tendril.Helpers;
@@ -27,12 +26,11 @@ public class AgentApp : ViewBase
         var agentRunner = UseService<IAgentRunner>();
         var chatService = UseService<IChatHistoryService>();
         Context.TryUseService<IJobService>(out var jobService);
-        Context.TryUseService<IPlanReaderService>(out var planService);
         var navigator = UseNavigation();
         var args = UseArgs<AgentAppArgs>();
         var sessionVersion = UseState(0);
         var deletingSessionId = UseState<string?>(null);
-        var activeSessionId = UseState<string?>(() => args?.SessionId);
+        var headerKey = UseRef<string?>(null);
 
         // The initial task is delivered as a command-line argument (see each provider's
         // BuildPtySpec) so the agent auto-runs it on launch — no fragile "wait then paste"
@@ -70,10 +68,20 @@ public class AgentApp : ViewBase
             }
         );
 
+        // Both events fire for every session and job in the process; only this pane's own
+        // title and jobs are worth a rebuild.
         UseEffect(() =>
         {
-            void OnSessionsChanged(object? sender, EventArgs e) => sessionVersion.Set(v => v + 1);
-            void OnJobsChanged() => sessionVersion.Set(v => v + 1);
+            void Refresh()
+            {
+                var key = HeaderKey(chatService, jobService, args?.SessionId);
+                if (key == headerKey.Value) return;
+                headerKey.Value = key;
+                sessionVersion.Set(v => v + 1);
+            }
+
+            void OnSessionsChanged(object? sender, EventArgs e) => Refresh();
+            void OnJobsChanged() => Refresh();
 
             chatService.SessionsChanged += OnSessionsChanged;
             if (jobService != null) jobService.JobsChanged += OnJobsChanged;
@@ -98,18 +106,15 @@ public class AgentApp : ViewBase
         var (agentLabel, _) = AgentBranding.For(configService.Settings.CodingAgent, agentRunner, configService);
         var title = session != null ? ChatApp.DisplayTitle(session) : (args?.Title ?? agentLabel);
 
-        var jobs = session != null && jobService != null
-            ? jobService.GetJobs()
-                .Where(j => string.Equals(j.ChatSessionId, session.Id, StringComparison.OrdinalIgnoreCase))
-                .Select(ChatApp.ToJobDto)
-                .ToList()
+        var jobs = session != null
+            ? SessionJobs(jobService, session.Id).Select(ChatApp.ToJobDto).ToList()
             : [];
 
         var header = new TerminalSessionHeader()
             .SessionId(session?.Id ?? "")
             .Title(title)
             .Jobs(jobs)
-            .Spawned(jobs.Count > 0)
+            .Spawned(session?.SpawnedJobIds is { Count: > 0 })
             .OnRenameSession((id, newTitle) =>
             {
                 chatService.RenameSession(id, newTitle);
@@ -117,17 +122,9 @@ public class AgentApp : ViewBase
             })
             .OnDeleteSession(id => deletingSessionId.Set(id))
             .OnCreateSession(() => ChatLauncher.StartNew(navigator, configService, chatService, agentRunner))
-            .OnOpenPlan(planId =>
-            {
-                if (planService == null || string.IsNullOrEmpty(planId)) return;
-                var plan = ContentView.FindPlan(planService, planId);
-                if (plan == null) return;
-                var (app, appArgs) = PlanSearchDialog.ResolveTarget(plan);
-                navigator.Navigate(app, appArgs);
-            })
             .OnReviewJobs(() => ptyHandle.HandleInput(ReviewJobsPrompt + "\r"));
 
-        var deleteDialog = new DeleteSessionDialog(deletingSessionId, session, chatService, activeSessionId, sessionVersion);
+        var deleteDialog = new DeleteSessionDialog(deletingSessionId, session, chatService, null, sessionVersion);
 
         var terminal = new Xterm.Terminal()
             .Stream(ptyHandle.Stream)
@@ -143,6 +140,17 @@ public class AgentApp : ViewBase
                    | terminal;
 
         return new Fragment(pane, deleteDialog);
+    }
+
+    private static IEnumerable<JobItem> SessionJobs(IJobService? jobService, string sessionId) =>
+        jobService?.GetJobs().Where(j => string.Equals(j.ChatSessionId, sessionId, StringComparison.OrdinalIgnoreCase)) ?? [];
+
+    internal static string HeaderKey(IChatHistoryService chatService, IJobService? jobService, string? sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return "";
+        var session = chatService.GetSession(sessionId);
+        var jobs = string.Join(",", SessionJobs(jobService, sessionId).Select(j => j.Id + ":" + j.Status));
+        return $"{session?.Title}|{session?.SpawnedJobIds?.Count ?? 0}|{jobs}";
     }
 
     private static Dictionary<string, string> BuildEnvironment(IConfigService config, string? sessionId)

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -1,10 +1,16 @@
+using System.Reactive.Disposables;
 using System.Text;
 using System.Text.RegularExpressions;
 using Ivy.Hooks.Pty;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
+using Ivy.Tendril.AppShell.Dialogs;
+using Ivy.Tendril.Apps.Chat;
+using Ivy.Tendril.Apps.Chat.Dialogs;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Widgets;
 using Ivy.Widgets.Xterm;
 using Xterm = Ivy.Widgets.Xterm;
 
@@ -13,11 +19,20 @@ namespace Ivy.Tendril.Apps.Agent;
 [App(title: "Agent", icon: Icons.Terminal, group: ["Apps"], order: Constants.Agent, isVisible: true, allowDuplicateTabs: true)]
 public class AgentApp : ViewBase
 {
+    private const string ReviewJobsPrompt = "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.";
+
     public override object Build()
     {
         var configService = UseService<IConfigService>();
         var agentRunner = UseService<IAgentRunner>();
+        var chatService = UseService<IChatHistoryService>();
+        Context.TryUseService<IJobService>(out var jobService);
+        Context.TryUseService<IPlanReaderService>(out var planService);
+        var navigator = UseNavigation();
         var args = UseArgs<AgentAppArgs>();
+        var sessionVersion = UseState(0);
+        var deletingSessionId = UseState<string?>(null);
+        var activeSessionId = UseState<string?>(() => args?.SessionId);
 
         // The initial task is delivered as a command-line argument (see each provider's
         // BuildPtySpec) so the agent auto-runs it on launch — no fragile "wait then paste"
@@ -37,7 +52,7 @@ public class AgentApp : ViewBase
             AgentLaunchHelper.GetWorkDir(configService, agentRunner),
             new PtyOptions
             {
-                Environment = AgentLaunchHelper.GetEnvironment(configService),
+                Environment = BuildEnvironment(configService, args?.SessionId),
                 OnOutput = text =>
                 {
                     var (regex, accept) = trust.Value;
@@ -55,6 +70,20 @@ public class AgentApp : ViewBase
             }
         );
 
+        UseEffect(() =>
+        {
+            void OnSessionsChanged(object? sender, EventArgs e) => sessionVersion.Set(v => v + 1);
+            void OnJobsChanged() => sessionVersion.Set(v => v + 1);
+
+            chatService.SessionsChanged += OnSessionsChanged;
+            if (jobService != null) jobService.JobsChanged += OnJobsChanged;
+            return Disposable.Create(() =>
+            {
+                chatService.SessionsChanged -= OnSessionsChanged;
+                if (jobService != null) jobService.JobsChanged -= OnJobsChanged;
+            });
+        });
+
         // Wire the input sink + trust pattern now that the handle exists (OnOutput is supplied first).
         sendInput.Value = ptyHandle.HandleInput;
         var patterns = AgentLaunchHelper.GetActivityPatterns(configService, agentRunner);
@@ -64,18 +93,63 @@ public class AgentApp : ViewBase
                 : null,
             patterns?.TrustAcceptInput is { Length: > 0 } accept ? accept : "\r");
 
+        _ = sessionVersion.Value;
+        var session = !string.IsNullOrEmpty(args?.SessionId) ? chatService.GetSession(args.SessionId) : null;
+        var (agentLabel, _) = AgentBranding.For(configService.Settings.CodingAgent, agentRunner, configService);
+        var title = session != null ? ChatApp.DisplayTitle(session) : (args?.Title ?? agentLabel);
+
+        var jobs = session != null && jobService != null
+            ? jobService.GetJobs()
+                .Where(j => string.Equals(j.ChatSessionId, session.Id, StringComparison.OrdinalIgnoreCase))
+                .Select(ChatApp.ToJobDto)
+                .ToList()
+            : [];
+
+        var header = new TerminalSessionHeader()
+            .SessionId(session?.Id ?? "")
+            .Title(title)
+            .Jobs(jobs)
+            .Spawned(jobs.Count > 0)
+            .OnRenameSession((id, newTitle) =>
+            {
+                chatService.RenameSession(id, newTitle);
+                sessionVersion.Set(v => v + 1);
+            })
+            .OnDeleteSession(id => deletingSessionId.Set(id))
+            .OnCreateSession(() => ChatLauncher.StartNew(navigator, configService, chatService, agentRunner))
+            .OnOpenPlan(planId =>
+            {
+                if (planService == null || string.IsNullOrEmpty(planId)) return;
+                var plan = ContentView.FindPlan(planService, planId);
+                if (plan == null) return;
+                var (app, appArgs) = PlanSearchDialog.ResolveTarget(plan);
+                navigator.Navigate(app, appArgs);
+            })
+            .OnReviewJobs(() => ptyHandle.HandleInput(ReviewJobsPrompt + "\r"));
+
+        var deleteDialog = new DeleteSessionDialog(deletingSessionId, session, chatService, activeSessionId, sessionVersion);
+
         var terminal = new Xterm.Terminal()
             .Stream(ptyHandle.Stream)
             .OnInput(ptyHandle.HandleInput)
             .OnResize(ptyHandle.HandleResize)
             .Closed(ptyHandle.Closed)
             .AllowClipboard()
-            .Loading($"Starting {agentRunner.GetCli(configService.Settings.CodingAgent).DisplayName}...");
+            .Loading($"Starting {agentLabel}...")
+            .Height(Size.Grow());
 
-        return terminal
-            .WithLayout()
-            .Full()
-            .RemoveParentPadding();
+        var pane = Layout.Vertical().Gap(0).Full().RemoveParentPadding()
+                   | header
+                   | terminal;
+
+        return new Fragment(pane, deleteDialog);
+    }
+
+    private static Dictionary<string, string> BuildEnvironment(IConfigService config, string? sessionId)
+    {
+        var env = AgentLaunchHelper.GetEnvironment(config);
+        if (!string.IsNullOrEmpty(sessionId)) env["TENDRIL_CHAT_SESSION_ID"] = sessionId;
+        return env;
     }
 
     private static string[] GetCommandLine(IConfigService config, IAgentRunner runner, string? initialPrompt)

--- a/src/Ivy.Tendril/Apps/Agent/AgentAppArgs.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentAppArgs.cs
@@ -3,7 +3,7 @@ namespace Ivy.Tendril.Apps.Agent;
 /// <summary>
 ///     Args for <see cref="AgentApp"/>. <paramref name="Title"/> is the fully-formatted tab title
 ///     (e.g. "#85"), built by the caller; when set, the shell uses it verbatim instead of the
-///     branded agent label. See TendrilAppShell.ResolveArgsTabTitle and
-///     TendrilAppShell.FormatPlanId for the helper callers should use to build it.
+///     branded agent label. <paramref name="SessionId"/> is the terminal's chat session, which the
+///     shell assigns when it opens the pane; callers leave it null.
 /// </summary>
-public record AgentAppArgs(string? Prompt = null, string? Title = null);
+public record AgentAppArgs(string? Prompt = null, string? Title = null, string? SessionId = null);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -164,7 +164,7 @@ public class ChatApp : ViewBase
             var sess = chatService.GetSession(sessionId);
             if (sess?.IsTerminal() == true)
             {
-                navigator.Navigate(typeof(ChatApp), new ChatAppArgs(SessionId: sessionId));
+                navigator.Navigate(typeof(AgentApp), new AgentAppArgs(SessionId: sessionId));
                 return;
             }
             activeSessionId.Set(sessionId);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -161,9 +161,14 @@ public class ChatApp : ViewBase
 
         void SelectSession(string sessionId)
         {
+            var sess = chatService.GetSession(sessionId);
+            if (sess?.IsTerminal() == true)
+            {
+                navigator.Navigate(typeof(ChatApp), new ChatAppArgs(SessionId: sessionId));
+                return;
+            }
             activeSessionId.Set(sessionId);
             chatService.ClearSessionCompleted(sessionId);
-            var sess = chatService.GetSession(sessionId);
             if (sess != null)
             {
                 if (!string.IsNullOrEmpty(sess.AgentId)) selectedAgent.Set(sess.AgentId);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -8,9 +8,11 @@ using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
 using Ivy.Tendril.Agents.Providers;
 using Ivy.Tendril.AppShell;
+using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Apps.Chat.Dialogs;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Jobs;
 using Ivy.Tendril.Widgets;
@@ -23,6 +25,9 @@ public class ChatApp : ViewBase
     internal static string DisplayTitle(ChatSessionModel session) =>
         string.IsNullOrWhiteSpace(session.Title) ? "New Chat" : session.Title;
 
+    internal static ChatJobDto ToJobDto(JobItem job) =>
+        new(job.Id, job.Type, job.Status.ToString(), job.ReportedPlanId, job.ReportedPlanTitle, job.StatusMessage);
+
     internal static List<ShellBadgeDto>? BuildRowBadges(
         ChatSessionModel session,
         string? selectedId,
@@ -34,23 +39,33 @@ public class ChatApp : ViewBase
         return null;
     }
 
-    /// <summary>The Chats list the shell sidebar shows while this app is open; selecting a row navigates here with that session.</summary>
+    /// <summary>
+    ///     The Chats list the shell sidebar shows while this app (or a terminal session) is open.
+    ///     Terminal sessions are listed too; the shell reroutes their selection to the terminal pane.
+    /// </summary>
     internal static ShellSidebarListState BuildSidebarList(
         IReadOnlyList<ChatSessionModel> sessions,
         string? selectedId,
         IReadOnlySet<string> generatingIds,
         IReadOnlySet<string> completedIds,
-        Action openSearch)
+        Action openSearch,
+        Action? startNewChat = null)
     {
         var items = sessions
-            .Select(s => new ShellSectionItemDto(s.Id, DisplayTitle(s), Badges: BuildRowBadges(s, selectedId, generatingIds, completedIds)))
+            .Select(s => new ShellSectionItemDto(
+                s.Id,
+                DisplayTitle(s),
+                Badges: BuildRowBadges(s, selectedId, generatingIds, completedIds),
+                Icon: s.IsTerminal() ? "Terminal" : null))
             .ToList();
         return new ShellSidebarListState(
             "chat", "Chats", items, selectedId,
             id => new ChatAppArgs(SessionId: id),
             Searchable: true,
             OnSearch: openSearch,
-            SearchLabel: "Search chats");
+            SearchLabel: "Search chats",
+            OnNew: startNewChat,
+            NewLabel: startNewChat != null ? "New chat" : null);
     }
 
     public override object Build()
@@ -131,10 +146,18 @@ public class ChatApp : ViewBase
             });
         });
 
-        // The session the args name, when it still exists, else the most recent one.
-        ChatSessionModel? InitialSession() =>
-            (!string.IsNullOrEmpty(args?.SessionId) ? chatService.GetSession(args.SessionId) : null)
-            ?? chatService.GetSessions().FirstOrDefault();
+        // The chat session the args name, when it still exists; a bare prompt starts a fresh chat;
+        // otherwise the most recent chat. Terminal sessions belong to the AgentApp pane, never here.
+        ChatSessionModel? InitialSession()
+        {
+            if (!string.IsNullOrEmpty(args?.SessionId))
+            {
+                var named = chatService.GetSession(args.SessionId);
+                if (named != null && !named.IsTerminal()) return named;
+            }
+            if (!string.IsNullOrEmpty(args?.Prompt)) return null;
+            return chatService.GetSessions().FirstOrDefault(s => !s.IsTerminal());
+        }
 
         void SelectSession(string sessionId)
         {
@@ -154,7 +177,8 @@ public class ChatApp : ViewBase
 
         _ = sessionVersion.Value;
         _ = streamVersion.Value;
-        var sessions = chatService.GetSessions();
+        var allSessions = chatService.GetSessions();
+        var sessions = allSessions.Where(s => !s.IsTerminal()).ToList();
         var currentSessionId = activeSessionId.Value;
         var activeSession = currentSessionId != null ? chatService.GetSession(currentSessionId) : null;
         var isSessionGenerating = currentSessionId != null && executionService.IsGenerating(currentSessionId);
@@ -247,14 +271,7 @@ public class ChatApp : ViewBase
                     {
                         var job = jobService.GetJob(jId);
                         if (job == null) return new ChatJobDto(jId, "Job", "Unknown");
-                        return new ChatJobDto(
-                            job.Id,
-                            job.Type,
-                            job.Status.ToString(),
-                            job.ReportedPlanId,
-                            job.ReportedPlanTitle,
-                            job.StatusMessage
-                        );
+                        return ToJobDto(job);
                     }).ToList();
                 }
             }
@@ -284,6 +301,17 @@ public class ChatApp : ViewBase
             );
         }).ToList();
 
+        void StartNewChat()
+        {
+            if (ChatLauncher.UsesTerminal(configService))
+            {
+                navigator.Navigate(typeof(AgentApp), new AgentAppArgs());
+                return;
+            }
+            var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort, kind: ChatSessionKinds.Chat);
+            SelectSession(newSess.Id);
+        }
+
         void SendMessage(ChatSendMessageDto dto)
         {
             var userPrompt = dto.Prompt?.Trim() ?? string.Empty;
@@ -293,7 +321,7 @@ public class ChatApp : ViewBase
             string targetSessionId = !string.IsNullOrEmpty(dto.SessionId) ? dto.SessionId : (activeSessionId.Value ?? string.Empty);
             if (string.IsNullOrEmpty(targetSessionId))
             {
-                var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort);
+                var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort, kind: ChatSessionKinds.Chat);
                 targetSessionId = newSess.Id;
                 SelectSession(targetSessionId);
             }
@@ -329,7 +357,7 @@ public class ChatApp : ViewBase
             var targetId = activeSessionId.Value;
             if (string.IsNullOrEmpty(targetId))
             {
-                var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort);
+                var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort, kind: ChatSessionKinds.Chat);
                 targetId = newSess.Id;
                 SelectSession(targetId);
             }
@@ -337,11 +365,12 @@ public class ChatApp : ViewBase
         }
 
         _ = sidebarListSignal.Send(BuildSidebarList(
-            sessions,
+            allSessions,
             currentSessionId,
             chatService.GetGeneratingSessionIds(),
             chatService.GetCompletedSessionIds(),
-            showSearchDialog));
+            showSearchDialog,
+            StartNewChat));
 
         var content = new ContentView(
             activeSession,
@@ -363,7 +392,8 @@ public class ChatApp : ViewBase
             executionService,
             agentRunner,
             SendMessage,
-            SelectSession
+            SelectSession,
+            StartNewChat
         );
 
         return new Fragment(content, searchDialog);

--- a/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
@@ -1,0 +1,37 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Apps.Agent;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Chat;
+
+internal static class ChatLauncher
+{
+    public static bool UsesTerminal(IConfigService config) => ChatModes.IsTerminal(config.Settings.ChatMode);
+
+    public static (Type App, object? Args) TargetFor(IConfigService config, string? prompt = null, string? title = null) =>
+        UsesTerminal(config)
+            ? (typeof(AgentApp), new AgentAppArgs(prompt, title))
+            : (typeof(ChatApp), new ChatAppArgs(Prompt: prompt));
+
+    public static void Open(INavigator navigator, IConfigService config, string? prompt = null, string? title = null)
+    {
+        var (app, args) = TargetFor(config, prompt, title);
+        navigator.Navigate(app, args);
+    }
+
+    public static (Type App, object? Args) NewSessionTarget(IConfigService config, IChatHistoryService chats, IAgentRunner runner)
+    {
+        if (UsesTerminal(config)) return (typeof(AgentApp), new AgentAppArgs());
+
+        var agent = config.Settings.CodingAgent ?? "claude";
+        var models = ChatApp.GetModelsForAgent(runner, agent);
+        var session = chats.CreateSession(agent, models.Count > 0 ? models[0].Id : "default", kind: ChatSessionKinds.Chat);
+        return (typeof(ChatApp), new ChatAppArgs(SessionId: session.Id));
+    }
+
+    public static void StartNew(INavigator navigator, IConfigService config, IChatHistoryService chats, IAgentRunner runner)
+    {
+        var (app, args) = NewSessionTarget(config, chats, runner);
+        navigator.Navigate(app, args);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
@@ -38,6 +38,10 @@ internal static class ChatLauncher
     public static string? LatestTerminalSessionId(IEnumerable<ChatSessionModel> sessions) =>
         sessions.Where(s => s.IsTerminal()).OrderByDescending(s => s.UpdatedAt).FirstOrDefault()?.Id;
 
-    public static string SessionListSignature(IEnumerable<ChatSessionModel> sessions) =>
-        string.Join("\u001e", sessions.Select(s => s.Id + "\u001f" + s.Title));
+    public static string SessionListSignature(
+        IEnumerable<ChatSessionModel> sessions,
+        IReadOnlySet<string>? generatingIds = null,
+        IReadOnlySet<string>? completedIds = null) =>
+        string.Join("\u001e", sessions.Select(s =>
+            $"{s.Id}\u001f{s.Title}\u001f{s.Kind}\u001f{generatingIds?.Contains(s.Id) == true}\u001f{completedIds?.Contains(s.Id) == true}"));
 }

--- a/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
@@ -34,4 +34,10 @@ internal static class ChatLauncher
         var (app, args) = NewSessionTarget(config, chats, runner);
         navigator.Navigate(app, args);
     }
+
+    public static string? LatestTerminalSessionId(IEnumerable<ChatSessionModel> sessions) =>
+        sessions.Where(s => s.IsTerminal()).OrderByDescending(s => s.UpdatedAt).FirstOrDefault()?.Id;
+
+    public static string SessionListSignature(IEnumerable<ChatSessionModel> sessions) =>
+        string.Join("\u001e", sessions.Select(s => s.Id + "\u001f" + s.Title));
 }

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -35,7 +35,8 @@ public class ContentView(
     IChatExecutionService executionService,
     IAgentRunner agentRunner,
     Action<ChatSendMessageDto> sendMessage,
-    Action<string> selectSession) : ViewBase
+    Action<string> selectSession,
+    Action startNewChat) : ViewBase
 {
     /// <summary>The plan a job event names, by folder, numeric id or zero-padded id.</summary>
     internal static PlanFile? FindPlan(IPlanReaderService planService, string planId)
@@ -92,14 +93,7 @@ public class ContentView(
             ? jobService.GetJobs()
                 .Where(j => string.Equals(j.ChatSessionId, activeSessionId.Value, StringComparison.OrdinalIgnoreCase)
                          && (j.Status == JobStatus.Running || j.Status == JobStatus.Pending || j.Status == JobStatus.Queued))
-                .Select(j => new ChatJobDto(
-                    j.Id,
-                    j.Type,
-                    j.Status.ToString(),
-                    j.ReportedPlanId,
-                    j.ReportedPlanTitle,
-                    j.StatusMessage
-                )).ToList()
+                .Select(ChatApp.ToJobDto).ToList()
             : new List<ChatJobDto>();
 
         var chatWidget = new ChatWidget
@@ -145,8 +139,7 @@ public class ContentView(
             },
             OnCreateSession = _ =>
             {
-                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
-                selectSession(newSess.Id);
+                startNewChat();
                 return ValueTask.CompletedTask;
             },
             OnSendMessage = e =>

--- a/src/Ivy.Tendril/Apps/Chat/Dialogs/DeleteSessionDialog.cs
+++ b/src/Ivy.Tendril/Apps/Chat/Dialogs/DeleteSessionDialog.cs
@@ -8,7 +8,7 @@ public class DeleteSessionDialog(
     IState<string?> deletingSessionId,
     ChatSessionModel? session,
     IChatHistoryService chatService,
-    IState<string?> activeSessionId,
+    IState<string?>? activeSessionId,
     IState<int> sessionVersion) : ViewBase
 {
     public override object? Build()
@@ -34,7 +34,7 @@ public class DeleteSessionDialog(
                     {
                         chatService.DeleteSession(idToDelete);
                         sessionVersion.Set(v => v + 1);
-                        if (activeSessionId.Value == idToDelete)
+                        if (activeSessionId != null && activeSessionId.Value == idToDelete)
                         {
                             var remaining = chatService.GetSessions();
                             activeSessionId.Set(remaining.FirstOrDefault()?.Id);

--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -1,6 +1,7 @@
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Apps.Agent;
+using Ivy.Tendril.Apps.Chat;
 using Ivy.Tendril.Apps.Views.Dialogs;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
@@ -96,9 +97,9 @@ public class ActionBarView(
         var standardOverflowItems = new[]
         {
             new MenuItem($"Discuss with {agentLabel}", Icon: agentIcon, Tag: "DiscussWithAgent")
-                .OnSelect(() => nav.Navigate<AgentApp>(new AgentAppArgs(
+                .OnSelect(() => ChatLauncher.Open(nav, config,
                     $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Draft mode.",
-                    $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}"))),
+                    $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}")),
             new MenuItem("Create Issue", Icon: Icons.Github, Tag: "CreateIssue").OnSelect(showCreateIssueDialog),
             new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
                 .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath); }),

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
@@ -7,6 +7,7 @@ using Ivy.Tendril.Helpers;
 using System;
 using System.IO;
 using Ivy.Tendril.Apps.Agent;
+using Ivy.Tendril.Apps.Chat;
 using Ivy.Tendril.Apps.Settings;
 using Ivy.Tendril.Apps.Settings.Dialogs;
 
@@ -196,7 +197,7 @@ public class CreatePlanDialog(
                     if (string.IsNullOrWhiteSpace(createPlanText.Value)) return ValueTask.CompletedTask;
                     planWasCreated = true;
                     var prompt = BuildAgentPrompt(selectedProject.Value, createPlanText.Value);
-                    nav.Navigate<AgentApp>(new AgentAppArgs(prompt));
+                    ChatLauncher.Open(nav, configService, prompt);
                     onClose();
                 }
                 return ValueTask.CompletedTask;

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -6,6 +6,7 @@ using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Agent;
+using Ivy.Tendril.Apps.Chat;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Review.Dialogs;
 using Ivy.Tendril.Apps.Review.Tabs;
@@ -481,9 +482,9 @@ public class ContentView(
         var standardOverflowItems = new[]
         {
             new MenuItem($"Discuss with {agentLabel}", Icon: agentIcon, Tag: "DiscussWithAgent")
-                .OnSelect(() => nav.Navigate<AgentApp>(new AgentAppArgs(
+                .OnSelect(() => ChatLauncher.Open(nav, config,
                     $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Review mode.",
-                    $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}"))),
+                    $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}")),
             new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
                 .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath, logger); }),
             new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
@@ -693,9 +694,9 @@ public class ContentView(
                 jobService,
                 refreshPlans,
                 selectedPlan.Project,
-                onDiscussWithAgent: () => nav.Navigate<AgentApp>(new AgentAppArgs(
+                onDiscussWithAgent: () => ChatLauncher.Open(nav, config,
                     $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Review mode.",
-                    $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}")));
+                    $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}"));
 
             var tabNamesList = new List<string> { "summary", "plan", "details", "git" };
             var isSummarySelected = selectedTab.Value == 0;

--- a/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
@@ -70,6 +70,14 @@ public class AppearanceSetupView : ViewBase
                 | (activeTheme.IsVaultTheme ? new Badge("Team Vault").Variant(BadgeVariant.Secondary).Small() : null));
 
         var isSidebarOpen = config.Settings.SidebarOpen;
+        var usesTerminal = ChatModes.IsTerminal(config.Settings.ChatMode);
+
+        void SetChatMode(string mode, string label)
+        {
+            config.Settings.ChatMode = mode;
+            config.SaveSettings();
+            client.Toast($"Chat opens as {label}", "Saved");
+        }
 
         return Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
                | Text.Block("Appearance").Bold()
@@ -131,6 +139,17 @@ public class AppearanceSetupView : ViewBase
                           config.Settings.SidebarOpen = false;
                           config.SaveSettings();
                           client.Toast("Sidebar set to collapsed by default", "Saved");
-                      }));
+                      }))
+               | Text.Block("Chat").Bold()
+               | Text.Muted("Choose how the Chat button talks to your coding agent: the chat view, or the agent's own terminal.").Small()
+               | (Layout.Horizontal()
+                  | new Button("Chat")
+                      .Variant(!usesTerminal ? ButtonVariant.Primary : ButtonVariant.Outline)
+                      .Icon(Icons.MessageCircle)
+                      .OnClick(() => SetChatMode(ChatModes.Chat, "chat"))
+                  | new Button("Terminal")
+                      .Variant(usesTerminal ? ButtonVariant.Primary : ButtonVariant.Outline)
+                      .Icon(Icons.Terminal)
+                      .OnClick(() => SetChatMode(ChatModes.Terminal, "terminal")));
     }
 }

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Apps.Agent;
+using Ivy.Tendril.Apps.Chat;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Jobs.Dialogs;
 using Ivy.Tendril.Helpers;
@@ -48,7 +49,7 @@ public class JobDebugSheet(
                 if (!string.IsNullOrEmpty(focus))
                     prompt += $"In particular, focus on: {focus}\n\n";
                 prompt += details;
-                nav.Navigate<AgentApp>(new AgentAppArgs(prompt));
+                ChatLauncher.Open(nav, config, prompt);
                 closeSheet();
             });
         });

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -329,8 +329,17 @@ public sealed class ChatExecutionService : IChatExecutionService
             _chatService.AddMessage(sessionId, "assistant", warning, targetAgent, targetModel, effort: targetEffort);
         }
 
+        var isFirstUserMessage = role.Equals("user", StringComparison.OrdinalIgnoreCase)
+            && (sess?.Messages.Count ?? 0) == 0
+            && ChatSessionNamingService.IsDefaultTitle(sess?.Title);
+
         // Add user or system message to history
         _chatService.AddMessage(sessionId, role, promptWithAttachments, targetAgent, targetModel, effort: targetEffort);
+
+        if (isFirstUserMessage)
+        {
+            _ = _namingService.GenerateAndSetTitleAsync(sessionId, userPrompt, targetAgent, targetModel);
+        }
 
         // Build prompt with conversation history and spawned jobs status
         var currentSess = _chatService.GetSession(sessionId);
@@ -567,34 +576,6 @@ public sealed class ChatExecutionService : IChatExecutionService
                         : (result.IsSuccess ? "Task completed successfully." : failureText);
 
                 _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true);
-
-                // Auto-generate title on first exchange
-                var updatedSession = _chatService.GetSession(sessionId);
-                if (updatedSession != null &&
-                    (updatedSession.Title == "New Chat" || string.IsNullOrWhiteSpace(updatedSession.Title)) &&
-                    updatedSession.Messages.Count == 2)
-                {
-                    var firstUserMsg = updatedSession.Messages.FirstOrDefault(m => m.Role == "user")?.Content;
-                    if (!string.IsNullOrWhiteSpace(firstUserMsg))
-                    {
-                        _ = Task.Run(async () =>
-                        {
-                            try
-                            {
-                                await _namingService.GenerateAndSetTitleAsync(
-                                    sessionId,
-                                    firstUserMsg,
-                                    responseContent,
-                                    targetAgent,
-                                    targetModel);
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogDebug(ex, "Failed to generate title for session {SessionId}", sessionId);
-                            }
-                        });
-                    }
-                }
             }
             catch (OperationCanceledException)
             {

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -289,7 +289,7 @@ public class ChatHistoryService : IChatHistoryService
         return session;
     }
 
-    public ChatSessionModel CreateSession(string agentId, string modelId, string? title = null, string? effort = null)
+    public ChatSessionModel CreateSession(string agentId, string modelId, string? title = null, string? effort = null, string? kind = null)
     {
         var now = DateTimeOffset.UtcNow;
         var id = Guid.NewGuid().ToString("N");
@@ -303,7 +303,8 @@ public class ChatHistoryService : IChatHistoryService
             AgentId: agentId,
             ModelId: modelId,
             Messages: new List<ChatMessageModel>(),
-            Effort: effort
+            Effort: effort,
+            Kind: kind
         );
 
         _sessions[id] = session;

--- a/src/Ivy.Tendril/Services/ChatSessionNamingService.cs
+++ b/src/Ivy.Tendril/Services/ChatSessionNamingService.cs
@@ -14,7 +14,6 @@ public interface IChatSessionNamingService
     Task GenerateAndSetTitleAsync(
         string sessionId,
         string userPrompt,
-        string assistantResponse,
         string? agentId = null,
         string? modelId = null,
         CancellationToken ct = default);
@@ -42,14 +41,11 @@ public class ChatSessionNamingService : IChatSessionNamingService
     public async Task GenerateAndSetTitleAsync(
         string sessionId,
         string userPrompt,
-        string assistantResponse,
         string? agentId = null,
         string? modelId = null,
         CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(sessionId) ||
-            string.IsNullOrWhiteSpace(userPrompt) ||
-            string.IsNullOrWhiteSpace(assistantResponse))
+        if (string.IsNullOrWhiteSpace(sessionId) || string.IsNullOrWhiteSpace(userPrompt))
         {
             return;
         }
@@ -62,7 +58,7 @@ public class ChatSessionNamingService : IChatSessionNamingService
                 return;
             }
 
-            var prompt = BuildPrompt(userPrompt, assistantResponse);
+            var prompt = BuildPrompt(userPrompt);
             var effectiveAgentId = !string.IsNullOrEmpty(agentId) ? agentId : (_configService.Settings.CodingAgent ?? "claude");
 
             var context = AgentLaunchHelper.PrepareResolutionContext(
@@ -126,17 +122,15 @@ public class ChatSessionNamingService : IChatSessionNamingService
         return clean.Equals("New Chat", StringComparison.OrdinalIgnoreCase);
     }
 
-    public static string BuildPrompt(string userPrompt, string assistantResponse)
+    public static string BuildPrompt(string userPrompt)
     {
         return $"""
-Generate a short 3 to 6 word title describing the conversation topic based on the following user message and assistant reply.
+Generate a short 3 to 6 word title describing the topic of the following user request.
 Output ONLY the title text. Do not include quotes, markdown headings, prefixes like "Title:", or trailing punctuation.
+Do not act on the request, run tools, or edit any files.
 
 User:
 {userPrompt}
-
-Assistant:
-{assistantResponse}
 """;
     }
 

--- a/src/Ivy.Tendril/Services/ChatSessionNamingService.cs
+++ b/src/Ivy.Tendril/Services/ChatSessionNamingService.cs
@@ -67,7 +67,7 @@ public class ChatSessionNamingService : IChatSessionNamingService
                 effectiveAgentId,
                 prompt,
                 modelOverride: modelId,
-                permissionMode: PermissionMode.FullAuto);
+                permissionMode: PermissionMode.Plan);
 
             context = context with
             {

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -243,6 +243,17 @@ public class InboxConfig
     public int CheckIntervalMinutes { get; set; } = 15;
 }
 
+public static class ChatModes
+{
+    public const string Chat = "chat";
+    public const string Terminal = "terminal";
+
+    public static string Normalize(string? mode) =>
+        string.Equals(mode, Terminal, StringComparison.OrdinalIgnoreCase) ? Terminal : Chat;
+
+    public static bool IsTerminal(string? mode) => Normalize(mode) == Terminal;
+}
+
 public class TendrilSettings
 {
     public string CodingAgent { get; set; } = "claude";
@@ -275,6 +286,7 @@ public class TendrilSettings
     public bool SidebarOpen { get; set; } = true;
     public string Theme { get; set; } = "default";
     public string ThemeMode { get; set; } = "system";
+    public string ChatMode { get; set; } = ChatModes.Chat;
     public bool Beta { get; set; } = false;
     public string? DismissedUpdateVersion { get; set; }
 
@@ -621,6 +633,8 @@ public class ConfigService : IConfigService, IDisposable
         {
             Settings.ThemeMode = Settings.ThemeMode.ToLowerInvariant();
         }
+
+        Settings.ChatMode = ChatModes.Normalize(Settings.ChatMode);
     }
 
     public TendrilSettings Settings { get; private set; }

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -31,8 +31,18 @@ public record ChatSessionModel(
     string ModelId,
     List<ChatMessageModel> Messages,
     string? Effort = null,
-    List<string>? SpawnedJobIds = null
+    List<string>? SpawnedJobIds = null,
+    string? Kind = null
 );
+
+public static class ChatSessionKinds
+{
+    public const string Chat = "chat";
+    public const string Terminal = "terminal";
+
+    public static bool IsTerminal(this ChatSessionModel session) =>
+        string.Equals(session.Kind, Terminal, StringComparison.OrdinalIgnoreCase);
+}
 
 public interface IChatHistoryService
 {
@@ -40,7 +50,7 @@ public interface IChatHistoryService
     event EventHandler? GeneratingSessionsChanged;
     IReadOnlyList<ChatSessionModel> GetSessions();
     ChatSessionModel? GetSession(string id);
-    ChatSessionModel CreateSession(string agentId, string modelId, string? title = null, string? effort = null);
+    ChatSessionModel CreateSession(string agentId, string modelId, string? title = null, string? effort = null, string? kind = null);
     void SaveSession(ChatSessionModel session);
     void DeleteSession(string id);
     void RenameSession(string id, string newTitle);

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -131,28 +131,7 @@ public static class TendrilServer
         });
 
         var assembly = typeof(TendrilServer).Assembly;
-        server.AppRepository.AddFactory(() => AppHelpers.GetApps(assembly)
-            .Select(app => app.Type == typeof(Ivy.Tendril.Apps.Chat.ChatApp) ? new AppDescriptor
-            {
-                Id = app.Id,
-                Title = app.Title,
-                Icon = app.Icon,
-                Description = app.Description,
-                Type = app.Type,
-                Group = app.Group,
-                Order = app.Order,
-                ViewFactory = app.ViewFactory,
-                ViewFunc = app.ViewFunc,
-                IsVisible = isBeta,
-                IsIndex = app.IsIndex,
-                GroupExpanded = app.GroupExpanded,
-                Next = app.Next,
-                Previous = app.Previous,
-                DocumentSource = app.DocumentSource,
-                SearchHints = app.SearchHints,
-                AllowDuplicateTabs = app.AllowDuplicateTabs,
-            } : app)
-            .ToArray());
+        server.AppRepository.AddFactory(() => AppHelpers.GetApps(assembly).ToArray());
         server.AddConnectionsFromAssembly(typeof(TendrilServer).Assembly);
 
         // Eagerly register Ivy.Tendril.Widgets and framework widgets assemblies to ensure widgets


### PR DESCRIPTION
## Summary

Merges the Chat app and the PTY Agent app behind one sidebar **Chat** button.

- The agent-provider row in the sidebar becomes a **Chat** row (message-circle icon). By default it opens the chat app; with the new `chatMode: terminal` setting in config.yaml (Settings > Appearance, "Chat" block) it opens the agent's own terminal instead.
- Terminal sessions are chat sessions of kind `terminal`. They show up in the **Chats** sidebar list (with a terminal icon) instead of the bottom tab strip, which now only holds review-action tabs. Their panes stay mounted in the shell; selecting a row switches to the pane, and reloading resumes the latest terminal session.
- The terminal pane keeps its top bar (title, options with rename and delete, new chat, started jobs), rendered black independent of theme. It is the chat widget's header extracted into a shared `ChatHeader` component and exported as the `TerminalSessionHeader` widget.
- The Chats section gets a `+` button left of the search icon to start a new chat (or terminal, per the setting). Cmd/Ctrl+Alt+A does the same.
- "Discuss with agent", "continue with agent" and debug-job flows go through `ChatLauncher`, so they respect the setting.
- Chat: the streaming status is a static "Thinking"; session titles are generated once, fire-and-forget, from the first prompt when the agent starts (also for terminal sessions), running the naming agent in plan mode.

## Verification

- `dotnet test` (Ivy.Tendril.Test): 3348 passed, 1 skipped.
- Frontend vitest: 455 passed across 42 files; `tsc --noEmit` clean.
- Browser-checked against a scratch TENDRIL_HOME: Chat button, Chats list with `+` and terminal rows, terminal pane header in light and dark theme, rename and delete from the header, `chatMode` persisted from Settings > Appearance, terminal mode opening a PTY session, terminal filling the pane.

## Notes

- Reopening a terminal session after a restart starts a fresh agent process in the same working directory (the old PTY is gone); the session keeps its title and history entry.
- Branch is based on `development` and does not include the two unmerged chat-refinement commits on `claude/chat-app-figma-design-100be6`; merging those later will conflict in `ChatWidget.tsx` (header extraction) and `ChatApp.cs` (sidebar list signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
