### PR TITLE
[00225] Remember Last Model Choice When Creating New Chat

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatModelPreferenceTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatModelPreferenceTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Ivy;
+using Ivy.Core;
+using Ivy.Core.Server;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Runtime;
+using Ivy.Tendril.Apps.Chat;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Chat;
+
+public class ChatModelPreferenceTests
+{
+    private static IServiceProvider CreateServiceProvider(
+        IConfigService configService,
+        IChatHistoryService chatService,
+        IAgentRunner agentRunner)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(configService);
+        services.AddSingleton(chatService);
+        services.AddSingleton(agentRunner);
+        services.AddSingleton<IEventSerializer>(new JsonEventSerializer());
+
+        var appContext = (Ivy.AppContext)Activator.CreateInstance(
+            typeof(Ivy.AppContext),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            null,
+            new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
+            null)!;
+        services.AddSingleton(appContext);
+
+        var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+        services.AddSingleton<IChatSessionNamingService>(namingService);
+        services.AddSingleton<IChatExecutionService, ChatExecutionService>();
+        services.AddSingleton<IUploadService>(new UploadService("conn1", null!));
+        services.AddSingleton<IClientProvider>(new DummyClientProvider());
+
+        var sessionStore = new AppSessionStore();
+        services.AddSingleton(sessionStore);
+        services.AddSingleton(new SignalRouter(sessionStore));
+        services.AddSingleton<Ivy.Core.Apps.IAppRepository>(new Ivy.Core.Apps.AppRepository());
+
+        return services.BuildServiceProvider();
+    }
+
+    private static (ChatApp App, Ivy.Core.WidgetTree Tree) CreateChatHost(IServiceProvider sp)
+    {
+        var app = new ChatApp();
+        var contentBuilder = new ContentBuilder();
+        var tree = new Ivy.Core.WidgetTree(app, contentBuilder, sp);
+        var store = sp.GetRequiredService<AppSessionStore>();
+        store.Sessions["conn1"] = new Ivy.Core.Apps.AppSession
+        {
+            ConnectionId = "conn1",
+            AppId = "chat",
+            MachineId = "mach1",
+            ParentId = null,
+            WidgetTree = tree,
+            AppDescriptor = Ivy.Core.Apps.AppHelpers.GetApp(typeof(ChatApp)),
+            App = app,
+            ContentBuilder = contentBuilder,
+            AppServices = sp,
+            LastInteraction = DateTime.UtcNow,
+        };
+        return (app, tree);
+    }
+
+    [Fact]
+    public void ChatApp_WhenNoExistingSessions_DefaultsToRememberedModelAndAgent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatModelPref_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var agentRunner = TestAgentRunner.Create();
+            var codexModels = ChatApp.GetModelsForAgent(agentRunner, "codex");
+            Assert.NotEmpty(codexModels);
+            var targetModel = codexModels[0].Id;
+
+            var config = new TendrilSettings
+            {
+                CodingAgent = "claude",
+                LastChatAgent = "codex",
+                LastChatModel = targetModel,
+                LastChatEffort = "high"
+            };
+
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+
+            var sp = CreateServiceProvider(configService, chatService, agentRunner);
+            var ctx = new Ivy.Core.Hooks.ViewContext(() => { }, null, sp);
+
+            var (app, _) = CreateChatHost(sp);
+            app.BeforeBuild(ctx);
+            var built = app.Build();
+            app.AfterBuild();
+            ctx.Reset();
+
+            var fragment = Assert.IsType<Fragment>(built);
+            var contentView = Assert.IsType<ContentView>(fragment.Children[0]);
+
+            Assert.Equal("codex", contentView.SelectedAgentState.Value);
+            Assert.Equal(targetModel, contentView.SelectedModelState.Value);
+            Assert.Equal("high", contentView.SelectedEffortState.Value);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ChatApp_WhenLastChatModelIsInvalidOrUnset_FallsBackGracefully()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatModelPref_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var agentRunner = TestAgentRunner.Create();
+            var codexModels = ChatApp.GetModelsForAgent(agentRunner, "codex");
+            Assert.NotEmpty(codexModels);
+
+            var config = new TendrilSettings
+            {
+                CodingAgent = "claude",
+                LastChatAgent = "codex",
+                LastChatModel = "nonexistent-model-xyz",
+                LastChatEffort = null
+            };
+
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+
+            var sp = CreateServiceProvider(configService, chatService, agentRunner);
+            var ctx = new Ivy.Core.Hooks.ViewContext(() => { }, null, sp);
+
+            var (app, _) = CreateChatHost(sp);
+            app.BeforeBuild(ctx);
+            var built = app.Build();
+            app.AfterBuild();
+            ctx.Reset();
+
+            var fragment = Assert.IsType<Fragment>(built);
+            var contentView = Assert.IsType<ContentView>(fragment.Children[0]);
+
+            Assert.Equal("codex", contentView.SelectedAgentState.Value);
+            // Fallback to first model in catalog for codex
+            Assert.Equal(codexModels[0].Id, contentView.SelectedModelState.Value);
+            Assert.Equal("default", contentView.SelectedEffortState.Value);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task ContentView_ModelAndAgentAndEffortChanged_PersistsToSettings()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatModelPref_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var agentRunner = TestAgentRunner.Create();
+            var config = new TendrilSettings { CodingAgent = "claude" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var sp = CreateServiceProvider(configService, chatService, agentRunner);
+            var ctx = new Ivy.Core.Hooks.ViewContext(() => { }, null, sp);
+
+            var (app, _) = CreateChatHost(sp);
+            app.BeforeBuild(ctx);
+            var built = app.Build();
+            app.AfterBuild();
+
+            var fragment = Assert.IsType<Fragment>(built);
+            var contentView = Assert.IsType<ContentView>(fragment.Children[0]);
+
+            // Build ContentView to get ChatWidget
+            contentView.BeforeBuild(ctx);
+            var builtContent = contentView.Build();
+            contentView.AfterBuild();
+            ctx.Reset();
+
+            var contentFragment = Assert.IsType<Fragment>(builtContent);
+            var layoutView = Assert.IsType<LayoutView>(contentFragment.Children[0]);
+            var layout = Assert.IsAssignableFrom<AbstractWidget>(layoutView.Build());
+            var chatWidget = Assert.IsType<Ivy.Tendril.Widgets.ChatWidget>(layout.Children[0]);
+
+            // 1. Change Agent to codex
+            Assert.NotNull(chatWidget.OnAgentChanged);
+            await chatWidget.OnAgentChanged(new Event<Ivy.Tendril.Widgets.ChatWidget, string>("OnAgentChanged", chatWidget, "codex"));
+
+            Assert.Equal("codex", configService.Settings.LastChatAgent);
+            var codexModels = ChatApp.GetModelsForAgent(agentRunner, "codex");
+            Assert.Equal(codexModels[0].Id, configService.Settings.LastChatModel);
+
+            // 2. Change Model
+            Assert.NotNull(chatWidget.OnModelChanged);
+            await chatWidget.OnModelChanged(new Event<Ivy.Tendril.Widgets.ChatWidget, string>("OnModelChanged", chatWidget, "custom-codex-model"));
+            Assert.Equal("custom-codex-model", configService.Settings.LastChatModel);
+            Assert.Equal("codex", configService.Settings.LastChatAgent);
+
+            // 3. Change Effort
+            Assert.NotNull(chatWidget.OnEffortChanged);
+            await chatWidget.OnEffortChanged(new Event<Ivy.Tendril.Widgets.ChatWidget, string>("OnEffortChanged", chatWidget, "low"));
+            Assert.Equal("low", configService.Settings.LastChatEffort);
+
+            // 4. Verify disk persistence
+            var reloaded = new ConfigService(new TendrilSettings(), tempDir);
+            reloaded.ReloadSettings();
+            Assert.Equal("codex", reloaded.Settings.LastChatAgent);
+            Assert.Equal("custom-codex-model", reloaded.Settings.LastChatModel);
+            Assert.Equal("low", reloaded.Settings.LastChatEffort);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    private sealed class DummyClientProvider : IClientProvider
+    {
+        public IClientSender Sender { get; set; } = new DummyClientSender();
+    }
+
+    private sealed class DummyClientSender : IClientSender
+    {
+        public void Send(string method, object? data) { }
+    }
+}

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -690,4 +690,38 @@ public class ChatHistoryServiceTests
                 Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void CreateSession_RecordsLastChatModelAndAgentInSettings()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configService = new ConfigService(new TendrilSettings(), tempDir);
