### PR TITLE
[00222] Position Jobs Badge to Left of Action Buttons in Chat UI

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
@@ -228,6 +228,9 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         )}
       </div>
       <div className="chat-header-actions">
+        {editable && jobs.length > 0 && (
+          <JobsMenu jobs={jobs} spawned={spawned} onReview={() => onReviewJobs?.()} />
+        )}
         <div className="chat-header-icons">
           <button
             type="button"
@@ -282,9 +285,6 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
             </div>
           )}
         </div>
-        {editable && jobs.length > 0 && (
-          <JobsMenu jobs={jobs} spawned={spawned} onReview={() => onReviewJobs?.()} />
-        )}
       </div>
     </div>
   );

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -1790,6 +1790,47 @@ describe("ChatWidget Running Jobs Badge and Spinner", () => {
     const pulseDot = badge.querySelector(".chat-jobs-pulse-dot");
     expect(pulseDot).toBeInTheDocument();
   });
+
+  it("renders running jobs badge to the left of action buttons in DOM order", () => {
+    const session: ChatSessionDto = {
+      id: "sess-order",
+      title: "Session Order",
+      agentId: "agent-1",
+      modelId: "model-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+    };
+    const runningJobs = [
+      { id: "job-1", type: "CreatePlan", status: "Running", planTitle: "Test Plan" },
+    ];
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-order"
+        sessions={[session]}
+        runningJobs={runningJobs}
+      />
+    );
+
+    const badge = screen.getByRole("button", { name: /View running jobs/i });
+    const newChatBtn = screen.getByRole("button", { name: /New chat/i });
+    const chatOptionsBtn = screen.getByRole("button", { name: /Chat options/i });
+
+    expect(badge).toBeInTheDocument();
+    expect(newChatBtn).toBeInTheDocument();
+    expect(chatOptionsBtn).toBeInTheDocument();
+
+    const actionsContainer = badge.closest(".chat-header-actions");
+    expect(actionsContainer).toBeInTheDocument();
+    expect(actionsContainer).toContainElement(badge);
+    expect(actionsContainer).toContainElement(newChatBtn);
+    expect(actionsContainer).toContainElement(chatOptionsBtn);
+
+    expect(badge.compareDocumentPosition(newChatBtn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(newChatBtn.compareDocumentPosition(chatOptionsBtn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });
 
 


### PR DESCRIPTION
Fixes #2425

# Summary

## Changes

Repositioned the background jobs badge menu to the left of the header action buttons ("New chat" and "Chat options") in the chat UI header. This stabilizes the action button positions at the right edge of the header, preventing layout shift when jobs start or finish.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx`: Moved `JobsMenu` before `chat-header-icons` within `chat-header-actions`.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Added unit test verifying `JobsMenu` precedes action buttons in DOM order within `chat-header-actions`.

## Manual Testing

1. Launch Tendril and open a chat session.
2. Start a background job (such as starting a plan creation or execution job).
3. Observe the chat header: the jobs badge appears to the left of the "New chat" and "Chat options" buttons.
4. Verify the "New chat" and "Chat options" buttons remain stable at the right edge and do not shift position when the jobs badge mounts or unmounts.

---
- aa33b971 00222: Position jobs badge to left of action buttons in chat UI

---
Created using [Ivy Tendril](https://ivy.app).
