### PR TITLE
[00206] Handle GitHub Secondary Rate Limits in Inbox Fetches

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/InboxAppTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/InboxAppTests.cs
@@ -1,7 +1,14 @@
+using Ivy;
 using Ivy.Tendril.Apps.Inbox;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Git;
+using Ivy.Tendril.Services.Inbox;
+using Ivy.Tendril.Services.Jobs;
+using Ivy.Tendril.Test.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test.Apps;
 
@@ -199,8 +206,80 @@ public class InboxAppTests
         Assert.Null(pr.Branch);
     }
 
-    private sealed class StubGithubService(ProjectConfig? projectToReturn) : IGithubService
+    [Fact]
+    public async Task InboxApp_SingleFlight_CollapsesConcurrentFetches_And_OnRefresh_BypassesTtl()
     {
+        var services = new ServiceCollection();
+        var stubGithub = new StubGithubService();
+        var configService = new ConfigService(new TendrilSettings());
+        var queryService = new QueryService(NullLogger<QueryService>.Instance);
+
+        services.AddSingleton<IGithubService>(stubGithub);
+        services.AddSingleton<IConfigService>(configService);
+        services.AddSingleton<IQueryService>(queryService);
+        services.AddSingleton<IClientProvider>(new DummyClientProvider());
+        services.AddLogging();
+        services.AddSingleton<ILogger<InboxApp>>(NullLogger<InboxApp>.Instance);
+        var autoImportService = new AssignedIssuesAutoImportService(
+            configService,
+            stubGithub,
+            new FakePlanReaderService(),
+            new DummyJobService(),
+            NullLogger<AssignedIssuesAutoImportService>.Instance,
+            queryService);
+        services.AddSingleton(autoImportService);
+
+        var appContext = (Ivy.AppContext)Activator.CreateInstance(
+            typeof(Ivy.AppContext),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            null,
+            new object?[] { "conn1", "mach1", "inbox", "inbox", null, "http", "localhost", null },
+            null)!;
+        services.AddSingleton(appContext);
+
+        var sp = services.BuildServiceProvider();
+
+        int refreshCount = 0;
+        var ctx = new Ivy.Core.Hooks.ViewContext(() => { refreshCount++; }, null, sp);
+
+        var app = new InboxApp();
+        app.BeforeBuild(ctx);
+        var built = app.Build();
+        app.AfterBuild();
+
+        Assert.NotNull(built);
+
+        var layout = Assert.IsType<SidebarLayout>(built);
+        var mainContentSlot = Assert.IsType<Slot>(layout.Children[0]);
+        var contentView = Assert.IsType<ContentView>(mainContentSlot.Children[0]);
+
+        var initialCompleted = RetryHelper.WaitUntil(() =>
+            stubGithub.MyAssignedIssuesCallCount == 1 &&
+            stubGithub.ReviewRequestsCallCount == 1,
+            timeout: TimeSpan.FromSeconds(5));
+
+        Assert.True(initialCompleted, "Initial queries did not complete within timeout.");
+        Assert.Equal(1, stubGithub.MyAssignedIssuesCallCount);
+        Assert.Equal(1, stubGithub.ReviewRequestsCallCount);
+
+        // Invoke the onRefresh callback passed to ContentView while selectedCategory is MyIssues
+        // and assert the counter increments by exactly one immediately, bypassing the 60-second Expiration.
+        await contentView.RefreshHandler();
+
+        var refreshCompleted = RetryHelper.WaitUntil(() =>
+            stubGithub.MyAssignedIssuesCallCount == 2,
+            timeout: TimeSpan.FromSeconds(5));
+
+        Assert.True(refreshCompleted, "OnRefresh did not trigger revalidation within timeout.");
+        Assert.Equal(2, stubGithub.MyAssignedIssuesCallCount);
+        Assert.Equal(1, stubGithub.ReviewRequestsCallCount);
+    }
+
+    private sealed class StubGithubService(ProjectConfig? projectToReturn = null) : IGithubService
+    {
+        public int MyAssignedIssuesCallCount { get; private set; }
+        public int ReviewRequestsCallCount { get; private set; }
+
         public List<RepoConfig> GetRepos() => [];
         public RepoConfig? GetRepoConfigFromPathCached(string repoPath) => null;
         public ProjectConfig? FindProjectForGithubRepo(string ownerRepo) => projectToReturn;
@@ -213,9 +292,55 @@ public class InboxAppTests
             Task.FromResult((new Dictionary<string, PrInfo>(), (string?)null));
         public Task<(List<GitHubIssue> issues, string? error)> SearchIssuesAsync(IssueSearchRequest request) =>
             Task.FromResult((new List<GitHubIssue>(), (string?)null));
-        public Task<(List<GitHubIssue> issues, string? error)> GetMyAssignedIssuesAsync() =>
-            Task.FromResult((new List<GitHubIssue>(), (string?)null));
-        public Task<(List<GitHubReviewItem> prs, string? error)> GetReviewRequestsAsync() =>
-            Task.FromResult((new List<GitHubReviewItem>(), (string?)null));
+        public Task<(List<GitHubIssue> issues, string? error)> GetMyAssignedIssuesAsync()
+        {
+            MyAssignedIssuesCallCount++;
+            return Task.FromResult((new List<GitHubIssue>(), (string?)null));
+        }
+        public Task<(List<GitHubReviewItem> prs, string? error)> GetReviewRequestsAsync()
+        {
+            ReviewRequestsCallCount++;
+            return Task.FromResult((new List<GitHubReviewItem>(), (string?)null));
+        }
+    }
+
+    private sealed class DummyClientProvider : IClientProvider
+    {
+        public IClientSender Sender { get; set; } = new DummyClientSender();
+    }
+
+    private sealed class DummyClientSender : IClientSender
+    {
+        public void Send(string method, object? data) { }
+    }
+
+    private sealed class DummyJobService : IJobService
+    {
+#pragma warning disable CS0067
+        public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
+        public event Action<JobNotification>? NotificationReady;
+        public event Action<JobItem>? JobFinished;
+#pragma warning restore CS0067
+
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null) => "job-1";
+        public void ForceStartJob(string id) { }
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
+        public void StopJob(string id) { }
+        public int StopAllJobs() => 0;
+        public void DeleteJob(string id) { }
+        public void ClearCompletedJobs() { }
+        public void ClearFailedJobs() { }
+        public void ClearAllJobs() { }
+        public int StopQueuedJobs() => 0;
+        public List<JobItem> GetJobs() => [];
+        public List<JobItem> GetJobsForPlan(string planFile) => [];
+        public JobItem? GetJob(string id) => null;
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => true;
+        public void SetChatSessionId(string id, string chatSessionId) { }
+        public bool ReportJobFailure(string id, string message) => true;
+        public bool IsInboxFileTracked(string filePath) => false;
+        public void Dispose() { }
     }
 }

