### PR TITLE
[00214] Remove the Previous 4 Weeks Comparison Series From the Dashboard Trend Chart

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -92,47 +92,6 @@ public class DashboardAppViewModelTests
     }
 
     [Fact]
-    public void BuildTrend_ComparesTheSameCalendarDayAYearEarlier()
-    {
-        var today = new DateTime(2026, 9, 6);
-        var dataStart = new DateOnly(2025, 1, 1);
-        var activity = new DashboardActivityStats(
-            [], 0m, DailyCosts(dataStart, new DateOnly(2026, 9, 6), Unique), null, dataStart);
-
-        var trend = DashboardApp.BuildTrend(activity, today);
-
-        Assert.NotNull(trend);
-        // A year before the last displayed day, read by date rather than by bucket offset.
-        Assert.Equal((double)Unique(new DateOnly(2025, 9, 6)), trend.PrevCost[^1]);
-
-        // The comparison day for 2026-01-01 is exactly the first recorded day, so it is known.
-        var firstOfYear = trend.Dates.IndexOf("2026-01-01");
-        Assert.Equal((double)Unique(dataStart), trend.PrevCost[firstOfYear]);
-
-        // One day earlier the comparison falls before any record: unknown, not zero.
-        Assert.Null(trend.PrevCost[firstOfYear - 1]);
-        Assert.Null(trend.PrevCost[0]);
-    }
-
-    [Fact]
-    public void BuildTrend_MapsLeapDayOntoTheTwentyEighth()
-    {
-        // 2027 has no 29th of February. Clamping to the 28th is the calendar behaviour wanted, and the
-        // alternative (a gap in the comparison every fourth year) would read as missing data.
-        var today = new DateTime(2028, 3, 1);
-        var dataStart = new DateOnly(2026, 1, 1);
-        var activity = new DashboardActivityStats(
-            [], 0m, DailyCosts(dataStart, new DateOnly(2028, 3, 1), Unique), null, dataStart);
-
-        var trend = DashboardApp.BuildTrend(activity, today);
-
-        Assert.NotNull(trend);
-        var leapDay = trend.Dates.IndexOf("2028-02-29");
-        Assert.True(leapDay >= 0, "the displayed range should contain the leap day");
-        Assert.Equal((double)Unique(new DateOnly(2027, 2, 28)), trend.PrevCost[leapDay]);
-    }
-
-    [Fact]
     public void BuildTrend_WithoutADailySeries_IsAbsent()
     {
         // No monthly fallback: monthly buckets cannot carry a 7 day average or a date axis, so the card
@@ -160,7 +119,6 @@ public class DashboardAppViewModelTests
         Assert.All(trend.Plans, plans => Assert.Equal(0d, plans));
         Assert.All(trend.RollingCost, rolling => Assert.Null(rolling));
         Assert.All(trend.RollingPlans, rolling => Assert.Null(rolling));
-        Assert.All(trend.PrevCost, prev => Assert.Null(prev));
     }
 
     [Fact]
@@ -317,7 +275,7 @@ public class DashboardAppViewModelTests
     }
 
     [Fact]
-    public void BuildWeeklyTrend_Projects28DaysWithComparison()
+    public void BuildWeeklyTrend_Projects28Days()
     {
         var today = new DateTime(2026, 9, 6);
         var dailyCosts = new List<DashboardDailyCost>
@@ -341,8 +299,6 @@ public class DashboardAppViewModelTests
         Assert.Equal(28, trend.Dates.Count);
         Assert.Equal(28, trend.Cost.Count);
         Assert.Equal(28, trend.Plans.Count);
-        Assert.Equal(28, trend.PrevCost.Count);
-        Assert.Equal(28, trend.PrevPlans.Count);
         Assert.Equal(28, trend.RollingCost.Count);
 
         // 27 days before today through today, as dates rather than labels.
@@ -353,10 +309,6 @@ public class DashboardAppViewModelTests
         Assert.Equal(5.0, trend.Plans[^1]);
         // Zero-filled: Sept 4 has no rows at all and is present as 0, not missing.
         Assert.Equal(0d, trend.Cost[trend.Dates.IndexOf("2026-09-04")]);
-
-        // Sept 6 compared to 28 days earlier (Aug 9)
-        Assert.Equal(12.50, trend.PrevCost[^1]);
-        Assert.Equal(2.0, trend.PrevPlans[^1]);
 
         // Records begin Aug 9 (the fallback for a mock with no DailyDataStart).
         // Leading dates have expanding averages rather than null.

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/TendrilDashboard/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/TendrilDashboard/DemoApp.cs
@@ -45,11 +45,6 @@ class DemoApp : ViewBase
             trendPlans.Add(weekend ? trendRandom.Next(0, 2) : trendRandom.Next(2, 12));
         }
 
