### PR TITLE
[00237] Add Week or Month Switch to Dashboard Pull Requests

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -419,4 +419,49 @@ public class DashboardAppViewModelTests
     {
         Assert.Equal(expected, DashboardApp.GetKpiSheetTitle(key));
     }
+
+    [Fact]
+    public void BuildWeeklyPullRequests_BucketsIntoTrailingWeeks()
+    {
+        var today = new DateTime(2026, 9, 9, 12, 0, 0, DateTimeKind.Utc);
+        var prDays = new List<(DateOnly Date, int Count)>
+        {
+            // Outside trailing 6 weeks: should not be counted
+            (new DateOnly(2026, 7, 1), 10),
+            // Week 1: Aug 3 to Aug 9
+            (new DateOnly(2026, 8, 4), 3),
+            (new DateOnly(2026, 8, 9), 2),
+            // Week 2: Aug 10 to Aug 16 has 0 PRs
+            // Week 3: Aug 17 to Aug 23
+            (new DateOnly(2026, 8, 20), 4),
+            // Week 4: Aug 24 to Aug 30
+            (new DateOnly(2026, 8, 24), 7),
+            // Week 5: Aug 31 to Sep 6
+            (new DateOnly(2026, 8, 31), 1),
+            (new DateOnly(2026, 9, 5), 2),
+            // Week 6: Sep 7 to Sep 13
+            (new DateOnly(2026, 9, 8), 6)
+        };
+
+        var result = DashboardApp.BuildWeeklyPullRequests(prDays, today, 6);
+
+        Assert.Equal(6, result.Count);
+        Assert.Equal("Aug 3", result[0].Label);
+        Assert.Equal(5, result[0].Value);
+
+        Assert.Equal("Aug 10", result[1].Label);
+        Assert.Equal(0, result[1].Value);
+
+        Assert.Equal("Aug 17", result[2].Label);
+        Assert.Equal(4, result[2].Value);
+
+        Assert.Equal("Aug 24", result[3].Label);
+        Assert.Equal(7, result[3].Value);
+
+        Assert.Equal("Aug 31", result[4].Label);
+        Assert.Equal(3, result[4].Value);
+
+        Assert.Equal("Sep 7", result[5].Label);
+        Assert.Equal(6, result[5].Value);
+    }
 }

--- a/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
+++ b/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
@@ -88,6 +88,7 @@ public record TendrilDashboard : WidgetBase<TendrilDashboard>
     [Prop] public DashboardTrendDto? Trend { get; init; }
     [Prop] public DashboardTrendDto? TrendWeekly { get; init; }
     [Prop] public List<DashboardMonthValueDto> PullRequests { get; init; } = new();
+    [Prop] public List<DashboardMonthValueDto> PullRequestsWeekly { get; init; } = new();
     [Prop] public List<DashboardActivityMonthDto> Activity { get; init; } = new();
     [Prop] public List<DashboardJobDto> Jobs { get; init; } = new();
 
@@ -135,6 +136,9 @@ public static class TendrilDashboardExtensions
 
     public static TendrilDashboard PullRequests(this TendrilDashboard w, List<DashboardMonthValueDto> value) =>
         w with { PullRequests = value };
+
+    public static TendrilDashboard PullRequestsWeekly(this TendrilDashboard w, List<DashboardMonthValueDto> value) =>
+        w with { PullRequestsWeekly = value };
 
     public static TendrilDashboard Activity(this TendrilDashboard w, List<DashboardActivityMonthDto> value) =>
         w with { Activity = value };

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { TendrilDashboard } from "./TendrilDashboard";
-import type { DashboardTrendDto } from "./types";
+import type { DashboardMonthValueDto, DashboardTrendDto } from "./types";
 
 const PLOT_LEFT = 44;
 const PLOT_WIDTH = 548;
