### PR TITLE
[00230] Resolve Rolldown Empty Import Meta Warning in Widgets Build

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/vite.widget.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/vite.widget.ts
@@ -26,6 +26,12 @@ export default defineConfig({
         },
         extend: false,
       },
+      onLog(level, log, defaultHandler) {
+        if (log.code === "EMPTY_IMPORT_META") {
+          return;
+        }
+        defaultHandler(level, log);
+      },
     },
     outDir: "dist",
     emptyOutDir: true,


### PR DESCRIPTION
# Summary

## Changes

Added an `onLog` handler to `rolldownOptions` in `vite.widget.ts` to filter out the benign `EMPTY_IMPORT_META` warning emitted during the widget bundle build. This cleans up build logs without impacting browser runtime behavior, where DOMCanvasFactory is used instead of NodeCanvasFactory.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/vite.widget.ts`: Added `onLog` hook to filter out `EMPTY_IMPORT_META` logs while forwarding other compiler messages.

## Manual Testing

1. Navigate to the widget frontend directory: `cd src/Ivy.Tendril.Widgets/frontend`.
2. Run `pnpm run build` or `vp build --config vite.widget.ts`.
3. Observe that the build completes successfully and no `[EMPTY_IMPORT_META]` warning appears in the console output.
4. Run `dotnet build src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj` and verify that the build succeeds with 0 warnings.

---

### Commits

- b8e95e00: Resolve Rolldown empty import.meta warning in widgets build (#00230)

---
Created using [Ivy Tendril](https://ivy.app).
