### PR TITLE
[00223] Resolve Null Reference Assignment Warnings in Review ContentView

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -323,7 +323,7 @@ public class ContentView(
             .WithLayout().Full().RemoveParentPadding()
             .Key(selectedPlan.Id);
 
-        var elements = new List<object> { workspace };
+        var elements = new List<object?> { workspace };
         elements.AddRange(page.Overlays);
         elements.AddRange([discardDialog, suggestChangesDialog, createPrDialog, resetToDraftDialog, debugSheet, costSheet]);
         if (isBeta || isShareMode)


### PR DESCRIPTION
Fixes #2448

# Summary

## Changes

Updated the `elements` list declaration in `Review/ContentView.cs` from `List<object>` to `List<object?>`. This allows dialog and sheet trigger instances (which are nullable objects) to be added to the list without causing CS8601 nullability compiler warnings.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Review/ContentView.cs`: Changed `var elements = new List<object> { workspace };` to `var elements = new List<object?> { workspace };`.

## Manual Testing

N/A: internal refactoring with no user-facing behavioral changes.

---
- 6277904d Resolve CS8601 warnings in Review ContentView (00223)

---
Created using [Ivy Tendril](https://ivy.app).