-        // Nulls at the start stand for days the comparison period has no records for.
-        var trendPrevCost = trendCost
-            .Select((v, i) => i < 30 ? (double?)null : Math.Round(v * 0.62)).ToList();
-        var trendPrevPlans = trendPlans
-            .Select((v, i) => i < 30 ? (double?)null : Math.Round(v * 0.7)).ToList();
 
         // Mirrors UpdateNoticeView's compact layout: alert + actions, filling
         // the dashboard's fixed 120px update slot.
@@ -114,8 +109,6 @@ class DemoApp : ViewBase
                 trendDates,
                 trendCost,
                 trendPlans,
-                trendPrevCost,
-                trendPrevPlans,
                 Rolling(trendCost),
                 Rolling(trendPlans)))
             // The short range is the tail of the same series, so its rolling curve starts six days in
@@ -124,8 +117,6 @@ class DemoApp : ViewBase
                 trendDates.TakeLast(28).ToList(),
                 trendCost.TakeLast(28).ToList(),
                 trendPlans.TakeLast(28).ToList(),
-                trendPrevCost.TakeLast(28).ToList(),
-                trendPrevPlans.TakeLast(28).ToList(),
                 Rolling(trendCost.TakeLast(28).ToList()),
                 Rolling(trendPlans.TakeLast(28).ToList())))
             .OnDrafts(() => client.Toast("Drafts clicked", "OnDrafts").Info())

--- a/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
+++ b/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
@@ -25,10 +25,6 @@ public record DashboardJobDto(string Id, string PlanId, string Title, string Sta
 ///     One <c>yyyy-MM-dd</c> per plotted day, ascending and contiguous. The frontend formats the axis
 ///     and the tooltip from these, so the series carries no pre-rendered labels.
 /// </param>
-/// <param name="PrevCost">
-///     The comparison period's raw value for the same calendar day, or null where that day predates the
-///     records and comparing against it would invent a zero.
-/// </param>
 /// <param name="RollingCost">
 ///     A 7 day trailing mean aligned to <paramref name="Dates" />, null where the window reaches back
 ///     past the earliest record. A gap here is drawn as a gap in the curve.
@@ -37,8 +33,6 @@ public record DashboardTrendDto(
     List<string> Dates,
     List<double> Cost,
     List<double> Plans,
-    List<double?> PrevCost,
-    List<double?> PrevPlans,
     List<double?> RollingCost,
     List<double?> RollingPlans);
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
@@ -31,8 +31,6 @@ const trendOf = (
     dates,
     cost: dates.map(() => cost),
     plans: dates.map(() => plans),
-    prevCost: dates.map(() => cost / 2),
-    prevPlans: dates.map(() => plans / 2),
     rollingCost: dates.map((_, i) => (rollingKnown && i >= 6 ? cost : null)),
     rollingPlans: dates.map((_, i) => (rollingKnown && i >= 6 ? plans : null)),
   };
@@ -65,12 +63,12 @@ describe("TendrilDashboard trend legend", () => {
     } as unknown as typeof ResizeObserver;
   });
 
