### PR TITLE
[00224] Show Chats in Sidebar in Collapsed Mode

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
@@ -368,4 +368,89 @@ describe("ShellSidebarSection", () => {
     expect(document.querySelector(".tsh-rail-tooltip")).toBeInTheDocument();
     vi.useRealTimers();
   });
+
+  it("renders items without tags (icon-only terminal sessions and default chat items) in collapsed rail", () => {
+    const mixedItems: ShellSectionItemDto[] = [
+      { id: "term-1", title: "Terminal Chat", icon: "Terminal" },
+      { id: "chat-1", title: "General Chat" },
+      { id: "plan-1", title: "Plan Item", tag: "#1" },
+    ];
+
+    const { container } = render(
+      <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+        <ShellSidebarSection id="sec-1" title="Chats" items={mixedItems} eventHandler={vi.fn()} />
+      </ShellContext.Provider>,
+    );
+
+    const railList = container.querySelector(".tsh-rail-list");
+    expect(railList).toBeInTheDocument();
+
+    const buttons = railList?.querySelectorAll("button.tsh-rail-item");
+    expect(buttons).toHaveLength(3);
+
+    expect(buttons?.[0].querySelector("svg")).toBeInTheDocument();
+    expect(buttons?.[0].querySelector(".tsh-rail-item-text")).not.toBeInTheDocument();
+
+    expect(buttons?.[1].querySelector("svg")).toBeInTheDocument();
+    expect(buttons?.[1].querySelector(".tsh-rail-item-text")).not.toBeInTheDocument();
+
+    expect(buttons?.[2].querySelector(".tsh-rail-item-text")).toHaveTextContent("#1");
+  });
+
+  it("triggers OnSelectItem when a rail chat item is clicked", () => {
+    const onSelect = vi.fn();
+    const chatItems: ShellSectionItemDto[] = [
+      { id: "chat-1", title: "General Chat" },
+    ];
+
+    render(
+      <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+        <ShellSidebarSection
+          id="sec-1"
+          title="Chats"
+          items={chatItems}
+          events={["OnSelectItem"]}
+          eventHandler={onSelect}
+        />
+      </ShellContext.Provider>,
+    );
+
+    const chatBtn = screen.getByRole("button", { name: "General Chat" });
+    fireEvent.click(chatBtn);
+    expect(onSelect).toHaveBeenCalledWith("OnSelectItem", "sec-1", ["chat-1"]);
+  });
+
+  it("displays tooltip with title and badges when hovering over a rail chat item", () => {
+    vi.useFakeTimers();
+    const chatItems: ShellSectionItemDto[] = [
+      {
+        id: "chat-1",
+        title: "Project Discussion",
+        badges: [{ label: "Active", kind: "success" }],
+      },
+    ];
+
+    render(
+      <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+        <ShellSidebarSection
+          id="sec-1"
+          title="Chats"
+          items={chatItems}
+          eventHandler={vi.fn()}
+        />
+      </ShellContext.Provider>,
+    );
+
+    const chatBtn = screen.getByRole("button", { name: "Project Discussion" });
+    fireEvent.pointerMove(chatBtn);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent("Project Discussion");
+    expect(tooltip).toHaveTextContent("Active");
+    vi.useRealTimers();
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from "react";
-import { Plus, Search, SquareTerminal } from "lucide-react";
+import { MessageCircle, Plus, Search, SquareTerminal } from "lucide-react";
 import { useShell } from "./ShellContext";
 import {
   ShellSectionItemDto,
@@ -16,6 +16,7 @@ const SEARCH_SHORTCUT_KEY = "K";
 /** Maps a `ShellSectionItemDto.icon` name to its lucide component; unknown names render nothing. */
 const sectionItemIcons: Record<string, React.FC<{ size?: number }>> = {
   Terminal: SquareTerminal,
+  MessageCircle: MessageCircle,
 };
 
 interface ShellSidebarSectionProps extends ShellWidgetProps {
@@ -104,39 +105,43 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
           </ShellTooltip>
         )}
         <div className="tsh-rail-list">
-          {items.map(
-            (item) =>
-              item.tag && (
-                <ShellTooltip
-                  key={item.id}
-                  side="right"
-                  className="tsh-rail-tooltip"
-                  content={
-                    <div>
-                      <div className="tsh-rail-tooltip-title">{item.title}</div>
-                      {item.badges && item.badges.length > 0 && (
-                        <div className="tsh-rail-tooltip-badges">
-                          {item.badges.map((badge, i) => (
-                            <span key={i} className="tsh-badge" data-kind={badge.kind}>
-                              {badge.label}
-                            </span>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  }
+          {items.map((item) => {
+            const RailIcon = (item.icon && sectionItemIcons[item.icon]) || MessageCircle;
+            return (
+              <ShellTooltip
+                key={item.id}
+                side="right"
+                className="tsh-rail-tooltip"
+                content={
+                  <div>
+                    <div className="tsh-rail-tooltip-title">{item.title}</div>
+                    {item.badges && item.badges.length > 0 && (
+                      <div className="tsh-rail-tooltip-badges">
+                        {item.badges.map((badge, i) => (
+                          <span key={i} className="tsh-badge" data-kind={badge.kind}>
+                            {badge.label}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                }
+              >
+                <button
+                  className="tsh-rail-item"
+                  data-selected={item.id === selectedId}
+                  onClick={() => select(item.id)}
+                  aria-label={item.title}
                 >
-                  <button
-                    className="tsh-rail-item"
-                    data-selected={item.id === selectedId}
-                    onClick={() => select(item.id)}
-                    aria-label={item.title}
-                  >
+                  {item.tag ? (
                     <span className="tsh-rail-item-text">{item.tag}</span>
-                  </button>
-                </ShellTooltip>
-              ),
-          )}
+                  ) : (
+                    <RailIcon size={16} />
+                  )}
+                </button>
+              </ShellTooltip>
+            );
+          })}
         </div>
       </div>
     );

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -779,6 +779,10 @@
 }
 
 .tsh-rail-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
   flex-shrink: 0;
   width: 100%;
   padding: 6px 2px;

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -323,13 +323,13 @@ public class ContentView(
             .WithLayout().Full().RemoveParentPadding()
             .Key(selectedPlan.Id);
 
-        var elements = new List<object> { workspace };
+        var elements = new List<object?> { workspace };
         elements.AddRange(page.Overlays);
         elements.AddRange([discardDialog, suggestChangesDialog, createPrDialog, resetToDraftDialog, debugSheet, costSheet]);
         if (isBeta || isShareMode)
             elements.Add(shareModal);
 
-        return new Fragment(elements.ToArray());
+        return new Fragment(elements.OfType<object>().ToArray());
     }
 
     private void AddPrimaryAction(


### PR DESCRIPTION
Fixes #2426

# Summary

## Changes

Enabled chat sessions and untagged items to render in the sidebar when in collapsed rail mode. Previously, untagged items were filtered out; they now render using their configured icon or a default chat icon with tooltips and selection handlers intact.

## API Changes

None.

## Files Modified

- Frontend Components:
  - `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx` (removed tag gate in collapsed rail; added icon rendering with `MessageCircle` fallback)
  - `src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css` (centered icon and text content for `.tsh-rail-item`)
- Frontend Tests:
  - `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx` (added unit tests for collapsed rail item rendering, selection, and tooltips)
- Backend Fixes:
  - `src/Ivy.Tendril/Apps/Review/ContentView.cs` (resolved CS8601 possible null reference assignment in dialog overlays)

## Manual Testing

1. Launch the Tendril web/desktop interface.
2. Create or open one or more chat sessions (including free-standing chats and terminal sessions).
3. Collapse the sidebar by clicking the sidebar collapse toggle.
4. Observe the collapsed rail on the left:
   - Chat sessions now appear in the collapsed rail with a chat bubble icon (or terminal icon for terminal sessions).
   - Hovering over a collapsed chat item shows a tooltip with the session title and status badge.
   - Clicking a collapsed chat item switches to and selects that chat session.

---
### Commits

- 9b6981e4 Show chats in sidebar in collapsed mode (#00224)
- 2d7d7821 Fix nullability in ContentView dialog overlays (#00224)

---
Created using [Ivy Tendril](https://ivy.app).