+            var service = new ChatHistoryService(configService);
+
+            Assert.Null(configService.Settings.LastChatAgent);
+            Assert.Null(configService.Settings.LastChatModel);
+            Assert.Null(configService.Settings.LastChatEffort);
+
+            service.CreateSession("antigravity", "gemini-3.8-flash", effort: "high");
+
+            Assert.Equal("antigravity", configService.Settings.LastChatAgent);
+            Assert.Equal("gemini-3.8-flash", configService.Settings.LastChatModel);
+            Assert.Equal("high", configService.Settings.LastChatEffort);
+
+            // Verify persisted to disk
+            var reloaded = new ConfigService(new TendrilSettings(), tempDir);
+            reloaded.ReloadSettings();
+            Assert.Equal("antigravity", reloaded.Settings.LastChatAgent);
+            Assert.Equal("gemini-3.8-flash", reloaded.Settings.LastChatModel);
+            Assert.Equal("high", reloaded.Settings.LastChatEffort);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -85,16 +85,35 @@ public class ChatApp : ViewBase
         var sidebarListSignal = Context.UseSignal<ShellSidebarListSignal, ShellSidebarListState, Unit>();
         var activeSessionId = UseState<string?>(() => InitialSession()?.Id);
         var sessionVersion = UseState(0);
