### PR TITLE
[00220] Gate Voice Recorder Debug Logging Behind a Flag

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 import * as pdfjsLib from "pdfjs-dist";
 import pdfjsWorker from "pdfjs-dist/build/pdf.worker.mjs?url";
 import { VoiceRecorder, type VoiceStatus } from "../voice-recorder";
+import { debugLog } from "../debug-log";
 import { isImageFile, processImageFile } from "../imageUtils";
 import "./content-input.css";
 
@@ -687,14 +688,14 @@ export const ContentInput: React.FC<ContentInputProps> = ({
         endpoint: transcriptionUrl,
         onStatusChange: (status) => setVoiceStatus(status),
         onResult: (transcription) => {
-          console.log("[ContentInput] Transcription result received:", transcription);
+          debugLog("[ContentInput] Transcription result received:", transcription);
           if (transcription.trim() === "") {
             setRecordError("The transcription did not contain enough information to generate a prompt. Please try again and speak clearly.");
             return;
           }
           setText((prev) => {
             const next = prev ? `${prev} ${transcription}` : transcription;
-            console.log("[ContentInput] Next text state:", next);
+            debugLog("[ContentInput] Next text state (length):", next.length);
             if (dispatchEvent) {
               const fullText = next + filesRef.current.map((f) => ` [file: ${f}]`).join("");
               dispatchEvent("OnChange", id, [fullText]);

--- a/src/Ivy.Tendril.Widgets/frontend/src/debug-log.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/debug-log.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { debugLog, isDebugLoggingEnabled } from "./debug-log";
+
+describe("debug-log", () => {
+  const originalDev = import.meta.env.DEV;
+
+  beforeEach(() => {
+    (import.meta.env as Record<string, unknown>).DEV = true;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    (import.meta.env as Record<string, unknown>).DEV = originalDev;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("isDebugLoggingEnabled returns boolean indicating whether import.meta.env.DEV is true", () => {
+    (import.meta.env as Record<string, unknown>).DEV = true;
+    expect(isDebugLoggingEnabled()).toBe(true);
+
+    (import.meta.env as Record<string, unknown>).DEV = false;
+    expect(isDebugLoggingEnabled()).toBe(false);
+  });
+
+  it("debugLog calls console.log with the given args when import.meta.env.DEV is true", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    (import.meta.env as Record<string, unknown>).DEV = true;
+
+    debugLog("hello", 123, { a: 1 });
+    expect(consoleSpy).toHaveBeenCalledWith("hello", 123, { a: 1 });
+  });
+
+  it("debugLog does not touch console.log when import.meta.env.DEV is falsy", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    (import.meta.env as Record<string, unknown>).DEV = false;
+
+    debugLog("suppressed", "log");
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/debug-log.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/debug-log.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+export function isDebugLoggingEnabled(): boolean {
+  return Boolean(import.meta.env.DEV);
+}
+
+export function debugLog(...args: unknown[]): void {
+  if (isDebugLoggingEnabled()) {
+    console.log(...args);
+  }
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.test.ts
@@ -86,4 +86,31 @@ describe("VoiceRecorder.start", () => {
     expect(audioContext).not.toHaveBeenCalled();
     expect(webSocket).not.toHaveBeenCalled();
   });
+
+  it("produces zero console.log calls while still producing console.warn when DEV mode is disabled", async () => {
+    const originalDev = import.meta.env.DEV;
+    (import.meta.env as Record<string, unknown>).DEV = false;
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      stubMediaDevices(undefined);
+      const recorder = new VoiceRecorder({
+        endpoint: "ws://test",
+        onStatusChange: vi.fn(),
+        onResult: vi.fn(),
+        onError: vi.fn(),
+      });
+
+      await recorder.start();
+
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      (import.meta.env as Record<string, unknown>).DEV = originalDev;
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.ts
@@ -1,3 +1,5 @@
+import { debugLog } from "./debug-log";
+
 export type VoiceStatus = "idle" | "connecting" | "recording" | "processing";
 
 export const INSECURE_CONTEXT_ERROR =
@@ -47,13 +49,14 @@ export class VoiceRecorder {
   private audioContext: AudioContext | null = null;
   private workletNode: AudioWorkletNode | null = null;
   private stream: MediaStream | null = null;
+  private chunksSent = 0;
 
   constructor(options: VoiceRecorderOptions) {
     this.options = options;
   }
 
   async start() {
-    console.log("[VoiceRecorder] start() initiated");
+    debugLog("[VoiceRecorder] start() initiated");
     this.options.onStatusChange("connecting");
 
     // Feature-detect before constructing anything, so an unsupported browser is not
@@ -70,22 +73,22 @@ export class VoiceRecorder {
       // Initialize AudioContext synchronously within the user gesture event handler
       // to prevent modern browsers from blocking/suspending the audio context.
       this.audioContext = new AudioContext({ sampleRate: 24000 });
-      console.log("[VoiceRecorder] AudioContext created, state:", this.audioContext.state);
+      debugLog("[VoiceRecorder] AudioContext created, state:", this.audioContext.state);
       if (this.audioContext.state === "suspended") {
         await this.audioContext.resume();
-        console.log("[VoiceRecorder] AudioContext resumed, state:", this.audioContext.state);
+        debugLog("[VoiceRecorder] AudioContext resumed, state:", this.audioContext.state);
       }
 
       this.stream = await navigator.mediaDevices.getUserMedia({
         audio: { sampleRate: 24000, channelCount: 1, echoCancellation: true },
       });
-      console.log("[VoiceRecorder] Microphone stream acquired successfully");
+      debugLog("[VoiceRecorder] Microphone stream acquired successfully");
 
-      console.log("[VoiceRecorder] Connecting to WebSocket endpoint:", this.options.endpoint);
+      debugLog("[VoiceRecorder] Connecting to WebSocket endpoint:", this.options.endpoint);
       this.ws = new WebSocket(this.options.endpoint);
 
       this.ws.onopen = () => {
-        console.log("[VoiceRecorder] WebSocket open. Sending start message.");
+        debugLog("[VoiceRecorder] WebSocket open. Sending start message.");
         const startMsg: any = {
           type: "start",
           format: "pcm16",
@@ -100,7 +103,7 @@ export class VoiceRecorder {
       this.ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          console.log("[VoiceRecorder] Received WebSocket message:", data.type, data);
+          debugLog("[VoiceRecorder] Received WebSocket message:", data.type, data);
           if (data.type === "ready") {
             this.options.onStatusChange("recording");
             if (this.stream && this.ws) {
@@ -111,7 +114,7 @@ export class VoiceRecorder {
               });
             }
           } else if (data.type === "result") {
-            console.log("[VoiceRecorder] Transcription result:", data.text);
+            debugLog("[VoiceRecorder] Transcription result:", data.text);
             this.options.onResult(data.text);
             this.cleanup();
           } else if (data.type === "error") {
@@ -131,7 +134,7 @@ export class VoiceRecorder {
       };
 
       this.ws.onclose = (evt) => {
-        console.log(
+        debugLog(
           `[VoiceRecorder] WebSocket closed: code=${evt.code}, reason=${evt.reason || "No reason"}, wasClean=${evt.wasClean}`,
         );
         if (!evt.wasClean && evt.code !== 1000 && evt.code !== 1005) {
@@ -161,21 +164,21 @@ export class VoiceRecorder {
   }
 
   private async beginPcmCapture(stream: MediaStream, ws: WebSocket) {
-    console.log("[VoiceRecorder] beginPcmCapture initiated");
+    this.chunksSent = 0;
+    debugLog("[VoiceRecorder] beginPcmCapture initiated");
     if (!this.audioContext) {
       this.audioContext = new AudioContext({ sampleRate: 24000 });
     }
     if (this.audioContext.state === "suspended") {
       await this.audioContext.resume();
     }
-    console.log("[VoiceRecorder] Loading audio worklet module...");
+    debugLog("[VoiceRecorder] Loading audio worklet module...");
     await this.audioContext.audioWorklet.addModule(pcmWorkletUrl());
-    console.log("[VoiceRecorder] Audio worklet module loaded successfully");
+    debugLog("[VoiceRecorder] Audio worklet module loaded successfully");
 
     const source = this.audioContext.createMediaStreamSource(stream);
     this.workletNode = new AudioWorkletNode(this.audioContext, "pcm-capture");
 
-    let chunkCount = 0;
     this.workletNode.port.onmessage = (event) => {
       const msg = event.data;
       if (msg.type === "volume" && this.options.onVolumeChange) {
@@ -183,24 +186,22 @@ export class VoiceRecorder {
       } else if (msg.type === "pcm16") {
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(msg.buffer);
-          chunkCount++;
-          if (chunkCount % 10 === 0) {
-            console.log(`[VoiceRecorder] Sent ${chunkCount} PCM16 audio chunks to server`);
-          }
+          this.chunksSent++;
         }
       }
     };
 
     source.connect(this.workletNode);
     this.workletNode.connect(this.audioContext.destination);
-    console.log("[VoiceRecorder] Audio graph connected and recording started");
+    debugLog("[VoiceRecorder] Audio graph connected and recording started");
   }
 
   stop() {
-    console.log("[VoiceRecorder] stop() initiated");
+    debugLog("[VoiceRecorder] stop() initiated");
+    debugLog(`[VoiceRecorder] Sent ${this.chunksSent} PCM16 audio chunks to server`);
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       try {
-        console.log("[VoiceRecorder] Sending stop signal to WebSocket");
+        debugLog("[VoiceRecorder] Sending stop signal to WebSocket");
         this.ws.send(JSON.stringify({ type: "stop" }));
       } catch (err) {
         console.error("[VoiceRecorder] Error sending stop signal:", err);
@@ -209,19 +210,19 @@ export class VoiceRecorder {
     }
 
     if (this.workletNode) {
-      console.log("[VoiceRecorder] Disconnecting AudioWorkletNode");
+      debugLog("[VoiceRecorder] Disconnecting AudioWorkletNode");
       this.workletNode.disconnect();
       this.workletNode = null;
     }
 
     if (this.audioContext) {
-      console.log("[VoiceRecorder] Closing AudioContext");
+      debugLog("[VoiceRecorder] Closing AudioContext");
       this.audioContext.close().catch(() => {});
       this.audioContext = null;
     }
 
     if (this.stream) {
-      console.log("[VoiceRecorder] Stopping media stream tracks");
+      debugLog("[VoiceRecorder] Stopping media stream tracks");
       this.stream.getTracks().forEach((track) => track.stop());
       this.stream = null;
     }
@@ -232,10 +233,10 @@ export class VoiceRecorder {
     if (!socket) return;
     this.ws = null;
 
-    console.log("[VoiceRecorder] Cleaning up session");
+    debugLog("[VoiceRecorder] Cleaning up session");
     this.stop();
     if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
-      console.log("[VoiceRecorder] Closing WebSocket connection");
+      debugLog("[VoiceRecorder] Closing WebSocket connection");
       socket.close();
     }
     this.options.onStatusChange("idle");


### PR DESCRIPTION
# Summary

## Changes

Added a `debugLog` utility gated on `import.meta.env.DEV` to eliminate noisy console output in production builds. Routed all informational logging in `voice-recorder.ts` and `ContentInput.tsx` through `debugLog`, replacing the 100ms audio chunk log stream with a single total summary emitted on recorder stop, while preserving diagnostic warnings and errors. Composed prompt text logging was also updated to report string length instead of logging raw prompt payloads.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/debug-log.ts`: New helper exporting `isDebugLoggingEnabled()` and `debugLog()`.
- `src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.ts`: Replaced unconditional `console.log` calls with `debugLog`, and replaced per-10-chunk audio logging with single summary in `stop()`.
- `src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx`: Routed transcription logs through `debugLog` and sanitized state logging.
- `src/Ivy.Tendril.Widgets/frontend/src/debug-log.test.ts`: Added unit test suite verifying DEV flag behavior.
- `src/Ivy.Tendril.Widgets/frontend/src/voice-recorder.test.ts`: Added test verifying recorder start is silent when DEV mode is disabled.

## Manual Testing

1. In development mode or running unit tests via `npx vitest run src/debug-log.test.ts`, confirm debug log output functions as expected.
2. In production builds (`npm run build` in `src/Ivy.Tendril.Widgets/frontend`), inspect the built bundle `dist/ivy-tendril-widgets.js` and verify `isDebugLoggingEnabled` evaluates to `false` and debug logs are silenced.

---

## Commits

- `a34d7315` Plan 00220: Route voice recorder and ContentInput logging through debugLog
- `c8193a99` Plan 00220: Add debugLog utility gated on DEV mode with tests

---
Created using [Ivy Tendril](https://ivy.app).