### PR TITLE
[00226] Add Frontend Vitest Suite to CI Workflows

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,47 @@
+name: Frontend Tests
+
+on:
+  push:
+    branches:
+      - development
+      - main
+    paths:
+      - 'src/Ivy.Tendril.Widgets/frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  pull_request:
+    branches:
+      - development
+      - main
+    paths:
+      - 'src/Ivy.Tendril.Widgets/frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Vitest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          cache-dependency-path: src/Ivy.Tendril.Widgets/frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: src/Ivy.Tendril.Widgets/frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: src/Ivy.Tendril.Widgets/frontend
+        run: pnpm test

--- a/src/Ivy.Tendril.Widgets/frontend/package.json
+++ b/src/Ivy.Tendril.Widgets/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vp dev",
     "build": "tsc && vp build --config vite.widget.ts",
-    "preview": "vp preview"
+    "preview": "vp preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",


### PR DESCRIPTION
# Summary

## Changes

Added a dedicated GitHub Actions CI workflow to run the frontend Vitest suite on pushes and pull requests targeting `development` and `main` when frontend files or the workflow itself are modified. Also added a standard `"test": "vitest run"` script to `src/Ivy.Tendril.Widgets/frontend/package.json` to allow running the test suite via `pnpm test`.

## API Changes

None.

## Files Modified

- **Frontend Package Config**:
  - `src/Ivy.Tendril.Widgets/frontend/package.json`: Added `"test": "vitest run"` script under `scripts`.
- **CI Workflows**:
  - `.github/workflows/frontend-tests.yml`: New GitHub Actions workflow executing Vitest on Node 22 with pnpm cache.

## Manual Testing

1. Verify the frontend test script:
   - Run `cd src/Ivy.Tendril.Widgets/frontend && pnpm test`
   - Observe that Vitest runs the test suite and passes (471 tests across 43 test files).
2. Verify YAML syntax for the GitHub Actions workflow:
   - Run `ruby -ryaml -e "YAML.load_file('.github/workflows/frontend-tests.yml'); puts 'yaml ok'"`
   - Observe `yaml ok`.
3. Verify .NET build:
   - Run `dotnet build src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj`
   - Observe that the project restores, compiles, and embeds widget frontend assets without errors.

---

## Commits

- 93adce1f: Add test script to frontend package.json (Plan 00226)
- ce14dc65: Add frontend-tests GitHub Actions workflow (Plan 00226)

---
Created using [Ivy Tendril](https://ivy.app).