-        var selectedAgent = UseState(() => InitialSession()?.AgentId ?? configService.Settings.CodingAgent ?? "claude");
+        var selectedAgent = UseState(() =>
+        {
+            var sess = InitialSession();
+            if (!string.IsNullOrEmpty(sess?.AgentId)) return sess.AgentId;
+            var lastAgent = configService.Settings.LastChatAgent;
+            if (!string.IsNullOrEmpty(lastAgent) && agentRunner.RegisteredAgents.Any(a => string.Equals(a, lastAgent, StringComparison.OrdinalIgnoreCase)))
+            {
+                return agentRunner.RegisteredAgents.First(a => string.Equals(a, lastAgent, StringComparison.OrdinalIgnoreCase));
+            }
+            return configService.Settings.CodingAgent ?? "claude";
+        });
         var selectedModel = UseState(() =>
         {
             var sess = InitialSession();
             if (!string.IsNullOrEmpty(sess?.ModelId)) return sess.ModelId;
-            var agent = sess?.AgentId ?? configService.Settings.CodingAgent ?? "claude";
-            var initialModels = GetModelsForAgent(agentRunner, agent);
+            var initialModels = GetModelsForAgent(agentRunner, selectedAgent.Value);
+            var lastModel = configService.Settings.LastChatModel;
+            if (!string.IsNullOrEmpty(lastModel) && initialModels.Any(m => string.Equals(m.Id, lastModel, StringComparison.OrdinalIgnoreCase)))
+            {
+                return initialModels.First(m => string.Equals(m.Id, lastModel, StringComparison.OrdinalIgnoreCase)).Id;
+            }
             return initialModels.Count > 0 ? initialModels[0].Id : "default";
         });
