### PR TITLE
[00221] Fix Node 26 Storage Globals Breaking the Frontend Vitest Suite

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/vitest.config.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/vitest.config.ts
@@ -6,5 +6,12 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    // Node enables experimental Web Storage by default from v25, so globalThis.localStorage
+    // exists as an accessor evaluating to undefined without --localstorage-file. Vitest's
+    // jsdom environment skips any window key that is already a global, so jsdom's real
+    // Storage never lands (and window.localStorage is undefined too, since Vitest aliases
+    // window to globalThis). Turning Node's webstorage off gives jsdom ownership again.
+    // No-op on Node 24 and earlier, which have no webstorage globals.
+    execArgv: ["--no-experimental-webstorage"],
   },
 });


### PR DESCRIPTION
# Summary

## Changes

Added `execArgv: ["--no-experimental-webstorage"]` to the `test` block of
`src/Ivy.Tendril.Widgets/frontend/vitest.config.ts`. Node >= 25 ships its own experimental
`localStorage`/`sessionStorage` globals that shadow jsdom's and evaluate to `undefined` without
`--localstorage-file`; this flag turns that off so jsdom's real `Storage` is used in every test,
regardless of the Node version running the suite.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/vitest.config.ts` - added the `execArgv` test option with an
  explanatory comment.

## Manual Testing

N/A - internal test-infrastructure change with no user-facing behavior. To confirm: from
`src/Ivy.Tendril.Widgets/frontend`, run `npx vitest run` under Node >= 25 (e.g. Node 26) and observe
all test files pass, including `src/Shell/TendrilShell.test.tsx` and `src/Shell/ShellNav.test.tsx`
(previously 8 failing tests in those two files with `TypeError: Cannot read properties of undefined
(reading 'clear')`).

---
## Commits
- f43512cd Disable Node's experimental Web Storage in the frontend Vitest config

---
Created using [Ivy Tendril](https://ivy.app).