-  it("names the rolling average and drops the old constant average item", () => {
+  it("names the rolling average and omits the comparison series", () => {
     renderDashboard(trendOf(30, 100, 4));
 
     expect(screen.getByText("7-day average")).toBeInTheDocument();
     expect(screen.getByText("Last 4 weeks")).toBeInTheDocument();
-    expect(screen.getByText("Previous 4 weeks")).toBeInTheDocument();
+    expect(screen.queryByText("Previous 4 weeks")).not.toBeInTheDocument();
     expect(screen.queryByText(/^Avg /)).not.toBeInTheDocument();
   });
 
@@ -105,7 +103,7 @@ describe("TendrilDashboard range and metric combinations", () => {
 
     expect(screen.getByText("Last 4 weeks: $45.00")).toBeInTheDocument();
     expect(screen.getByText("7-day average: $45.00")).toBeInTheDocument();
-    expect(screen.getByText("Previous 4 weeks: $22.50")).toBeInTheDocument();
+    expect(screen.queryByText("Previous 4 weeks: $22.50")).not.toBeInTheDocument();
   });
 
   it("shows the 4 week plan series counted in plans", () => {
@@ -116,7 +114,7 @@ describe("TendrilDashboard range and metric combinations", () => {
 
     expect(screen.getByText("Last 4 weeks: 4 plans")).toBeInTheDocument();
     expect(screen.getByText("7-day average: 4 plans")).toBeInTheDocument();
-    expect(screen.getByText("Previous 4 weeks: 2 plans")).toBeInTheDocument();
+    expect(screen.queryByText("Previous 4 weeks: 2 plans")).not.toBeInTheDocument();
   });
 
   it("falls back to monthly trend if weekly trend is not provided", () => {
@@ -126,7 +124,7 @@ describe("TendrilDashboard range and metric combinations", () => {
 
     expect(screen.getByText("Last 4 weeks: $120.00")).toBeInTheDocument();
     expect(screen.getByText("7-day average: $120.00")).toBeInTheDocument();
-    expect(screen.getByText("Previous 4 weeks: $60.00")).toBeInTheDocument();
+    expect(screen.queryByText("Previous 4 weeks: $60.00")).not.toBeInTheDocument();
   });
 
   it("hides the trend card entirely when there is no series", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -93,7 +93,6 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
 
   const activeTrend = trendWeekly ?? trend;
   const currentTrendName = "Last 4 weeks";
-  const previousTrendName = "Previous 4 weeks";
 
   const trendData =
     activeTrend == null
@@ -101,14 +100,12 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
       : tab === "cost"
         ? {
             values: activeTrend.cost,
-            previous: activeTrend.prevCost,
             rolling: activeTrend.rollingCost,
             formatTick: formatCurrencyTick,
             formatValue: formatCurrencyValue,
           }
         : {
             values: activeTrend.plans,
-            previous: activeTrend.prevPlans,
             rolling: activeTrend.rollingPlans,
             formatTick: formatCountTick,
             formatValue: formatPlansValue,
@@ -211,10 +208,6 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
                       {currentTrendName}
                     </span>
                     <span className="tdb-legend-item">
-                      <span className="tdb-legend-dash" />
-                      {previousTrendName}
-                    </span>
-                    <span className="tdb-legend-item">
                       <span className="tdb-legend-line-avg" />
                       7-day average
                     </span>
@@ -224,10 +217,8 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
                   <TrendChart
                     dates={activeTrend!.dates}
                     values={trendData.values}
-                    previous={trendData.previous}
                     rolling={trendData.rolling}
                     currentName={currentTrendName}
-                    previousName={previousTrendName}
                     formatTick={trendData.formatTick}
                     formatValue={trendData.formatValue}
                   />

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx
@@ -23,10 +23,8 @@ const renderChart = (props: Partial<React.ComponentProps<typeof TrendChart>> = {
     <TrendChart
       dates={dates}
       values={props.values ?? dates.map((_, i) => 100 + i * 10)}
-      previous={props.previous}
       rolling={props.rolling}
       currentName={props.currentName ?? "Last 4 weeks"}
-      previousName={props.previousName ?? "Previous 4 weeks"}
       formatTick={props.formatTick ?? ((v) => `$${v}`)}
       formatValue={props.formatValue ?? formatCurrencyValue}
     />,
@@ -56,6 +54,15 @@ describe("TrendChart rolling average curve", () => {
 
     expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(1);
     expect(container.querySelectorAll(".tdb-trend-avg-line")).toHaveLength(0);
+  });
+
+  it("does not render the comparison curve", () => {
+    const dates = days(30);
+    const values = dates.map((_, i) => 100 + i * 10);
+
+    const { container } = renderChart({ dates, values });
+
+    expect(container.querySelectorAll(".tdb-trend-compare")).toHaveLength(0);
   });
 
   it("draws an expanding average curve when rolling series is omitted", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
@@ -5,9 +5,7 @@ interface TrendChartProps {
   /** One `yyyy-MM-dd` per point, ascending and contiguous. Axis ticks and tooltips come from these. */
   dates: string[];
   values: number[];
-  previous?: (number | null)[];
   currentName: string;
-  previousName: string;
   formatTick: (value: number) => string;
   formatValue: (value: number) => string;
   /**
@@ -75,9 +73,7 @@ const ZERO_LIFT = 6;
 export const TrendChart: React.FC<TrendChartProps> = ({
   dates,
   values,
-  previous = [],
   currentName,
-  previousName,
   formatTick,
   formatValue,
   rolling,
@@ -121,12 +117,11 @@ export const TrendChart: React.FC<TrendChartProps> = ({
     [rolling, values],
   );
 
-  const { ticks, points, previousPoints, rollingSegments } = useMemo(() => {
-    const previousValues = previous.filter((v): v is number => v != null);
+  const { ticks, points, rollingSegments } = useMemo(() => {
     // The rolling series counts towards the scale: its first points average days from before the
     // displayed range, which can sit above everything on screen.
     const rollingValues = rollingSeries.filter((v): v is number => v != null);
-    const maxValue = Math.max(1, ...values, ...previousValues, ...rollingValues);
+    const maxValue = Math.max(1, ...values, ...rollingValues);
     const tickValues = niceTicks(maxValue, 4);
     const scaleMax = tickValues[tickValues.length - 1];
     const toPoint = (value: number, index: number): Point => ({
@@ -136,14 +131,11 @@ export const TrendChart: React.FC<TrendChartProps> = ({
     return {
       ticks: tickValues,
       points: values.map(toPoint),
-      previousPoints: previous
-        .map((value, index) => (value != null ? toPoint(value, index) : null))
-        .filter((p): p is Point => p != null),
       rollingSegments: splitSegments(
         rollingSeries.map((value, index) => (value != null ? toPoint(value, index) : null)),
       ),
     };
-  }, [values, previous, rollingSeries, n, plotLeft, plotWidth, zeroY, plotHeight]);
+  }, [values, rollingSeries, n, plotLeft, plotWidth, zeroY, plotHeight]);
 
   const scaleTop = ticks[ticks.length - 1];
 
@@ -175,11 +167,6 @@ export const TrendChart: React.FC<TrendChartProps> = ({
           x: plotLeft + (n <= 1 ? plotWidth / 2 : (hoverIndex / (n - 1)) * plotWidth),
           value: values[hoverIndex],
           rollingValue: rollingSeries[hoverIndex] ?? null,
-          previousValue: previous[hoverIndex] ?? null,
-          previousY:
-            previous[hoverIndex] != null
-              ? zeroY - (previous[hoverIndex]! / scaleTop) * plotHeight
-              : null,
         }
       : null;
 
@@ -224,7 +211,6 @@ export const TrendChart: React.FC<TrendChartProps> = ({
             );
           })}
           {areaPath && <path d={areaPath} fill={`url(#${gradientId})`} style={{ color: "var(--tdb-fg)" }} />}
-          {previousPoints.length > 1 && <path className="tdb-trend-compare" d={smoothPath(previousPoints, zeroY)} />}
           {rollingSegments.map((segment, i) => (
             <path
               key={`rolling-${i}`}
@@ -244,9 +230,6 @@ export const TrendChart: React.FC<TrendChartProps> = ({
                 strokeDasharray="3 3"
               />
               <circle cx={hover.x} cy={points[hover.index].y} r={3.5} fill="var(--tdb-fg)" />
-              {hover.previousY != null && (
-                <circle cx={hover.x} cy={hover.previousY} r={3.5} fill="var(--tdb-compare)" />
-              )}
             </g>
           )}
         </svg>
@@ -262,12 +245,6 @@ export const TrendChart: React.FC<TrendChartProps> = ({
             <div className="tdb-chart-tooltip-row">
               <span className="tdb-legend-line-avg" />
               7-day average: {formatValue(hover.rollingValue)}
-            </div>
-          )}
-          {hover.previousValue != null && (
-            <div className="tdb-chart-tooltip-row">
-              <span className="tdb-legend-dash" />
-              {previousName}: {formatValue(hover.previousValue)}
             </div>
           )}
         </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -21,10 +21,6 @@
   --tdb-ramp-3: color-mix(in srgb, var(--foreground, #000000) 60%, transparent);
   --tdb-ramp-4: var(--foreground, #000000);
 
-  /* Comparison (previous year) line. Derived from the theme's --primary so it
-     tracks alternate themes; kept near full strength (unlike the KPI tints)
-     because it is a thin dashed stroke that has to stay readable. */
-  --tdb-compare: color-mix(in srgb, var(--primary, #a0bce8) 70%, var(--tdb-bg));
 
   /* KPI card tints. All four derive from the host theme's --primary so
      alternate themes (neon, retro, cupcake...) recolor the cards
@@ -346,12 +342,6 @@
   flex-shrink: 0;
 }
 
-.tdb-legend-dash {
-  width: 10px;
-  height: 0;
-  border-top: 2px dashed var(--tdb-compare);
-  flex-shrink: 0;
-}
 
 .tdb-legend-line-avg {
   width: 10px;
@@ -401,14 +391,6 @@
   stroke-linejoin: round;
 }
 
-.tdb-trend-compare {
-  fill: none;
-  stroke: var(--tdb-compare);
-  stroke-width: 1.25;
-  stroke-dasharray: 5 4;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
 
 /* Dashed curve for 7-day average to distinguish from solid current usage. */
 .tdb-trend-avg-curve {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -87,6 +87,8 @@ describe("dashboard.css rolling average curve and legend", () => {
   it("no longer carries the constant horizontal reference line", () => {
     expect(css).not.toContain(".tdb-trend-avg-line");
     expect(css).not.toContain(".tdb-legend-dash-avg");
+    expect(css).not.toContain(".tdb-trend-compare");
+    expect(css).not.toContain(".tdb-legend-dash {");
   });
 
   it("no longer carries granularity toggle styles", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -38,8 +38,6 @@ export interface DashboardTrendDto {
   dates: string[];
   cost: number[];
   plans: number[];
-  prevCost: (number | null)[];
-  prevPlans: (number | null)[];
   /** 7-day trailing mean aligned to `dates`; null where the window reaches past the earliest record. */
   rollingCost: (number | null)[];
   rollingPlans: (number | null)[];

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -287,24 +287,21 @@ public class DashboardApp : ViewBase
     internal const int TrendDailyWindowDays = 28;
 
     /// <summary>
-    ///     The last twelve months as daily points, compared against the same calendar day a year
-    ///     earlier. Null when no daily series is available.
+    ///     The last twelve months as daily points. Null when no daily series is available.
     /// </summary>
     internal static DashboardTrendDto? BuildTrend(
         DashboardActivityStats activity, DateTime? todayOverride = null) =>
-        BuildDailyTrend(activity, TrendDailyShownDays, date => date.AddYears(-1), todayOverride);
+        BuildDailyTrend(activity, TrendDailyShownDays, todayOverride);
 
     /// <summary>
-    ///     The last four weeks as daily points, compared against the 28 days before them. Null when no
-    ///     daily series is available.
+    ///     The last four weeks as daily points. Null when no daily series is available.
     /// </summary>
     internal static DashboardTrendDto? BuildWeeklyTrend(
         DashboardActivityStats activity, DateTime? todayOverride = null) =>
-        BuildDailyTrend(activity, TrendDailyWindowDays, date => date.AddDays(-TrendDailyWindowDays), todayOverride);
+        BuildDailyTrend(activity, TrendDailyWindowDays, todayOverride);
 
     /// <summary>
-    ///     One trend card's worth of contiguous daily points ending today, each with a date-aligned
-    ///     comparison and a rolling 7 day mean.
+    ///     One trend card's worth of contiguous daily points ending today, with a rolling 7 day mean.
     /// </summary>
     /// <remarks>
     ///     Returns null when neither daily series is present rather than falling back to weekly or
@@ -315,7 +312,6 @@ public class DashboardApp : ViewBase
     internal static DashboardTrendDto? BuildDailyTrend(
         DashboardActivityStats activity,
         int days,
-        Func<DateOnly, DateOnly> comparisonDate,
         DateTime? todayOverride = null)
     {
         if (activity.DailyCosts == null && activity.DailyPlans == null)
@@ -337,24 +333,10 @@ public class DashboardApp : ViewBase
         double CostAt(DateOnly date) => costsByDay.GetValueOrDefault(date, 0.0);
         double PlansAt(DateOnly date) => plansByDay.GetValueOrDefault(date, 0);
 
-        var prevCost = new List<double?>(days);
-        var prevPlans = new List<double?>(days);
-        foreach (var date in dates)
-        {
-            // Note that Feb 29 maps to Feb 28 a year earlier, which is the calendar behaviour wanted.
-            var prev = comparisonDate(date);
-            // Before the first recorded day the comparison is unknown, not zero.
-            var known = dataStart != null && prev >= dataStart.Value;
-            prevCost.Add(known && activity.DailyCosts != null ? CostAt(prev) : null);
-            prevPlans.Add(known && activity.DailyPlans != null ? PlansAt(prev) : null);
-        }
-
         return new DashboardTrendDto(
             dates.Select(d => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)).ToList(),
             dates.Select(CostAt).ToList(),
             dates.Select(PlansAt).ToList(),
-            prevCost,
-            prevPlans,
             RollingAverageCalculator.Compute(dates, CostAt, dataStart),
             RollingAverageCalculator.Compute(dates, PlansAt, dataStart));
     }


### PR DESCRIPTION
# Summary

## Changes

Removed the dashed "Previous 4 weeks" comparison series end to end across frontend and backend. The dashboard trend card now focuses cleanly on the solid 4-week series and dashed 7-day rolling average without visual noise or extraneous computation.

## API Changes

- `TendrilDashboard.cs`: Removed `PrevCost` and `PrevPlans` fields from public record `DashboardTrendDto`.
- `types.ts`: Removed `prevCost` and `prevPlans` properties from interface `DashboardTrendDto`.
- `TrendChart.tsx`: Removed `previous` and `previousName` optional properties from `TrendChartProps`.

## Files Modified

- **Frontend Components & Styles**:
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`: Removed comparison fields from TypeScript trend DTO.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx`: Removed comparison series state, legend entry, and chart props.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx`: Removed comparison series props, y-axis scaling contribution, SVG path, hover dot, and tooltip row.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`: Removed `--tdb-compare` variable, `.tdb-legend-dash`, and `.tdb-trend-compare` rules.
- **Backend ViewModels & DTOs**:
  - `src/Ivy.Tendril.Widgets/TendrilDashboard.cs`: Removed comparison fields and XML docs from C# `DashboardTrendDto`.
  - `src/Ivy.Tendril/Apps/DashboardApp.cs`: Removed comparison date parameter and comparison lists from `BuildDailyTrend`, `BuildTrend`, and `BuildWeeklyTrend`.
  - `src/Ivy.Tendril.Widgets/.samples/Apps/TendrilDashboard/DemoApp.cs`: Removed sample comparison series generation.
- **Unit & Component Tests**:
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx`: Added negative assertions confirming "Previous 4 weeks" is not present in legend or tooltips.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx`: Added negative assertion confirming `.tdb-trend-compare` path is not rendered.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`: Added negative checks for comparison CSS classes.
  - `src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs`: Removed obsolete comparison tests and updated remaining assertions.

## Manual Testing

1. Launch Tendril and open the Dashboard view (or run the widget sample app).
2. Inspect the Trend card:
   - Verify the legend displays only "Last 4 weeks" (with dot) and "7-day average" (with dashed line), with no "Previous 4 weeks" item.
   - Verify the chart renders only the solid series line and the dashed rolling average line.
   - Hover over chart data points and verify the tooltip displays only the date, the current period value, and the 7-day average row, with no previous period row.

---
- 16f65488 [00214] Remove previous 4 weeks comparison series from dashboard trend

---
Created using [Ivy Tendril](https://ivy.app).