-        var selectedEffort = UseState(() => InitialSession()?.Effort ?? "default");
+        var selectedEffort = UseState(() =>
+        {
+            var sess = InitialSession();
+            if (sess != null) return sess.Effort ?? "default";
+            return configService.Settings.LastChatEffort ?? "default";
+        });
         var initialHandled = UseRef(false);
         var streamVersion = UseState(0);
         var (searchDialog, showSearchDialog) = UseTrigger(isOpen =>

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -39,6 +39,10 @@ public class ContentView(
     Action startNewChat,
     bool embedded = false) : ViewBase
 {
+    internal IState<string> SelectedAgentState => selectedAgent;
+    internal IState<string> SelectedModelState => selectedModel;
+    internal IState<string> SelectedEffortState => selectedEffort;
+
     /// <summary>The plan a job event names, by folder, numeric id or zero-padded id.</summary>
     internal static PlanFile? FindPlan(IPlanReaderService planService, string planId)
     {
@@ -161,22 +165,35 @@ public class ContentView(
             {
                 selectedAgent.Set(e.Value);
                 var newModels = ChatApp.GetModelsForAgent(agentRunner, e.Value);
+                string? initialModel = null;
                 if (newModels.Count > 0)
                 {
-                    selectedModel.Set(newModels[0].Id);
+                    initialModel = newModels[0].Id;
+                    selectedModel.Set(initialModel);
                 }
                 selectedEffort.Set("default");
+                configService.Settings.LastChatAgent = e.Value;
+                if (initialModel != null)
+                {
+                    configService.Settings.LastChatModel = initialModel;
+                }
+                configService.SaveSettings();
                 return ValueTask.CompletedTask;
             },
             OnModelChanged = e =>
             {
                 selectedModel.Set(e.Value);
                 selectedEffort.Set("default");
+                configService.Settings.LastChatModel = e.Value;
+                configService.Settings.LastChatAgent = selectedAgent.Value;
+                configService.SaveSettings();
                 return ValueTask.CompletedTask;
             },
             OnEffortChanged = e =>
             {
                 selectedEffort.Set(e.Value);
+                configService.Settings.LastChatEffort = e.Value;
+                configService.SaveSettings();
                 return ValueTask.CompletedTask;
             },
             OnDeleteQueuedMessage = e =>

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -310,6 +310,22 @@ public class ChatHistoryService : IChatHistoryService
 
         _sessions[id] = session;
         PersistSessionToDisk(session);
+        if (_configService?.Settings != null)
+        {
+            if (!string.IsNullOrEmpty(agentId))
+            {
+                _configService.Settings.LastChatAgent = agentId;
+            }
+            if (!string.IsNullOrEmpty(modelId))
+            {
+                _configService.Settings.LastChatModel = modelId;
+            }
+            if (!string.IsNullOrEmpty(effort))
+            {
+                _configService.Settings.LastChatEffort = effort;
+            }
+            _configService.SaveSettings();
+        }
         SessionsChanged?.Invoke(this, EventArgs.Empty);
         return session;
     }

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -289,6 +289,9 @@ public class TendrilSettings
     public string ChatMode { get; set; } = ChatModes.Chat;
     public bool Beta { get; set; } = false;
     public string? DismissedUpdateVersion { get; set; }
+    public string? LastChatModel { get; set; }
+    public string? LastChatAgent { get; set; }
+    public string? LastChatEffort { get; set; }
 
     public List<LevelConfig> Levels { get; set; } = new()
     {


### PR DESCRIPTION
Fixes #2431

# Summary: Plan 00225 - Remember Last Model Choice When Creating New Chat

## Changes
- Updated `TendrilSettings` in `ConfigService` to persist `LastChatModel`, `LastChatAgent`, and `LastChatEffort`.
- Updated `ContentView` in the Chat app to persist the selected model, agent, and effort into `TendrilSettings` whenever the user changes them in the model picker dropdown.
- Updated `ChatHistoryService.CreateSession` to persist the model, agent, and effort into `TendrilSettings` whenever a new chat session is created.
- Updated `ChatApp` so that when there are no active chat sessions (`InitialSession() == null`), it initializes `selectedAgent`, `selectedModel`, and `selectedEffort` from the persisted `LastChat*` settings (validating against the agent runner's registered agents and models list) before falling back to default values.
- Added comprehensive unit tests in `ChatModelPreferenceTests` and `ChatHistoryServiceTests` covering fallback behavior, invalid model handling, event handler persistence, and session creation persistence.

## API Changes
- Added properties to `TendrilSettings`:
  - `public string? LastChatModel { get; set; }`
  - `public string? LastChatAgent { get; set; }`
  - `public string? LastChatEffort { get; set; }`

## Files Modified
- `src/Ivy.Tendril/Services/ConfigService.cs`: Added `LastChatModel`, `LastChatAgent`, and `LastChatEffort` properties to `TendrilSettings`.
- `src/Ivy.Tendril/Apps/Chat/ContentView.cs`: Persisted dropdown selections in `OnModelChanged`, `OnAgentChanged`, and `OnEffortChanged`, saving settings immediately.
- `src/Ivy.Tendril/Services/ChatHistoryService.cs`: Persisted settings in `CreateSession`.
- `src/Ivy.Tendril/Apps/Chat/ChatApp.cs`: Defaulted `selectedAgent`, `selectedModel`, and `selectedEffort` to the remembered settings when starting fresh without sessions.
- `src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs`: Added test verifying session creation records last chat choices.
- `src/Ivy.Tendril.Test/Apps/Chat/ChatModelPreferenceTests.cs`: Added test suite covering fallback resolution and event handling.

## Manual Testing
1. Launch Tendril and navigate to the Chat app.
2. In a fresh state with no chats, select an agent (e.g. `gemini`), model (e.g. `gemini-2.5-flash`), and effort if applicable.
3. Close the chat app or refresh the page.
4. Verify that the model picker preserves `gemini` and `gemini-2.5-flash` as the preselected defaults instead of resetting to the coding agent's first model.
5. Create a new chat session, change the model in a subsequent session, and verify the latest selection is remembered for new chats.

---
1a03b2c5 Plan 00225: Remember last model choice when creating new chat

---
Created using [Ivy Tendril](https://ivy.app).
