### PR TITLE
[00215] Finish the Git Activity Revert by Dropping the Summary Metrics Row

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.test.tsx
@@ -4,17 +4,16 @@ import "@testing-library/jest-dom";
 import { ActivityGrid } from "./ActivityGrid";
 
 describe("ActivityGrid summary metrics", () => {
-  it("renders total merged PRs and active weeks", () => {
+  it("does not render a summary metrics row", () => {
     const months = [
       { label: "Jan", weeks: [0, 2, 0, 1] },
       { label: "Feb", weeks: [3, 0, 0, 0] },
     ];
-    render(<ActivityGrid months={months} />);
+    const { container } = render(<ActivityGrid months={months} />);
 
-    expect(screen.getByText("6")).toBeInTheDocument();
-    expect(screen.getByText("PRs merged")).toBeInTheDocument();
-    expect(screen.getByText("3")).toBeInTheDocument();
-    expect(screen.getByText("Active weeks")).toBeInTheDocument();
+    expect(container.querySelector(".tdb-activity-metrics")).toBeNull();
+    expect(screen.queryByText("PRs merged")).not.toBeInTheDocument();
+    expect(screen.queryByText("Active weeks")).not.toBeInTheDocument();
   });
 });
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx
@@ -1,9 +1,5 @@
 import React, { useMemo } from "react";
-import {
-  computeActivityMetrics,
-  DashboardActivityMonthDto,
-  rampLevel,
-} from "./types";
+import { DashboardActivityMonthDto, rampLevel } from "./types";
 import { HoverTip, useHoverTip } from "./HoverTip";
 
 interface ActivityGridProps {
@@ -45,11 +41,6 @@ const weekStartDates = (month: DashboardActivityMonthDto): Map<number, Date> => 
 export const ActivityGrid: React.FC<ActivityGridProps> = ({ months }) => {
   const { wrapRef, tip, showTip, hideTip } = useHoverTip();
 
-  const { totalPrs, activeWeeks } = useMemo(
-    () => computeActivityMetrics(months),
-    [months],
-  );
-
   const maxWeek = useMemo(
     () => Math.max(0, ...months.flatMap((m) => m.weeks)),
     [months],
@@ -64,57 +55,45 @@ export const ActivityGrid: React.FC<ActivityGridProps> = ({ months }) => {
 
   return (
     <div className="tdb-tip-wrap" ref={wrapRef}>
-      <div className="tdb-activity-wrap">
-        <div className="tdb-activity-scroll">
-          <div className="tdb-activity">
-            {months.map((month, monthIndex) => {
-              const starts = weekStartDates(month);
-              return (
-                <div className="tdb-activity-col" key={monthIndex}>
-                  {month.weeks
-                    .map((count, weekIndex) => ({ count, weekIndex }))
-                    .filter(({ count }) => count > 0)
-                    .map(({ count, weekIndex }) => {
-                      const weekStart = starts.get(weekIndex);
-                      const title = weekStart
-                        ? `Week of ${weekStart.toLocaleDateString("en-US", {
-                            weekday: "short",
-                            month: "short",
-                            day: "numeric",
-                          })}`
-                        : month.label;
-                      const body = `${count} pull request${count === 1 ? "" : "s"} merged`;
-                      return (
-                        <div
-                          key={weekIndex}
-                          className="tdb-activity-cell"
-                          data-level={rampLevel(count, maxWeek)}
-                          onMouseEnter={showTip(title, body)}
-                          onMouseLeave={hideTip}
-                        />
-                      );
-                    })}
-                </div>
-              );
-            })}
-          </div>
-          <div className="tdb-activity-labels">
-            {months.map((month, monthIndex) => (
-              <div className="tdb-activity-label" key={monthIndex}>
-                {(months.length - 1 - monthIndex) % step === 0 ? month.label : ""}
+      <div className="tdb-activity-scroll">
+        <div className="tdb-activity">
+          {months.map((month, monthIndex) => {
+            const starts = weekStartDates(month);
+            return (
+              <div className="tdb-activity-col" key={monthIndex}>
+                {month.weeks
+                  .map((count, weekIndex) => ({ count, weekIndex }))
+                  .filter(({ count }) => count > 0)
+                  .map(({ count, weekIndex }) => {
+                    const weekStart = starts.get(weekIndex);
+                    const title = weekStart
+                      ? `Week of ${weekStart.toLocaleDateString("en-US", {
+                          weekday: "short",
+                          month: "short",
+                          day: "numeric",
+                        })}`
+                      : month.label;
+                    const body = `${count} pull request${count === 1 ? "" : "s"} merged`;
+                    return (
+                      <div
+                        key={weekIndex}
+                        className="tdb-activity-cell"
+                        data-level={rampLevel(count, maxWeek)}
+                        onMouseEnter={showTip(title, body)}
+                        onMouseLeave={hideTip}
+                      />
+                    );
+                  })}
               </div>
-            ))}
-          </div>
+            );
+          })}
         </div>
-        <div className="tdb-activity-metrics">
-          <div className="tdb-activity-metric">
-            <span className="tdb-activity-metric-value">{totalPrs}</span>
-            <span className="tdb-activity-metric-label">PRs merged</span>
-          </div>
-          <div className="tdb-activity-metric">
-            <span className="tdb-activity-metric-value">{activeWeeks}</span>
-            <span className="tdb-activity-metric-label">Active weeks</span>
-          </div>
+        <div className="tdb-activity-labels">
+          {months.map((month, monthIndex) => (
+            <div className="tdb-activity-label" key={monthIndex}>
+              {(months.length - 1 - monthIndex) % step === 0 ? month.label : ""}
+            </div>
+          ))}
         </div>
       </div>
       <HoverTip tip={tip} />

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -480,6 +480,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
   min-height: 0;
 }
 
@@ -487,19 +488,12 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
   margin-top: 16px;
   min-height: 0;
 }
 
 /* ---------- Activity grid ---------- */
-
-.tdb-activity-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  width: 100%;
-  flex: 1;
-}
 
 .tdb-activity-scroll {
   overflow-x: auto;
@@ -548,32 +542,6 @@
   color: var(--tdb-muted);
   text-align: left;
   white-space: nowrap;
-}
-
-.tdb-activity-metrics {
-  display: flex;
-  align-items: center;
-  gap: 24px;
-  margin-top: auto;
-  padding-top: 16px;
-  border-top: 1px solid var(--tdb-divider);
-}
-
-.tdb-activity-metric {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.tdb-activity-metric-value {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--tdb-fg);
-}
-
-.tdb-activity-metric-label {
-  font-size: 12px;
-  color: var(--tdb-muted);
 }
 
 .tdb-empty-note {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -40,24 +40,23 @@ describe("dashboard.css KPI grid", () => {
 });
 
 describe("dashboard.css side block and git activity layout", () => {
-  it("top-aligns side body and tip wrap by omitting justify-content: flex-end", () => {
+  it("bottom-anchors side body and tip wrap with justify-content: flex-end", () => {
     const sideBodyBlocks = [...css.matchAll(/\.tdb-side-body\s*\{([^}]*)\}/g)].map((m) => m[1]);
     expect(sideBodyBlocks.length).toBeGreaterThanOrEqual(1);
     for (const block of sideBodyBlocks) {
-      expect(block).not.toContain("justify-content: flex-end;");
+      expect(block).toContain("justify-content: flex-end;");
     }
 
     const tipWrapBlocks = [...css.matchAll(/\.tdb-tip-wrap\s*\{([^}]*)\}/g)].map((m) => m[1]);
     expect(tipWrapBlocks.length).toBeGreaterThanOrEqual(1);
     for (const block of tipWrapBlocks) {
-      expect(block).not.toContain("justify-content: flex-end;");
+      expect(block).toContain("justify-content: flex-end;");
     }
   });
 
-  it("defines activity metrics styles", () => {
-    expect(css).toContain(".tdb-activity-metrics {");
-    expect(css).toMatch(/\.tdb-activity-metrics\s*\{[^}]*display:\s*flex;/);
-    expect(css).toMatch(/\.tdb-activity-metrics\s*\{[^}]*border-top:\s*1px solid var\(--tdb-divider\);/);
+  it("no longer carries the activity metrics summary row", () => {
+    expect(css).not.toContain(".tdb-activity-metrics");
+    expect(css).not.toContain(".tdb-activity-wrap");
   });
 
   it("stacks monthly activity columns from the bottom", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  computeActivityMetrics,
   computeAverage,
   computeRollingAverage,
   formatAxisDate,
@@ -48,28 +47,6 @@ describe("tick formatters", () => {
   it("abbreviates thousands as counts", () => {
     expect(formatCountTick(1500)).toBe("2K");
     expect(formatCountTick(150)).toBe("150");
-  });
-});
-
-describe("computeActivityMetrics", () => {
-  it("returns 0 for empty months or months without weeks", () => {
-    expect(computeActivityMetrics([])).toEqual({ totalPrs: 0, activeWeeks: 0 });
-    expect(computeActivityMetrics([{ label: "Jan", weeks: [] }])).toEqual({
-      totalPrs: 0,
-      activeWeeks: 0,
-    });
-  });
-
-  it("sums total merged PRs and counts weeks with merged PRs", () => {
-    const months = [
-      { label: "Jan", weeks: [0, 2, 0, 1] },
-      { label: "Feb", weeks: [3, 0, 0, 0] },
-      { label: "Mar", weeks: [0, 0, 0, 0] },
-    ];
-    expect(computeActivityMetrics(months)).toEqual({
-      totalPrs: 6,
-      activeWeeks: 3,
-    });
   });
 });
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -109,25 +109,6 @@ export const formatCountTick = (value: number): string => {
   return String(Math.round(value));
 };
 
-export interface DashboardActivityMetrics {
-  totalPrs: number;
-  activeWeeks: number;
-}
-
-export const computeActivityMetrics = (
-  months: DashboardActivityMonthDto[],
-): DashboardActivityMetrics => {
-  const totalPrs = months.reduce(
-    (acc, m) => acc + (m.weeks ?? []).reduce((wAcc, c) => wAcc + c, 0),
-    0,
-  );
-  const activeWeeks = months.reduce(
-    (acc, m) => acc + (m.weeks ?? []).filter((c) => c > 0).length,
-    0,
-  );
-  return { totalPrs, activeWeeks };
-};
-
 /** Arithmetic mean of non-empty number arrays, returning null when empty. */
 export const computeAverage = (values: number[]): number | null => {
   if (!values || values.length === 0) return null;


### PR DESCRIPTION
# Summary

## Changes

Removed the "PRs merged / Active weeks" summary row from the Git Activity card and restored the
bottom-anchored card layout it had displaced, completing the revert to @dcrjodle's original design
that Plan 00202 started. The row's `computeActivityMetrics` helper and its supporting CSS are gone.

## API Changes

- Removed `DashboardActivityMetrics` interface and `computeActivityMetrics` function from `types.ts`.
- No changes to any C# APIs (`DashboardActivityMonthDto`, `BuildActivityMonths` untouched).

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx`  -  removed the metrics
  markup and its `useMemo`/import; `.tdb-tip-wrap` now wraps `.tdb-activity-scroll` directly.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`  -  restored
  `justify-content: flex-end` on `.tdb-tip-wrap` and `.tdb-side-body`; deleted the
  `.tdb-activity-wrap`/`.tdb-activity-metrics*` rules.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`  -  deleted
  `computeActivityMetrics`/`DashboardActivityMetrics`.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.test.tsx`,
  `dashboard.css.test.ts`, `helpers.test.ts`  -  inverted/removed the tests that asserted the removed
  behaviour.

## Manual Testing

1. Run `dotnet run --project src/Ivy.Tendril.Widgets/.samples --find-available-port` and open the
   Dashboard app.
2. Look at the Git Activity card (left side card).
3. Confirm the monthly column grid sits at the bottom of the card with month labels directly beneath
   it, with no divider line and no "PRs merged" / "Active weeks" row, and no empty gap between the
   grid and the bottom of the card. The Pull Requests card should show the same bottom-anchored
   behavior.


---

## Commits

- 339d2ed1: Drop Git Activity summary metrics row (Plan 00215)
- 8b80f927: Update dashboard tests for dropped metrics row (Plan 00215)

---
Created using [Ivy Tendril](https://ivy.app).