--- a/src/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test;
@@ -688,5 +689,48 @@ public class GithubServiceTests
         };
         using var process = Process.Start(psi)!;
         process.WaitForExit();
+    }
+
+    [Fact]
+    public async Task SearchIssuesAsync_NonexistentRepo_ReturnsErrorWithoutRateLimitMessage()
+    {
+        var configService = new ConfigService(new TendrilSettings());
+        using var githubService = new GithubService(configService, NullLogger<GithubService>.Instance);
+
+        var request = new IssueSearchRequest("nonexistent-owner-12345", "nonexistent-repo-12345");
+        var (issues, error) = await githubService.SearchIssuesAsync(request);
+
+        Assert.Empty(issues);
+        Assert.NotNull(error);
+        Assert.NotEqual(GhRateLimit.UserMessage, error);
+    }
+
+    [Fact]
+    public async Task ExecuteGhCliAsync_ConcurrentCalls_AreSerializedByGhGate()
+    {
+        var configService = new ConfigService(new TendrilSettings());
+        using var githubService = new GithubService(configService, NullLogger<GithubService>.Instance);
+
+        // Pre-acquire the gate to simulate an active operation holding the semaphore
+        await githubService.GhGate.WaitAsync();
+
+        // Launch an operation that calls ExecuteGhCliAsync
+        var task = Task.Run(async () =>
+        {
+            return await githubService.ExecuteGhCliAsync("version", s => s, string.Empty);
+        });
+
+        // Give the background task time to attempt acquiring the gate
+        await Task.Delay(100);
+
+        // While gate is held, the queued call must remain blocked
+        Assert.False(task.IsCompleted);
+
+        // Release the gate
+        githubService.GhGate.Release();
+
+        // Now the task should unblock and complete
+        var (result, error) = await task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(task.IsCompletedSuccessfully);
     }
 }

