### PR TITLE
[00231] Restore Project Badge to Plan Workspace Header Nav

### DIFF
--- a/src/Ivy.Tendril.Test/ProjectHelperTests.cs
+++ b/src/Ivy.Tendril.Test/ProjectHelperTests.cs
@@ -94,4 +94,50 @@ public class ProjectHelperTests
         Assert.Equal(BadgeVariant.Outline, badges[1].Variant);
         Assert.Equal(Colors.Amber, badges[1].Color);
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildProjectBadges_NullOrEmpty_ReturnsEmpty(string? input)
+    {
+        var config = new StubConfigService();
+        var badges = ProjectHelper.BuildProjectBadges(input, config);
+        Assert.Empty(badges);
+    }
+
+    [Fact]
+    public void BuildProjectBadges_SingleProject_ReturnsBadgeWithConfiguredColor()
+    {
+        var config = new StubConfigService(
+        [
+            new ProjectConfig { Name = "Tendril", Color = "Blue" }
+        ]);
+
+        var badges = ProjectHelper.BuildProjectBadges("Tendril", config);
+
+        var badge = Assert.Single(badges);
+        Assert.Equal("Tendril", badge.Label);
+        Assert.Equal("Blue", badge.Color);
+    }
+
+    [Fact]
+    public void BuildProjectBadges_MultipleProjects_ReturnsBadgeForEachProject()
+    {
+        var config = new StubConfigService(
+        [
+            new ProjectConfig { Name = "Tendril", Color = "Blue" },
+            new ProjectConfig { Name = "Framework", Color = "Amber" }
+        ]);
+
+        var badges = ProjectHelper.BuildProjectBadges("Tendril, Framework", config);
+
+        Assert.Equal(2, badges.Count);
+
+        Assert.Equal("Tendril", badges[0].Label);
+        Assert.Equal("Blue", badges[0].Color);
+
+        Assert.Equal("Framework", badges[1].Label);
+        Assert.Equal("Amber", badges[1].Color);
+    }
 }

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/PlanWorkspace/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/PlanWorkspace/DemoApp.cs
@@ -224,6 +224,7 @@ class DemoApp : ViewBase
         var workspace = new PlanWorkspaceControl(content, chat, verifications, questions, toolbar)
             .PlanId("#59")
             .Title("Revamp the User Authentication Experience")
+            .Project("ivy-tendril", "Amber")
             .Meta("1/32 plans · Depends on #57, #58")
             .Source("https://github.com/Ivy-Interactive/Ivy-Tendril/issues/59", "Issue")
             .Persona(shareMode.Value ? "Curious Otter" : null, shareMode.Value ? "CO" : null)

