### PR TITLE
[00238] Ensure Dashboard Git Activity Card Fits Container Bounds

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -437,6 +437,7 @@
   min-height: 280px;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .tdb-side-head {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -40,6 +40,10 @@ describe("dashboard.css KPI grid", () => {
 });
 
 describe("dashboard.css side block and git activity layout", () => {
+  it("constrains side block contents within container bounds with overflow: hidden", () => {
+    expect(css).toMatch(/\.tdb-side-block\s*\{[^}]*overflow:\s*hidden;/);
+  });
+
   it("bottom-anchors side body and tip wrap with justify-content: flex-end", () => {
     const sideBodyBlocks = [...css.matchAll(/\.tdb-side-body\s*\{([^}]*)\}/g)].map((m) => m[1]);
     expect(sideBodyBlocks.length).toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
# Summary

## Changes

Added `overflow: hidden` to `.tdb-side-block` in `dashboard.css` to guarantee that dashboard side card contents (including the Git Activity card) are strictly contained within their rounded card container bounds. Added a corresponding unit test in `dashboard.css.test.ts` and verified the compiled widget bundle.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`: Added `overflow: hidden;` to `.tdb-side-block`.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`: Added unit test verifying `.tdb-side-block` has `overflow: hidden;`.

## Manual Testing

1. Launch the Tendril desktop application or web interface.
2. Navigate to the Dashboard view.
3. Observe the Git Activity card in the right-hand column under various window widths (both full-width and container query split-view modes).
4. Verify that the activity heatmap grid and labels remain neatly inside the white rounded card container with no content extending below or outside the bottom border.

---
## Commits

- 766c95c3: Ensure dashboard git activity card fits container bounds (Plan 00238)

---
Created using [Ivy Tendril](https://ivy.app).