--- a/src/Ivy.Tendril.Test/Services/Git/GhRateLimitTests.cs
+++ b/src/Ivy.Tendril.Test/Services/Git/GhRateLimitTests.cs
@@ -1,0 +1,73 @@
+using Ivy.Tendril.Services.Git;
+
+namespace Ivy.Tendril.Test.Services.Git;
+
+public class GhRateLimitTests
+{
+    [Theory]
+    [InlineData("HTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.")]
+    [InlineData("API rate limit exceeded for user ID 12345.")]
+    [InlineData("You have triggered an abuse detection mechanism.")]
+    [InlineData("was submitted too quickly")]
+    [InlineData("Retry-After: 60")]
+    public void IsRateLimitError_ReturnsTrue_ForRateLimitErrors(string stderr)
+    {
+        Assert.True(GhRateLimit.IsRateLimitError(stderr));
+    }
+
+    [Theory]
+    [InlineData("GraphQL: Could not resolve to a Repository")]
+    [InlineData("fatal: not a git repository")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsRateLimitError_ReturnsFalse_ForNonRateLimitErrors(string? stderr)
+    {
+        Assert.False(GhRateLimit.IsRateLimitError(stderr));
+    }
+
+    [Fact]
+    public void ParseRetryAfter_ExtractsHeader_AndClampsToMax()
+    {
+        var result42 = GhRateLimit.ParseRetryAfter("HTTP 403: rate limited\nRetry-After: 42\nDetails...");
+        Assert.NotNull(result42);
+        Assert.Equal(TimeSpan.FromSeconds(42), result42.Value);
+
+        var resultClamped = GhRateLimit.ParseRetryAfter("HTTP 403: rate limited\nRetry-After: 9999");
+        Assert.NotNull(resultClamped);
+        Assert.Equal(TimeSpan.FromSeconds(120), resultClamped.Value);
+
+        var resultAbsent = GhRateLimit.ParseRetryAfter("HTTP 403: You have exceeded a secondary rate limit.");
+        Assert.Null(resultAbsent);
+
+        var resultNull = GhRateLimit.ParseRetryAfter(null);
+        Assert.Null(resultNull);
+    }
+
+    [Fact]
+    public void GetRetryDelay_HonoursSuppliedRetryAfter_Verbatim()
+    {
+        var customDelay = TimeSpan.FromSeconds(42);
+        var delay = GhRateLimit.GetRetryDelay(1, customDelay);
+        Assert.Equal(customDelay, delay);
+    }
+
+    [Fact]
+    public void GetRetryDelay_ReturnsIncreasingDelaysWithinBasePlusJitterRange()
+    {
+        for (var i = 0; i < 20; i++)
+        {
+            var delay1 = GhRateLimit.GetRetryDelay(1);
+            Assert.InRange(delay1.TotalSeconds, 2.0, 2.41);
+
+            var delay2 = GhRateLimit.GetRetryDelay(2);
+            Assert.InRange(delay2.TotalSeconds, 8.0, 9.61);
+
+            var delay3 = GhRateLimit.GetRetryDelay(3);
+            Assert.InRange(delay3.TotalSeconds, 30.0, 36.01);
+
+            Assert.True(delay2 > delay1);
+            Assert.True(delay3 > delay2);
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/Inbox/AssignedIssuesAutoImportServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/Inbox/AssignedIssuesAutoImportServiceTests.cs
@@ -1,3 +1,4 @@
+using Ivy;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Git;
@@ -49,7 +50,7 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
         var jobService = new TestJobService();
         var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
 
-        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, new FakeQueryService());
 
         await service.RunSyncAsync();
 
@@ -76,7 +77,7 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
         var jobService = new TestJobService();
         var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
 
-        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, new FakeQueryService());
 
         await service.RunSyncAsync();
 
@@ -115,7 +116,7 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
         var jobService = new TestJobService();
         var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
 
-        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, new FakeQueryService());
 
         await service.RunSyncAsync();
 
@@ -155,7 +156,7 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
         var jobService = new TestJobService();
         var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
 
-        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, new FakeQueryService());
 
         await service.RunSyncAsync();
 
@@ -216,7 +217,7 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
         var jobService = new TestJobService();
         var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
 
-        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, new FakeQueryService());
 
         await service.RunSyncAsync();
 
@@ -257,7 +258,7 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
         var planReader = new FakePlanReaderService();
         var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
 
-        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, new FakeQueryService());
 
         await service.RunSyncAsync();
 
@@ -285,7 +286,7 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
         var jobService = new TestJobService();
         var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
 
-        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger);
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, new FakeQueryService());
 
         await service.TriggerManualCheckAsync();
 
@@ -295,9 +296,127 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
         Assert.Single(files601);
     }
 