@@ -153,8 +153,8 @@ describe("TendrilDashboard git activity and pull requests side cards", () => {
     expect(titles).toContain("Git Activity");
     expect(titles).toContain("Pull Requests");
 
-    const sideTabs = container.querySelectorAll(".tdb-col-side .tdb-tabs");
-    expect(sideTabs).toHaveLength(0);
+    expect(screen.queryByRole("button", { name: "Git Activity" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Pull Requests" })).not.toBeInTheDocument();
   });
 
   it("shows both the activity grid and the pull requests list at the same time", () => {
@@ -267,5 +267,77 @@ describe("TendrilDashboard KPI card interactions and accessibility", () => {
     fireEvent.click(card);
 
     expect(eventHandler).toHaveBeenCalledWith("OnSelectKpi", "dash", ["dailyPrs"]);
+  });
+});
+
+describe("TendrilDashboard pull requests week/month toggle", () => {
+  const monthlyPrs: DashboardMonthValueDto[] = [
+    { label: "Apr", value: 10 },
+    { label: "May", value: 15 },
+    { label: "Jun", value: 8 },
+    { label: "Jul", value: 12 },
+    { label: "Aug", value: 20 },
+    { label: "Sep", value: 7 },
+  ];
+
+  const weeklyPrs: DashboardMonthValueDto[] = [
+    { label: "Aug 3", value: 4 },
+    { label: "Aug 10", value: 6 },
+    { label: "Aug 17", value: 3 },
+    { label: "Aug 24", value: 5 },
+    { label: "Aug 31", value: 8 },
+    { label: "Sep 7", value: 2 },
+  ];
+
+  it("defaults to month view and displays monthly pull requests", () => {
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={vi.fn()}
+        pullRequests={monthlyPrs}
+        pullRequestsWeekly={weeklyPrs}
+      />,
+    );
+
+    const monthBtn = screen.getByRole("button", { name: "Month" });
+    const weekBtn = screen.getByRole("button", { name: "Week" });
+
+    expect(monthBtn).toHaveAttribute("data-active", "true");
+    expect(weekBtn).toHaveAttribute("data-active", "false");
+
+    expect(screen.getByText("Apr")).toBeInTheDocument();
+    expect(screen.getByText("Sep")).toBeInTheDocument();
+    expect(screen.queryByText("Aug 24")).not.toBeInTheDocument();
+  });
+
+  it("switches to week view on click and restores month view when clicked again", () => {
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={vi.fn()}
+        pullRequests={monthlyPrs}
+        pullRequestsWeekly={weeklyPrs}
+      />,
+    );
+
+    const monthBtn = screen.getByRole("button", { name: "Month" });
+    const weekBtn = screen.getByRole("button", { name: "Week" });
+
+    // Switch to Week
+    fireEvent.click(weekBtn);
+    expect(weekBtn).toHaveAttribute("data-active", "true");
+    expect(monthBtn).toHaveAttribute("data-active", "false");
+
+    expect(screen.getByText("Aug 24")).toBeInTheDocument();
+    expect(screen.getByText("Sep 7")).toBeInTheDocument();
+    expect(screen.queryByText("Apr")).not.toBeInTheDocument();
+
+    // Switch back to Month
+    fireEvent.click(monthBtn);
+    expect(monthBtn).toHaveAttribute("data-active", "true");
+    expect(weekBtn).toHaveAttribute("data-active", "false");
+
+    expect(screen.getByText("Apr")).toBeInTheDocument();
+    expect(screen.queryByText("Aug 24")).not.toBeInTheDocument();
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -59,11 +59,14 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
   trend = null,
   trendWeekly = null,
   pullRequests = [],
+  pullRequestsWeekly = [],
   activity = [],
   jobs = [],
   slots,
 }) => {
   const [tab, setTab] = useState<"cost" | "plans">("cost");
+  const [prPeriod, setPrPeriod] = useState<"week" | "month">("month");
+  const activePrs = prPeriod === "week" ? (pullRequestsWeekly ?? []) : (pullRequests ?? []);
 
   const fireEvent = (eventName: string) => {
     if (events.includes(eventName)) {
@@ -237,9 +240,29 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
               </div>
             </div>
             <div className="tdb-block tdb-side-block">
-              <div className="tdb-block-title">Pull Requests</div>
+              <div className="tdb-side-head">
+                <div className="tdb-block-title">Pull Requests</div>
+                <div className="tdb-tabs tdb-side-tabs">
+                  <button
+                    type="button"
+                    className="tdb-tab tdb-side-tab"
+                    data-active={prPeriod === "week"}
+                    onClick={() => setPrPeriod("week")}
+                  >
+                    Week
+                  </button>
+                  <button
+                    type="button"
+                    className="tdb-tab tdb-side-tab"
+                    data-active={prPeriod === "month"}
+                    onClick={() => setPrPeriod("month")}
+                  >
+                    Month
+                  </button>
+                </div>
+              </div>
               <div className="tdb-side-body">
-                <PillBars items={pullRequests} />
+                <PillBars items={activePrs} />
               </div>
             </div>
             {hasSlotContent(slots?.TunnelQr) && (

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -447,6 +447,16 @@
   min-height: 24px;
 }
 
+.tdb-side-tabs {
+  gap: 8px;
+}
+
+.tdb-side-tab {
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 6px;
+}
+
 .tdb-tunnel {
   min-height: 0;
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -95,3 +95,13 @@ describe("dashboard.css rolling average curve and legend", () => {
     expect(css).not.toContain(".tdb-granularity-btn");
   });
 });
+
+describe("dashboard.css side tabs", () => {
+  it("defines compact tab controls for side card headers", () => {
+    expect(css).toContain(".tdb-side-tabs {");
+    expect(css).toContain(".tdb-side-tab {");
+    expect(css).toMatch(/\.tdb-side-tab\s*\{[^}]*font-size:\s*12px;/);
+    expect(css).toMatch(/\.tdb-side-tab\s*\{[^}]*padding:\s*3px 8px;/);
+    expect(css).toMatch(/\.tdb-side-tab\s*\{[^}]*border-radius:\s*6px;/);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -61,6 +61,7 @@ export interface TendrilDashboardProps {
   trend?: DashboardTrendDto | null;
   trendWeekly?: DashboardTrendDto | null;
   pullRequests?: DashboardMonthValueDto[];
+  pullRequestsWeekly?: DashboardMonthValueDto[];
   activity?: DashboardActivityMonthDto[];
   jobs?: DashboardJobDto[];
   slots?: {

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -139,6 +139,7 @@ public class DashboardApp : ViewBase
                 .TakeLast(6)
                 .Select(m => new DashboardMonthValueDto(MonthLabel(m.Month), m.PrsMerged))
                 .ToList())
+            .PullRequestsWeekly(BuildWeeklyPullRequests(prDays, today))
             .Activity(BuildActivityMonths(prDays, firstActivityMonth))
             .Jobs(BuildActiveJobs(jobs, planService))
             .OnDrafts(() => navigator.Navigate<PlansApp>())
@@ -201,6 +202,25 @@ public class DashboardApp : ViewBase
 
     private static string MonthLabel(int month) =>
         CultureInfo.InvariantCulture.DateTimeFormat.GetAbbreviatedMonthName(month);
+
+    internal static List<DashboardMonthValueDto> BuildWeeklyPullRequests(
+        List<(DateOnly Date, int Count)> prDays, DateTime today, int weeks = 6)
+    {
+        var daysSinceMonday = ((int)today.DayOfWeek + 6) % 7;
+        var currentWeekMonday = DateOnly.FromDateTime(today).AddDays(-daysSinceMonday);
+        var result = new List<DashboardMonthValueDto>(weeks);
+
+        for (var i = weeks - 1; i >= 0; i--)
+        {
+            var weekStart = currentWeekMonday.AddDays(-i * 7);
+            var weekEnd = weekStart.AddDays(6);
+            var count = prDays.Where(p => p.Date >= weekStart && p.Date <= weekEnd).Sum(p => p.Count);
+            var label = $"{MonthLabel(weekStart.Month)} {weekStart.Day}";
+            result.Add(new DashboardMonthValueDto(label, count));
+        }
+
+        return result;
+    }
 
     internal static List<DashboardKpiDto> BuildKpis(
         DashboardModels stats,


### PR DESCRIPTION
# Summary

## Changes

Added a Week or Month period switch to the Dashboard Pull Requests side card, with Month selected by default. The backend computes trailing 6 weekly buckets based on completed pull requests with Monday-to-Sunday boundaries, allowing users to toggle between viewing monthly and weekly throughput trends.

## API Changes

- Added `List<DashboardMonthValueDto> PullRequestsWeekly { get; init; }` property to `Ivy.Tendril.Widgets.TendrilDashboard`.
- Added `PullRequestsWeekly(this TendrilDashboard w, List<DashboardMonthValueDto> value)` extension method to `Ivy.Tendril.Widgets.TendrilDashboardExtensions`.
- Added `pullRequestsWeekly?: DashboardMonthValueDto[];` property to `TendrilDashboardProps` in frontend widget types.

## Files Modified

- **Backend & UI Apps:**
  - `src/Ivy.Tendril/Apps/DashboardApp.cs`: Implemented `BuildWeeklyPullRequests` aggregation helper and provided `PullRequestsWeekly` to `TendrilDashboard`.
  - `src/Ivy.Tendril.Widgets/TendrilDashboard.cs`: Added `PullRequestsWeekly` property and fluent extension method.
- **Frontend Widget:**
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`: Added `pullRequestsWeekly` prop definition.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx`: Added period toggle state and header tab controls for the Pull Requests card.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`: Added compact `.tdb-side-tabs` and `.tdb-side-tab` styling.
- **Tests:**
  - `src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs`: Added unit tests for weekly PR aggregation and date boundary handling.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx`: Added unit tests for default month view and toggling between week and month.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`: Added assertion verifying `.tdb-side-tab` styles.

## Manual Testing

1. Launch Tendril and navigate to the Dashboard view.
2. Locate the "Pull Requests" card in the right column.
3. Verify that the header shows "Week" and "Month" toggle buttons, with "Month" active by default.
4. Verify the bars display monthly pull request counts for the last 6 months.
5. Click "Week": verify "Week" becomes highlighted and the bars update to show weekly merged PR totals for the trailing 6 weeks (labeled by starting Monday, e.g. "Aug 24", "Sep 7").
6. Click "Month": verify "Month" becomes highlighted and the original monthly data is restored.

---
### Commits

- 046cbd63 Add week or month switch to dashboard pull requests widget (Plan 00237)
- 9d003124 Aggregate trailing weekly pull requests in DashboardApp (Plan 00237)

---
Created using [Ivy Tendril](https://ivy.app).