--- a/src/Ivy.Tendril.Widgets/PlanWorkspace.cs
+++ b/src/Ivy.Tendril.Widgets/PlanWorkspace.cs
@@ -23,6 +23,8 @@ public record PlanActionDto(
 
 public record PlanTabDto(string Id, string Label, string? Badge = null);
 
+public record PlanProjectBadgeDto(string Label, string? Color = null);
+
 /// <summary>
 ///     The plan page frame shared by the Drafts and Review apps: a title bar with icon actions and a
 ///     primary button, a tab strip whose trailing corner holds the Verifications and Questions
@@ -68,6 +70,7 @@ public record PlanWorkspace : WidgetBase<PlanWorkspace>
     [Prop] public string? SourceLabel { get; init; }
     [Prop] public string? Persona { get; init; }
     [Prop] public string? PersonaInitials { get; init; }
+    [Prop] public List<PlanProjectBadgeDto> Projects { get; init; } = [];
     [Prop] public List<PlanActionDto> Actions { get; init; } = [];
     [Prop] public List<PlanActionDto> MenuItems { get; init; } = [];
     [Prop] public PlanActionDto? Primary { get; init; }
@@ -96,6 +99,12 @@ public static class PlanWorkspaceExtensions
 
     public static PlanWorkspace Persona(this PlanWorkspace w, string? persona, string? initials) =>
         w with { Persona = persona, PersonaInitials = initials };
+
+    public static PlanWorkspace Project(this PlanWorkspace w, string? label, string? color = null) =>
+        string.IsNullOrWhiteSpace(label) ? w : w with { Projects = [new PlanProjectBadgeDto(label, color)] };
+
+    public static PlanWorkspace Projects(this PlanWorkspace w, IEnumerable<PlanProjectBadgeDto> projects) =>
+        w with { Projects = projects.ToList() };
 
     public static PlanWorkspace Actions(this PlanWorkspace w, IEnumerable<PlanActionDto> actions) =>
         w with { Actions = actions.ToList() };

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/PlanWorkspace.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/PlanWorkspace.test.tsx
@@ -208,6 +208,35 @@ describe("PlanWorkspace", () => {
     expect(screen.getByText("Curious Otter")).toBeInTheDocument();
     expect(screen.getByText("CO")).toBeInTheDocument();
   });
+
+  it("renders project badges to the left of topbar actions with label and color attribute", () => {
+    renderWorkspace(vi.fn(), {
+      projects: [
+        { label: "tendril", color: "Amber" },
+        { label: "ivy-framework" },
+      ],
+    });
+
+    const badge1 = screen.getByTitle("tendril");
+    expect(badge1).toBeInTheDocument();
+    expect(badge1).toHaveTextContent("tendril");
+    expect(badge1).toHaveAttribute("data-color", "amber");
+    expect(badge1).toHaveClass("pws-project-badge");
+
+    const badge2 = screen.getByTitle("ivy-framework");
+    expect(badge2).toBeInTheDocument();
+    expect(badge2).toHaveTextContent("ivy-framework");
+    expect(badge2).toHaveClass("pws-project-badge");
+
+    const badgesContainer = badge1.closest(".pws-project-badges");
+    expect(badgesContainer).toBeInTheDocument();
+    const topbarRight = badgesContainer?.parentElement;
+    expect(topbarRight).toHaveClass("pws-topbar-right");
+    const children = Array.from(topbarRight?.children || []);
+    const badgeIdx = children.indexOf(badgesContainer!);
+    const actionsIdx = children.findIndex((el) => el.classList.contains("pws-icon-group"));
+    expect(badgeIdx).toBeLessThan(actionsIdx);
+  });
 });
 
 describe("shortcuts", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/PlanWorkspace.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/PlanWorkspace.tsx
@@ -10,7 +10,7 @@ import { hasNodes } from "./types";
 import type { PlanActionDto, PlanWorkspaceProps } from "./types";
 import "./plan-workspace.css";
 
-export type { PlanActionDto, PlanTabDto, PlanWorkspaceProps } from "./types";
+export type { PlanActionDto, PlanProjectBadgeDto, PlanTabDto, PlanWorkspaceProps } from "./types";
 
 /** Below this the chat panel stacks under the plan instead of sitting beside it. */
 const NARROW_WIDTH = 760;
@@ -199,6 +199,7 @@ export const PlanWorkspace: React.FC<PlanWorkspaceProps> = ({
   sourceLabel,
   persona,
   personaInitials,
+  projects = [],
   actions = EMPTY_ACTIONS,
   menuItems = EMPTY_ACTIONS,
   primary,
@@ -338,6 +339,20 @@ export const PlanWorkspace: React.FC<PlanWorkspaceProps> = ({
           {meta && <span className="pws-meta">{meta}</span>}
         </div>
         <div className="pws-topbar-right">
+          {projects && projects.length > 0 && (
+            <div className="pws-project-badges">
+              {projects.map((proj, i) => (
+                <span
+                  key={proj.label || i}
+                  className="pws-project-badge"
+                  data-color={proj.color?.toLowerCase()}
+                  title={proj.label}
+                >
+                  {proj.label}
+                </span>
+              ))}
+            </div>
+          )}
           {persona && (
             <div className="pws-persona" title={persona}>
               <span className="pws-avatar" aria-hidden="true">

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/plan-workspace.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/plan-workspace.css
@@ -261,6 +261,65 @@
   height: 18px;
 }
 
+/* ---------- Project badges ---------- */
+
+.pws-project-badges {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.pws-project-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  border-radius: 4px;
+  border: 1px solid var(--tsh-badge-border, color-mix(in srgb, var(--pws-border) 70%, transparent));
+  background: var(--tsh-badge-project-bg, color-mix(in srgb, var(--info, #bcd6ff) 18%, var(--pws-bg)));
+  color: var(--tsh-badge-project-fg, color-mix(in srgb, var(--info, #183b75) 40%, var(--pws-fg)));
+  font-size: 11px;
+  font-weight: 500;
+  line-height: normal;
+  white-space: nowrap;
+}
+
+.pws-project-badge[data-color="amber"] {
+  border-color: color-mix(in srgb, #f59e0b 40%, var(--pws-border));
+  background: color-mix(in srgb, #f59e0b 16%, var(--pws-bg));
+  color: color-mix(in srgb, #d97706 80%, var(--pws-fg));
+}
+
+.pws-project-badge[data-color="blue"] {
+  border-color: color-mix(in srgb, #3b82f6 40%, var(--pws-border));
+  background: color-mix(in srgb, #3b82f6 16%, var(--pws-bg));
+  color: color-mix(in srgb, #2563eb 80%, var(--pws-fg));
+}
+
+.pws-project-badge[data-color="green"] {
+  border-color: color-mix(in srgb, #10b981 40%, var(--pws-border));
+  background: color-mix(in srgb, #10b981 16%, var(--pws-bg));
+  color: color-mix(in srgb, #059669 80%, var(--pws-fg));
+}
+
+.pws-project-badge[data-color="red"] {
+  border-color: color-mix(in srgb, #ef4444 40%, var(--pws-border));
+  background: color-mix(in srgb, #ef4444 16%, var(--pws-bg));
+  color: color-mix(in srgb, #dc2626 80%, var(--pws-fg));
+}
+
+.pws-project-badge[data-color="purple"] {
+  border-color: color-mix(in srgb, #8b5cf6 40%, var(--pws-border));
+  background: color-mix(in srgb, #8b5cf6 16%, var(--pws-bg));
+  color: color-mix(in srgb, #7c3aed 80%, var(--pws-fg));
+}
+
+.pws-project-badge[data-color="orange"] {
+  border-color: color-mix(in srgb, #f97316 40%, var(--pws-border));
+  background: color-mix(in srgb, #f97316 16%, var(--pws-bg));
+  color: color-mix(in srgb, #ea580c 80%, var(--pws-fg));
+}
+
 .pws-persona {
   display: flex;
   align-items: center;

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/types.ts
@@ -24,6 +24,11 @@ export interface PlanTabDto {
   badge?: string;
 }
 
+export interface PlanProjectBadgeDto {
+  label: string;
+  color?: string;
+}
+
 export interface PlanWorkspaceSlots {
   Content?: React.ReactNode[];
   Chat?: React.ReactNode[];
@@ -41,6 +46,7 @@ export interface PlanWorkspaceProps {
   sourceLabel?: string;
   persona?: string;
   personaInitials?: string;
+  projects?: PlanProjectBadgeDto[];
   actions?: PlanActionDto[];
   menuItems?: PlanActionDto[];
   primary?: PlanActionDto | null;

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -333,6 +333,7 @@ public class ContentView(
                 questionsPanel)
             .PlanId($"#{selectedPlan.Id}")
             .Title(selectedPlan.Title)
+            .Projects(ProjectHelper.BuildProjectBadges(selectedPlan.Project, config))
             .Meta(BuildMeta(selectedPlan, currentIndex, allPlans.Count))
             .Source(
                 string.IsNullOrEmpty(selectedPlan.SourceUrl) ? null : selectedPlan.SourceUrl,

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -310,6 +310,7 @@ public class ContentView(
                 page.Toolbar)
             .PlanId($"#{selectedPlan.Id}")
             .Title(selectedPlan.Title)
+            .Projects(ProjectHelper.BuildProjectBadges(selectedPlan.Project, config))
             .Meta($"{currentIndex + 1}/{allPlans.Count} plans")
             .Source(
                 string.IsNullOrEmpty(selectedPlan.SourceUrl) ? null : selectedPlan.SourceUrl,

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -324,13 +324,13 @@ public class ContentView(
             .WithLayout().Full().RemoveParentPadding()
             .Key(selectedPlan.Id);
 
-        var elements = new List<object> { workspace };
+        var elements = new List<object?> { workspace };
         elements.AddRange(page.Overlays);
         elements.AddRange([discardDialog, suggestChangesDialog, createPrDialog, resetToDraftDialog, debugSheet, costSheet]);
         if (isBeta || isShareMode)
             elements.Add(shareModal);
 
-        return new Fragment(elements.ToArray());
+        return new Fragment(elements.Where(e => e is not null).ToArray()!);
     }
 
     private void AddPrimaryAction(

--- a/src/Ivy.Tendril/Helpers/ProjectHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ProjectHelper.cs
@@ -1,5 +1,6 @@
 using Ivy;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Widgets;
 
 namespace Ivy.Tendril.Helpers;
 
@@ -14,6 +15,12 @@ public static class ProjectHelper
                 .Variant(BadgeVariant.Outline)
                 .WithProjectColor(config, project);
         }
+    }
+
+    public static List<PlanProjectBadgeDto> BuildProjectBadges(string? projectValue, IConfigService config)
+    {
+        var projects = ParseProjects(projectValue);
+        return projects.Select(p => new PlanProjectBadgeDto(p, config.GetProjectColor(p)?.ToString())).ToList();
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary

## Changes

Restored the project badge to the plan workspace top navigation header in the Drafts (Plans) and Review apps. Added project badge support to the PlanWorkspace widget (backend DTOs, props, frontend rendering, and styling) and wired project badge resolution using ProjectHelper.

## API Changes

- `Ivy.Tendril.Widgets.PlanProjectBadgeDto`: new record `(string Label, string? Color = null)`
- `Ivy.Tendril.Widgets.PlanWorkspace`: added `[Prop] public List<PlanProjectBadgeDto> Projects { get; init; } = []`
- `Ivy.Tendril.Widgets.PlanWorkspaceExtensions`: added fluent extensions `Project(string? label, string? color = null)` and `Projects(IEnumerable<PlanProjectBadgeDto> projects)`
- `Ivy.Tendril.Helpers.ProjectHelper`: added `public static List<PlanProjectBadgeDto> BuildProjectBadges(string? projectValue, IConfigService config)`

## Files Modified

- `src/Ivy.Tendril.Widgets/PlanWorkspace.cs`: added PlanProjectBadgeDto, Projects prop, and extension methods
- `src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/types.ts`: added PlanProjectBadgeDto and projects prop
- `src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/PlanWorkspace.tsx`: rendered project badges in topbar header nav
- `src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/plan-workspace.css`: added styles and color theme support for project badges
- `src/Ivy.Tendril/Helpers/ProjectHelper.cs`: added BuildProjectBadges helper method
- `src/Ivy.Tendril/Apps/Plans/ContentView.cs`: wired project badges to PlanWorkspace in Drafts app
- `src/Ivy.Tendril/Apps/Review/ContentView.cs`: wired project badges to PlanWorkspace in Review app
- `src/Ivy.Tendril.Widgets/.samples/Apps/PlanWorkspace/DemoApp.cs`: configured demo project badge
- `src/Ivy.Tendril.Test/ProjectHelperTests.cs`: added unit tests for BuildProjectBadges
- `src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/PlanWorkspace.test.tsx`: added unit test for topbar project badge rendering

## Manual Testing

1. Run the application locally or launch the widget samples.
2. Navigate to the Drafts or Review apps with plans belonging to a project.
3. Observe that the project badge (e.g. "ivy-tendril") renders in the top right header navigation immediately to the left of the button actions with its configured project accent color.

---

### Commits

- b2b33840 Fix CS8601 warning in Review ContentView for nullability check (#00231)
- e11ac760 Restore project badge to Plans and Review header navigation (#00231)
- 5bb32849 Add project badge support to PlanWorkspace widget (#00231)

---
Created using [Ivy Tendril](https://ivy.app).