+    [Fact]
+    public async Task RunSyncAsync_WhenSuccessful_InvalidatesMyIssuesQueryTagOnce()
+    {
+        var config = CreateConfigService(autoAccept: true);
+        var github = new TestGithubService
+        {
+            IssuesToReturn = [new GitHubIssue(101, "Issue 1", "Body", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/101")]
+        };
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+        var queryService = new FakeQueryService();
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, queryService);
+
+        await service.RunSyncAsync();
+
+        Assert.Single(queryService.InvalidatedTags);
+        Assert.Equal(GithubService.MyIssuesQueryTag, queryService.InvalidatedTags[0]);
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_WhenSyncFails_DoesNotInvalidateQueryTag()
+    {
+        var config = CreateConfigService(autoAccept: true);
+        var github = new TestGithubService
+        {
+            ErrorToReturn = "Failed to fetch issues"
+        };
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+        var queryService = new FakeQueryService();
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, queryService);
+
+        await service.RunSyncAsync();
+
+        Assert.Empty(queryService.InvalidatedTags);
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_WhenDisabled_DoesNotInvalidateQueryTag()
+    {
+        var config = CreateConfigService(autoAccept: false);
+        var github = new TestGithubService
+        {
+            IssuesToReturn = [new GitHubIssue(101, "Issue 1", "Body", [], ["user1"], "owner/repo", "https://github.com/owner/repo/issues/101")]
+        };
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+        var queryService = new FakeQueryService();
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, queryService);
+
+        await service.RunSyncAsync();
+
+        Assert.Empty(queryService.InvalidatedTags);
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_WhenAlreadyInProgress_DoesNotInvalidateQueryTag()
+    {
+        var config = CreateConfigService(autoAccept: true);
+        var tcs = new TaskCompletionSource<(List<GitHubIssue>, string?)>();
+        var github = new BlockingGithubService(tcs.Task);
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+        var queryService = new FakeQueryService();
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, queryService);
+
+        var firstSync = service.RunSyncAsync();
+
+        await service.RunSyncAsync();
+
+        Assert.Empty(queryService.InvalidatedTags);
+
+        tcs.SetResult(([], null));
+        await firstSync;
+
+        Assert.Single(queryService.InvalidatedTags);
+    }
+
+    private sealed class FakeQueryService : IQueryService
+    {
+        public List<object> InvalidatedTags { get; } = [];
+
+        public void InvalidateByTag(object tag) => InvalidatedTags.Add(tag);
+        public void RevalidateByTag(object tag) { }
+        public void Invalidate(Func<object, bool> predicate) { }
+        public void Revalidate(Func<object, bool> predicate) { }
+        public void Clear() { }
+    }
+
+    private sealed class BlockingGithubService(Task<(List<GitHubIssue>, string?)> waitTask) : IGithubService
+    {
+        public List<RepoConfig> GetRepos() => [];
+        public RepoConfig? GetRepoConfigFromPathCached(string repoPath) => null;
+        public ProjectConfig? FindProjectForGithubRepo(string ownerRepo) => null;
+        public IReadOnlyList<string> GetResolvedGithubRepos(ProjectConfig project) => [];
+        public Task<(List<string> assignees, string? error)> GetAssigneesAsync(string owner, string repo) =>
+            Task.FromResult((new List<string>(), (string?)null));
+        public Task<(List<string> labels, string? error)> GetLabelsAsync(string owner, string repo) =>
+            Task.FromResult((new List<string>(), (string?)null));
+        public Task<(Dictionary<string, PrInfo> statuses, string? error)> GetPrStatusesAsync(string owner, string repo) =>
+            Task.FromResult((new Dictionary<string, PrInfo>(), (string?)null));
+        public Task<(List<GitHubIssue> issues, string? error)> SearchIssuesAsync(IssueSearchRequest request) =>
+            Task.FromResult((new List<GitHubIssue>(), (string?)null));
+        public async Task<(List<GitHubIssue> issues, string? error)> GetMyAssignedIssuesAsync() =>
+            await waitTask;
+        public Task<(List<GitHubReviewItem> prs, string? error)> GetReviewRequestsAsync() =>
+            Task.FromResult((new List<GitHubReviewItem>(), (string?)null));
+    }
+
     private sealed class TestGithubService : IGithubService
     {
         public List<GitHubIssue> IssuesToReturn { get; set; } = [];
+        public string? ErrorToReturn { get; set; }
         public int CallCount { get; private set; }
         public Dictionary<string, ProjectConfig> ProjectMap { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -318,7 +437,7 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
         public Task<(List<GitHubIssue> issues, string? error)> GetMyAssignedIssuesAsync()
         {
             CallCount++;
-            return Task.FromResult((IssuesToReturn, (string?)null));
+            return Task.FromResult((IssuesToReturn, ErrorToReturn));
         }
         public Task<(List<GitHubReviewItem> prs, string? error)> GetReviewRequestsAsync() =>
             Task.FromResult((new List<GitHubReviewItem>(), (string?)null));

--- a/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
@@ -48,6 +48,8 @@ public class ContentView(
     Func<IReadOnlyList<GitHubIssue>, Task> onFireOffIssues,
     AssignedIssuesAutoImportService? autoImportService = null) : ViewBase
 {
+    internal Func<Task> RefreshHandler => onRefresh;
+
     public override object Build()
     {
         var client = UseService<IClientProvider>();

--- a/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Ivy;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -26,8 +27,17 @@ public class InboxApp : ViewBase
         var selectedLabels = UseState(Array.Empty<string>());
         var selectedIssueNumbers = UseState<HashSet<int>>([]);
 
-        var myIssues = UseState<List<GitHubIssue>>([]);
-        var reviewRequests = UseState<List<GitHubReviewItem>>([]);
+        var myIssuesQuery = this.UseQuery<(List<GitHubIssue> Issues, string? Error), string>(
+            "inbox:my-issues",
+            async (_, _) => await githubService.GetMyAssignedIssuesAsync(),
+            new QueryOptions { Expiration = TimeSpan.FromSeconds(60) },
+            tags: [GithubService.MyIssuesQueryTag]);
+        var reviewRequestsQuery = this.UseQuery<(List<GitHubReviewItem> Reviews, string? Error), string>(
+            "inbox:review-requests",
+            async (_, _) => await githubService.GetReviewRequestsAsync(),
+            new QueryOptions { Expiration = TimeSpan.FromSeconds(60) },
+            tags: [GithubService.ReviewRequestsQueryTag]);
+
         var projectIssues = UseState<List<GitHubIssue>>([]);
         var availableAssignees = UseState<List<string>>([]);
         var availableLabels = UseState<List<string>>([]);
@@ -35,7 +45,6 @@ public class InboxApp : ViewBase
         var isFetching = UseState(false);
         var isImporting = UseState(false);
         var errorMessage = UseState<string?>(null);
-        var hasInitialLoaded = UseState(false);
         var refreshToken = UseRefreshToken();
 
         UseEffect(() =>
@@ -45,7 +54,10 @@ public class InboxApp : ViewBase
             selectedAssignees.Set(Array.Empty<string>());
             selectedLabels.Set(Array.Empty<string>());
 
-            Task.Run(FetchCurrentDataAsync);
+            if (selectedCategory.Value == InboxCategory.Project)
+            {
+                Task.Run(FetchCurrentDataAsync);
+            }
         }, selectedCategory);
 
         UseEffect(() =>
@@ -61,117 +73,63 @@ public class InboxApp : ViewBase
             }
         }, selectedProject);
 
-        UseEffect(() =>
-        {
-            if (!hasInitialLoaded.Value)
-            {
-                hasInitialLoaded.Set(true);
-                Task.Run(FetchCurrentDataAsync);
-
-                // Also background-fetch counts for MyIssues and Reviews
-                Task.Run(async () =>
-                {
-                    try
-                    {
-                        var (issues, _) = await githubService.GetMyAssignedIssuesAsync();
-                        myIssues.Set(issues);
-                    }
-                    catch { }
-
-                    try
-                    {
-                        var (reviews, _) = await githubService.GetReviewRequestsAsync();
-                        reviewRequests.Set(reviews);
-                    }
-                    catch { }
-                });
-            }
-        });
-
         async Task FetchCurrentDataAsync()
         {
+            if (string.IsNullOrEmpty(selectedProject.Value))
+            {
+                projectIssues.Set([]);
+                return;
+            }
+
             isFetching.Set(true);
             errorMessage.Set(null);
 
             try
             {
-                if (selectedCategory.Value == InboxCategory.MyIssues)
+                var proj = config.Settings.Projects.FirstOrDefault(p =>
+                    string.Equals(p.Name, selectedProject.Value, StringComparison.OrdinalIgnoreCase));
+                if (proj == null)
                 {
-                    var (issues, err) = await githubService.GetMyAssignedIssuesAsync();
-                    if (err != null)
-                    {
+                    projectIssues.Set([]);
+                    return;
+                }
+
+                var resolvedRepos = githubService.GetResolvedGithubRepos(proj);
+                if (resolvedRepos.Count == 0)
+                {
+                    projectIssues.Set([]);
+                    errorMessage.Set($"No git remotes resolved for project {proj.Name}.");
+                    return;
+                }
+
+                var allIssues = new List<GitHubIssue>();
+                var allAssignees = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var allLabels = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var repoStr in resolvedRepos)
+                {
+                    var parts = repoStr.Split('/');
+                    if (parts.Length != 2) continue;
+                    var owner = parts[0];
+                    var repoName = parts[1];
+
+                    var (issues, err) = await githubService.SearchIssuesAsync(
+                        CreateProjectIssueRequest(owner, repoName));
+
+                    if (err != null && errorMessage.Value == null)
                         errorMessage.Set(err);
-                    }
-                    else
+
+                    foreach (var issue in issues)
                     {
-                        myIssues.Set(issues);
+                        allIssues.Add(issue with { Repository = repoStr });
+                        foreach (var a in issue.Assignees) if (!string.IsNullOrWhiteSpace(a)) allAssignees.Add(a);
+                        foreach (var l in issue.Labels) if (!string.IsNullOrWhiteSpace(l)) allLabels.Add(l);
                     }
                 }
-                else if (selectedCategory.Value == InboxCategory.Reviews)
-                {
-                    var (reviews, err) = await githubService.GetReviewRequestsAsync();
-                    if (err != null)
-                    {
-                        errorMessage.Set(err);
-                    }
-                    else
-                    {
-                        reviewRequests.Set(reviews);
-                    }
-                }
-                else // Project
-                {
-                    if (string.IsNullOrEmpty(selectedProject.Value))
-                    {
-                        projectIssues.Set([]);
-                        return;
-                    }
 
-                    var proj = config.Settings.Projects.FirstOrDefault(p =>
-                        string.Equals(p.Name, selectedProject.Value, StringComparison.OrdinalIgnoreCase));
-                    if (proj == null)
-                    {
-                        projectIssues.Set([]);
-                        return;
-                    }
-
-                    var resolvedRepos = githubService.GetResolvedGithubRepos(proj);
-                    if (resolvedRepos.Count == 0)
-                    {
-                        projectIssues.Set([]);
-                        errorMessage.Set($"No git remotes resolved for project {proj.Name}.");
-                        return;
-                    }
-
-                    var allIssues = new List<GitHubIssue>();
-                    var allAssignees = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    var allLabels = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-                    foreach (var repoStr in resolvedRepos)
-                    {
-                        var parts = repoStr.Split('/');
-                        if (parts.Length != 2) continue;
-                        var owner = parts[0];
-                        var repoName = parts[1];
-
-                        var (issues, err) = await githubService.SearchIssuesAsync(
-                            CreateProjectIssueRequest(owner, repoName));
-
-                        if (err != null && errorMessage.Value == null)
-                            errorMessage.Set(err);
-
-                        foreach (var issue in issues)
-                        {
-                            allIssues.Add(issue with { Repository = repoStr });
-                            foreach (var a in issue.Assignees) if (!string.IsNullOrWhiteSpace(a)) allAssignees.Add(a);
-                            foreach (var l in issue.Labels) if (!string.IsNullOrWhiteSpace(l)) allLabels.Add(l);
-                        }
-                    }
-
-                    projectIssues.Set(allIssues);
-                    availableAssignees.Set(allAssignees.OrderBy(a => a).ToList());
-                    availableLabels.Set(allLabels.OrderBy(l => l).ToList());
-                }
+                projectIssues.Set(allIssues);
+                availableAssignees.Set(allAssignees.OrderBy(a => a).ToList());
+                availableLabels.Set(allLabels.OrderBy(l => l).ToList());
             }
             catch (Exception ex)
             {
@@ -252,12 +210,15 @@ public class InboxApp : ViewBase
             }
         }
 
+        var myIssuesCount = myIssuesQuery.Loading ? 0 : (myIssuesQuery.Value.Issues?.Count ?? 0);
+        var reviewsCount = reviewRequestsQuery.Loading ? 0 : (reviewRequestsQuery.Value.Reviews?.Count ?? 0);
+
         var sidebar = new SidebarView(
             selectedCategory,
             selectedProject,
             config.Settings.Projects,
-            myIssuesCount: myIssues.Value.Count,
-            reviewsCount: reviewRequests.Value.Count,
+            myIssuesCount: myIssuesCount,
+            reviewsCount: reviewsCount,
             config: config,
             onSelectMyIssues: () => selectedCategory.Set(InboxCategory.MyIssues),
             onSelectReviews: () => selectedCategory.Set(InboxCategory.Reviews),
@@ -268,21 +229,47 @@ public class InboxApp : ViewBase
             }
         );
 
+        var myIssuesList = myIssuesQuery.Value.Issues ?? [];
+        var reviewRequestsList = reviewRequestsQuery.Value.Reviews ?? [];
+
+        var currentIsFetching = selectedCategory.Value switch
+        {
+            InboxCategory.MyIssues => myIssuesQuery.Loading,
+            InboxCategory.Reviews => reviewRequestsQuery.Loading,
+            _ => isFetching.Value
+        };
+
+        var currentErrorMessage = selectedCategory.Value switch
+        {
+            InboxCategory.MyIssues => myIssuesQuery.Value.Error,
+            InboxCategory.Reviews => reviewRequestsQuery.Value.Error,
+            _ => errorMessage.Value
+        };
+
+        Func<Task> onRefresh = selectedCategory.Value switch
+        {
+            InboxCategory.MyIssues => () => { myIssuesQuery.Mutator.Revalidate(); return Task.CompletedTask; }
+            ,
+            InboxCategory.Reviews => () => { reviewRequestsQuery.Mutator.Revalidate(); return Task.CompletedTask; }
+            ,
+            _ => FetchCurrentDataAsync
+        };
+
         var content = new ContentView(
             selectedCategory,
             selectedProject,
             config.Settings.Projects,
             selectedIssueNumbers,
-            myIssues.Value,
-            reviewRequests.Value,
+            myIssuesList,
+            reviewRequestsList,
             projectIssues.Value,
-            isFetching.Value,
-            errorMessage.Value,
+            currentIsFetching,
+            currentErrorMessage,
             isImporting,
             config,
             githubService,
             refreshToken,
-            onRefresh: FetchCurrentDataAsync,
+            onRefresh: onRefresh,
             onFireOffIssues: FireOffIssues,
             autoImportService: autoImportService
         );

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -323,7 +323,7 @@ public class ContentView(
             .WithLayout().Full().RemoveParentPadding()
             .Key(selectedPlan.Id);
 
-        var elements = new List<object> { workspace };
+        var elements = new List<object?> { workspace };
         elements.AddRange(page.Overlays);
         elements.AddRange([discardDialog, suggestChangesDialog, createPrDialog, resetToDraftDialog, debugSheet, costSheet]);
         if (isBeta || isShareMode)

--- a/src/Ivy.Tendril/Services/Git/GhRateLimit.cs
+++ b/src/Ivy.Tendril/Services/Git/GhRateLimit.cs
@@ -1,0 +1,65 @@
+using System.Text.RegularExpressions;
+
+namespace Ivy.Tendril.Services.Git;
+
+internal static class GhRateLimit
+{
+    internal const string UserMessage =
+        "GitHub is rate limiting requests. Tendril retried and is still being throttled, please try again in a few minutes.";
+
+    private static readonly string[] RateLimitIndicators =
+    [
+        "secondary rate limit",
+        "API rate limit exceeded",
+        "abuse detection",
+        "was submitted too quickly",
+        "retry-after"
+    ];
+
+    private static readonly Regex RetryAfterRegex = new(@"retry-after:\s*(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    internal static bool IsRateLimitError(string? stderr)
+    {
+        if (string.IsNullOrWhiteSpace(stderr))
+            return false;
+
+        foreach (var indicator in RateLimitIndicators)
+        {
+            if (stderr.Contains(indicator, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    internal static TimeSpan? ParseRetryAfter(string? stderr)
+    {
+        if (string.IsNullOrWhiteSpace(stderr))
+            return null;
+
+        var match = RetryAfterRegex.Match(stderr);
+        if (match.Success && int.TryParse(match.Groups[1].Value, out var seconds))
+        {
+            var clamped = Math.Min(Math.Max(0, seconds), 120);
+            return TimeSpan.FromSeconds(clamped);
+        }
+
+        return null;
+    }
+
+    internal static TimeSpan GetRetryDelay(int attempt, TimeSpan? retryAfter = null)
+    {
+        if (retryAfter.HasValue)
+            return retryAfter.Value;
+
+        double baseSeconds = attempt switch
+        {
+            <= 1 => 2.0,
+            2 => 8.0,
+            _ => 30.0
+        };
+
+        var jitter = Random.Shared.NextDouble() * 0.20 * baseSeconds;
+        return TimeSpan.FromSeconds(baseSeconds + jitter);
+    }
+}

--- a/src/Ivy.Tendril/Services/Git/GithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/GithubService.cs
@@ -13,6 +13,8 @@ public class GithubService : IGithubService, IDisposable
 {
     public const int DefaultIssueLimit = 1000;
     public const int MaxIssueLimit = 1000;
+    public const string MyIssuesQueryTag = "github:my-issues";
+    public const string ReviewRequestsQueryTag = "github:review-requests";
 
     // ConcurrentDictionary required: multiple UseQuery calls from different views/dialogs
     // can fetch different repos simultaneously, causing concurrent writes to different keys.
@@ -21,6 +23,8 @@ public class GithubService : IGithubService, IDisposable
     private readonly ILogger<GithubService> _logger;
     private readonly ConcurrentDictionary<string, List<string>> _labelCache = new();
     private readonly ConcurrentDictionary<string, RepoConfig?> _repoPathCache = new();
+    private readonly SemaphoreSlim _ghGate = new(1, 1);
+    internal SemaphoreSlim GhGate => _ghGate;
 
     public GithubService(IConfigService config, ILogger<GithubService> logger)
     {
@@ -37,6 +41,7 @@ public class GithubService : IGithubService, IDisposable
     public void Dispose()
     {
         _config.SettingsReloaded -= OnSettingsReloaded;
+        _ghGate.Dispose();
         GC.SuppressFinalize(this);
     }
 
@@ -94,33 +99,15 @@ public class GithubService : IGithubService, IDisposable
         try
         {
             var args = BuildIssueListArgs(request);
+            var (output, error) = await ExecuteGhCliAsync(
+                args,
+                s => s,
+                string.Empty);
 
-            var psi = new ProcessStartInfo("gh", args)
+            if (error != null)
             {
-                WorkingDirectory = Path.GetTempPath(),
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8,
-                StandardErrorEncoding = Encoding.UTF8
-            };
-
-            using var process = Process.Start(psi);
-            if (process is null)
-                return ([], "GitHub CLI (gh) is not available. Please install it from https://cli.github.com/");
-
-            var output = await process.StandardOutput.ReadToEndAsync();
-            var stderr = await process.StandardError.ReadToEndAsync();
-            await process.WaitForExitOrKillAsync(60000);
-
-            if (process.ExitCode != 0)
-            {
-                _logger.LogWarning("gh issue list failed for {Owner}/{Repo}: {Stderr}", request.Owner, request.Repo, stderr);
-                var errorMsg = !string.IsNullOrWhiteSpace(stderr)
-                    ? stderr.Trim()
-                    : $"GitHub CLI exited with code {process.ExitCode}";
-                return ([], errorMsg);
+                _logger.LogWarning("gh issue list failed for {Owner}/{Repo}: {Stderr}", request.Owner, request.Repo, error);
+                return ([], error);
             }
 
             var issues = ParseIssuesFromJson(output);
@@ -357,46 +344,73 @@ public class GithubService : IGithubService, IDisposable
             .ToList();
     }
 
-    private async Task<(T result, string? error)> ExecuteGhCliAsync<T>(
+    internal async Task<(T result, string? error)> ExecuteGhCliAsync<T>(
         string args,
         Func<string, T> parseOutput,
         T emptyResult)
     {
+        await _ghGate.WaitAsync();
         try
         {
-            var psi = new ProcessStartInfo("gh", args)
+            const int maxAttempts = 3;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
-                WorkingDirectory = Path.GetTempPath(),
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8,
-                StandardErrorEncoding = Encoding.UTF8
-            };
+                var psi = new ProcessStartInfo("gh", args)
+                {
+                    WorkingDirectory = Path.GetTempPath(),
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    StandardOutputEncoding = Encoding.UTF8,
+                    StandardErrorEncoding = Encoding.UTF8
+                };
 
-            using var process = Process.Start(psi);
-            if (process is null)
-                return (emptyResult, "GitHub CLI (gh) is not available. Please install it from https://cli.github.com/");
+                using var process = Process.Start(psi);
+                if (process is null)
+                    return (emptyResult, "GitHub CLI (gh) is not available. Please install it from https://cli.github.com/");
 
-            var output = await process.StandardOutput.ReadToEndAsync();
-            var stderr = await process.StandardError.ReadToEndAsync();
-            await process.WaitForExitOrKillAsync(60000);
+                var output = await process.StandardOutput.ReadToEndAsync();
+                var stderr = await process.StandardError.ReadToEndAsync();
+                await process.WaitForExitOrKillAsync(60000);
 
-            if (process.ExitCode != 0)
-            {
-                var errorMsg = !string.IsNullOrWhiteSpace(stderr)
-                    ? stderr.Trim()
-                    : $"GitHub CLI exited with code {process.ExitCode}";
-                return (emptyResult, errorMsg);
+                if (process.ExitCode != 0)
+                {
+                    if (GhRateLimit.IsRateLimitError(stderr))
+                    {
+                        if (attempt < maxAttempts)
+                        {
+                            var delay = GhRateLimit.GetRetryDelay(attempt, GhRateLimit.ParseRetryAfter(stderr));
+                            _logger.LogWarning("GitHub rate limit hit on attempt {Attempt}/{MaxAttempts} for gh {Args}. Retrying in {DelayMs:F0}ms. Stderr: {Stderr}",
+                                attempt, maxAttempts, args, delay.TotalMilliseconds, stderr);
+                            await Task.Delay(delay);
+                            continue;
+                        }
+
+                        _logger.LogWarning("GitHub rate limit exceeded after {MaxAttempts} attempts for gh {Args}. Stderr: {Stderr}",
+                            maxAttempts, args, stderr);
+                        return (emptyResult, GhRateLimit.UserMessage);
+                    }
+
+                    var errorMsg = !string.IsNullOrWhiteSpace(stderr)
+                        ? stderr.Trim()
+                        : $"GitHub CLI exited with code {process.ExitCode}";
+                    return (emptyResult, errorMsg);
+                }
+
+                return (parseOutput(output), null);
             }
 
-            return (parseOutput(output), null);
+            return (emptyResult, "Failed to execute gh CLI.");
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to execute gh CLI: {Args}", args);
             return (emptyResult, $"Failed to execute gh CLI: {ex.Message}");
+        }
+        finally
+        {
+            _ghGate.Release();
         }
     }
 

--- a/src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs
+++ b/src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs
@@ -1,3 +1,4 @@
+using Ivy;
 using Ivy.Tendril.Apps.Inbox;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
@@ -15,6 +16,7 @@ public class AssignedIssuesAutoImportService : IStartable, IDisposable
     private readonly IPlanReaderService _planReader;
     private readonly IJobService _jobService;
     private readonly ILogger<AssignedIssuesAutoImportService> _logger;
+    private readonly IQueryService _queryService;
     private readonly SemaphoreSlim _syncLock = new(1, 1);
     private Timer? _timer;
 
@@ -23,20 +25,22 @@ public class AssignedIssuesAutoImportService : IStartable, IDisposable
         IGithubService githubService,
         IPlanReaderService planReader,
         IJobService jobService,
-        ILogger<AssignedIssuesAutoImportService> logger)
+        ILogger<AssignedIssuesAutoImportService> logger,
+        IQueryService queryService)
     {
         _config = config;
         _githubService = githubService;
         _planReader = planReader;
         _jobService = jobService;
         _logger = logger;
+        _queryService = queryService;
     }
 
     public void Start()
     {
         var intervalMinutes = Math.Max(1, _config.Settings.Inbox.CheckIntervalMinutes);
         var interval = TimeSpan.FromMinutes(intervalMinutes);
-        _timer = new Timer(_ => _ = RunSyncAsync(), null, TimeSpan.FromSeconds(15), interval);
+        _timer = new Timer(_ => _ = RunSyncAsync(), null, TimeSpan.FromSeconds(90), interval);
     }
 
     public void Dispose()
@@ -78,6 +82,8 @@ public class AssignedIssuesAutoImportService : IStartable, IDisposable
                 _logger.LogWarning("Failed to fetch assigned GitHub issues: {Error}", error);
                 return;
             }
+
+            _queryService.InvalidateByTag(GithubService.MyIssuesQueryTag);
 
             if (issues == null || issues.Count == 0)
                 return;


### PR DESCRIPTION
Fixes #2423

# Execution Summary: Plan 00206

## Title
Handle GitHub Secondary Rate Limits in Inbox Fetches

## Problem Summary
When opening the Inbox view in Tendril or launching the application, users experienced HTTP 403 secondary rate limit errors from the GitHub CLI. This was caused by:
1. Two separate `UseEffect` hooks in `InboxApp` fetching assigned issues concurrently on mount.
2. A background timer in `AssignedIssuesAutoImportService` triggering a fetch 15 seconds after startup.
3. Lack of serialization across GitHub CLI subprocess invocations.
4. Immediate failure without exponential backoff or retry when secondary rate limit responses were received.

## Implemented Solution
1. **GitHub Rate Limit Detection and Backoff (`GhRateLimit.cs`):**
   - Created helper functions to identify secondary rate limit errors (HTTP 403, retry-after headers, abuse detection).
   - Implemented exponential backoff (2s, 8s, 30s) with 20% jitter.
   - Parsed and clamped `Retry-After` headers (up to 120s).
   - Standardized user-facing messaging when rate limit retries are exhausted.

2. **Process Serialization and Retry Loop (`GithubService.cs`):**
   - Added `SemaphoreSlim _ghGate` to serialize `gh` CLI invocations across the application.
   - Refactored `ExecuteGhCliAsync` to automatically retry up to 3 times on rate limit encounters.
   - Routed `SearchIssuesAsync` through `ExecuteGhCliAsync` so search operations benefit from process serialization.
   - Declared query tags `MyIssuesQueryTag` and `ReviewRequestsQueryTag`.

3. **Coalesced Queries in Inbox (`InboxApp.cs`):**
   - Converted `@me` assigned issues and review requests to `this.UseQuery` with a 60-second TTL and tags.
   - Removed the duplicate mount fetch effect, letting single-flight request coalescing collapse parallel calls.
   - Wired the manual refresh action to `Mutator.Revalidate()` to bypass the TTL on demand.

4. **Freshness Push and Delayed Startup Timer (`AssignedIssuesAutoImportService.cs`):**
   - Injected `IQueryService?` and called `_queryService.InvalidateByTag(GithubService.MyIssuesQueryTag)` upon successful import to update the inbox cache.
   - Extended the background timer start delay from 15s to 90s to avoid launch-time contention.

5. **Build and Warning Fix (`Review/ContentView.cs`):**
   - Corrected element collection type to `List<object?>` to resolve CS8601 nullability warnings under `--warnaserror`.

## Verifications Passed
- **DotnetFormat:** Solution formatted cleanly with zero errors.
- **DotnetBuild:** Built solution in Release configuration with `--warnaserror`; 0 warnings, 0 errors.
- **DotnetTest:** 222 unit tests passed in Release configuration across all impacted areas.
- **CheckResult:** Confirmed complete conformance with the plan revision and Plan 00051 boundaries.

---
### Commits

- 9ec3d941 Plan 00206: Fix nullable elements list in Review ContentView to resolve CS8601 warning under warnaserror
- 835d6be2 Plan 00206: Handle GitHub secondary rate limits and coalesce inbox fetches

---
Created using [Ivy Tendril](https://ivy.app).