### PR TITLE
[00247] Display Chat Names in Search Chats Dialog

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatSearchDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatSearchDialogTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Ivy.Tendril.Apps.Chat.Dialogs;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Widgets;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Chat;
+
+public class ChatSearchDialogTests
+{
+    private static ChatSessionModel CreateSession(
+        string id,
+        string title,
+        DateTimeOffset updatedAt,
+        string? kind = null) =>
+        new(id, title, DateTimeOffset.UtcNow, updatedAt, "claude", "opus", [], Kind: kind);
+
+    [Fact]
+    public void BuildResultsSection_BuildsNonCollapsibleSectionWithTitlesTagsAndIcons()
+    {
+        var updated = new DateTimeOffset(2026, 9, 10, 12, 0, 0, TimeSpan.Zero);
+        var sessions = new List<ChatSessionModel>
+        {
+            CreateSession("s1", "Investigate Bug", updated, ChatSessionKinds.Chat),
+            CreateSession("s2", "Shell Terminal", updated, ChatSessionKinds.Terminal),
+            CreateSession("s3", "", updated)
+        };
+
+        var selected = "";
+        var section = ChatSearchDialog.BuildResultsSection(sessions, id => selected = id);
+
+        Assert.False(section.Collapsible);
+        Assert.Equal(3, section.Items.Count);
+
+        var first = section.Items[0];
+        Assert.Equal("s1", first.Id);
+        Assert.Equal("Investigate Bug", first.Title);
+        Assert.Equal(updated.ToLocalTime().ToString("MMM d"), first.Tag);
+        Assert.Null(first.Icon);
+
+        var second = section.Items[1];
+        Assert.Equal("s2", second.Id);
+        Assert.Equal("Shell Terminal", second.Title);
+        Assert.Equal("Terminal", second.Icon);
+
+        var third = section.Items[2];
+        Assert.Equal("s3", third.Id);
+        Assert.Equal("New Chat", third.Title);
+
+        section.OnSelectItem!.Invoke(new Event<ShellSidebarSection, string>("select", section, "s2"));
+        Assert.Equal("s2", selected);
+    }
+}

--- a/src/Ivy.Tendril.Widgets/ShellSidebarSection.cs
+++ b/src/Ivy.Tendril.Widgets/ShellSidebarSection.cs
@@ -15,6 +15,7 @@ public record ShellSidebarSection : WidgetBase<ShellSidebarSection>
     [Prop] public string? SearchLabel { get; init; }
     [Prop] public string? EmptyText { get; init; }
     [Prop] public string? NewLabel { get; init; }
+    [Prop] public bool Collapsible { get; init; } = true;
 
     [Event] public EventHandler<Event<ShellSidebarSection, string>>? OnSelectItem { get; init; }
     [Event] public EventHandler<Event<ShellSidebarSection>>? OnSearch { get; init; }
@@ -49,6 +50,9 @@ public static class ShellSidebarSectionExtensions
 
     public static ShellSidebarSection NewLabel(this ShellSidebarSection w, string? newLabel) =>
         w with { NewLabel = newLabel };
+
+    public static ShellSidebarSection Collapsible(this ShellSidebarSection w, bool collapsible = true) =>
+        w with { Collapsible = collapsible };
 
     public static ShellSidebarSection OnNew(this ShellSidebarSection w, Action? handler) =>
         handler == null ? w : w with { OnNew = new(_ => { handler(); return ValueTask.CompletedTask; }) };

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
@@ -453,4 +453,30 @@ describe("ShellSidebarSection", () => {
     expect(tooltip).toHaveTextContent("Active");
     vi.useRealTimers();
   });
+
+  it("renders full list view with titles and tags when collapsible is false even if collapsed in context", () => {
+    const chatItems: ShellSectionItemDto[] = [
+      { id: "chat-1", title: "General Discussion", tag: "Sep 10" },
+      { id: "chat-2", title: "Bug Triage", tag: "Sep 9" },
+    ];
+
+    const { container } = render(
+      <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+        <ShellSidebarSection
+          id="sec-non-collapsible"
+          title="Search Results"
+          items={chatItems}
+          collapsible={false}
+          eventHandler={vi.fn()}
+        />
+      </ShellContext.Provider>,
+    );
+
+    expect(container.querySelector(".tsh-section-rail")).toBeNull();
+    expect(container.querySelector(".tsh-section-list")).toBeInTheDocument();
+    expect(screen.getByText("General Discussion")).toBeInTheDocument();
+    expect(screen.getByText("Sep 10")).toBeInTheDocument();
+    expect(screen.getByText("Bug Triage")).toBeInTheDocument();
+    expect(screen.getByText("Sep 9")).toBeInTheDocument();
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
@@ -29,6 +29,7 @@ interface ShellSidebarSectionProps extends ShellWidgetProps {
   emptyText?: string;
   /** Shows a "+" button in the header (e.g. "New chat"); fires OnNew. */
   newLabel?: string;
+  collapsible?: boolean;
 }
 
 /**
@@ -50,6 +51,7 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
   searchLabel = "Search plans",
   emptyText,
   newLabel,
+  collapsible = true,
 }) => {
   const select = (itemId: string) => {
     if (events.includes("OnSelectItem")) eventHandler("OnSelectItem", id, [itemId]);
@@ -87,7 +89,7 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
   const hasHeader = !!title || searchable;
   const showSearchButton = searchable && (!title || (items.length === 0 && !newLabel));
 
-  if (collapsed) {
+  if (collapsible && collapsed) {
     return (
       <div className="tsh-section tsh-section-rail">
         {newLabel && (

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.test.tsx
@@ -93,4 +93,26 @@ describe("TendrilShell", () => {
     expect(window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe("false");
     expect(eventHandler).toHaveBeenCalledWith("OnCollapsedChanged", "shell-1", [false]);
   });
+
+  it("content in slots.Content receives collapsed: false even when sidebar is collapsed", () => {
+    let observedCollapsed: boolean | undefined;
+    const TestContent = () => {
+      const { collapsed } = useShell();
+      observedCollapsed = collapsed;
+      return <div data-testid="test-content">Content (collapsed={String(collapsed)})</div>;
+    };
+
+    render(
+      <TendrilShell
+        id="shell-test"
+        collapsed={true}
+        eventHandler={vi.fn()}
+        slots={{
+          Content: <TestContent />,
+        }}
+      />
+    );
+
+    expect(observedCollapsed).toBe(false);
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.tsx
@@ -95,13 +95,15 @@ export const TendrilShell: React.FC<TendrilShellProps> = ({
     activeSessionIndex != null && activeSessionIndex >= 0 && activeSessionIndex < sessionPanes.length;
 
   return (
-    <ShellContext.Provider value={{ collapsed, toggle }}>
-      <div className="tsh-root remove-parent-padding" data-collapsed={collapsed}>
+    <div className="tsh-root remove-parent-padding" data-collapsed={collapsed}>
+      <ShellContext.Provider value={{ collapsed, toggle }}>
         <div className="tsh-sidebar">
           <div className="tsh-sidebar-header">{slots?.SidebarHeader}</div>
           <div className="tsh-sidebar-body">{slots?.SidebarBody}</div>
           <div className="tsh-sidebar-footer">{slots?.SidebarFooter}</div>
         </div>
+      </ShellContext.Provider>
+      <ShellContext.Provider value={{ collapsed: false, toggle }}>
         <div className="tsh-main">
           <div className="tsh-container">
             <div className="tsh-frame" data-has-tabs={hasTabs}>
@@ -121,8 +123,8 @@ export const TendrilShell: React.FC<TendrilShellProps> = ({
             {hasTabs && slots?.Tabs && <div className="tsh-tabs-row">{slots.Tabs}</div>}
           </div>
         </div>
-        {slots?.Hidden && <div style={{ display: "none" }}>{slots.Hidden}</div>}
-      </div>
-    </ShellContext.Provider>
+      </ShellContext.Provider>
+      {slots?.Hidden && <div style={{ display: "none" }}>{slots.Hidden}</div>}
+    </div>
   );
 };

--- a/src/Ivy.Tendril/AppShell/Dialogs/PlanSearchDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/PlanSearchDialog.cs
@@ -63,6 +63,7 @@ public class PlanSearchDialog(IState<bool> dialogOpen) : ViewBase
 
                 body |= new ShellSidebarSection()
                     .Items(items)
+                    .Collapsible(false)
                     .OnSelectItem(folderName =>
                     {
                         if (!resultsByFolder.TryGetValue(folderName, out var plan)) return;

--- a/src/Ivy.Tendril/Apps/Chat/Dialogs/ChatSearchDialog.cs
+++ b/src/Ivy.Tendril/Apps/Chat/Dialogs/ChatSearchDialog.cs
@@ -1,4 +1,5 @@
 using Ivy;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Widgets;
 
@@ -15,6 +16,24 @@ public class ChatSearchDialog(
     Action<string> selectSession) : ViewBase
 {
     private const int MaxResults = 15;
+
+    internal static ShellSidebarSection BuildResultsSection(
+        IEnumerable<ChatSessionModel> sessions,
+        Action<string> onSelect)
+    {
+        var items = sessions
+            .Select(s => new ShellSectionItemDto(
+                s.Id,
+                ChatApp.DisplayTitle(s),
+                s.UpdatedAt.ToLocalTime().ToString("MMM d"),
+                Icon: s.IsTerminal() ? "Terminal" : null))
+            .ToList();
+
+        return new ShellSidebarSection()
+            .Items(items)
+            .Collapsible(false)
+            .OnSelectItem(onSelect);
+    }
 
     public override object Build()
     {
@@ -35,17 +54,11 @@ public class ChatSearchDialog(
         }
         else
         {
-            var items = results
-                .Select(s => new ShellSectionItemDto(s.Id, ChatApp.DisplayTitle(s), s.UpdatedAt.ToLocalTime().ToString("MMM d")))
-                .ToList();
-
-            body |= new ShellSidebarSection()
-                .Items(items)
-                .OnSelectItem(sessionId =>
-                {
-                    dialogOpen.Set(false);
-                    selectSession(sessionId);
-                });
+            body |= BuildResultsSection(results, sessionId =>
+            {
+                dialogOpen.Set(false);
+                selectSession(sessionId);
+            });
         }
 
         return new Dialog(


### PR DESCRIPTION
Fixes #2477

# Summary

## Changes

Fixed an issue where the Search Chats and Search Plans dialogs displayed only tags or dates centered in the modal when opened while the sidebar was collapsed. Scoped the sidebar collapse context to the sidebar area only, added a `collapsible` option to `ShellSidebarSection`, and configured search dialogs to remain in full list view.

## API Changes

- `Ivy.Tendril.Widgets.ShellSidebarSection`: Added property `[Prop] public bool Collapsible { get; init; } = true;`
- `Ivy.Tendril.Widgets.ShellSidebarSectionExtensions`: Added fluent extension method `Collapsible(this ShellSidebarSection w, bool collapsible = true)`
- Frontend `ShellSidebarSectionProps`: Added optional `collapsible?: boolean` prop (defaults to `true`)

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.tsx`: Scoped ShellContext provider to sidebar and main content separately.
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx`: Added `collapsible` prop and updated rail view branch condition.
- `src/Ivy.Tendril.Widgets/ShellSidebarSection.cs`: Added `Collapsible` prop and fluent extension method.
- `src/Ivy.Tendril/Apps/Chat/Dialogs/ChatSearchDialog.cs`: Configured sidebar section with `.Collapsible(false)` and added terminal icon handling.
- `src/Ivy.Tendril/AppShell/Dialogs/PlanSearchDialog.cs`: Configured sidebar section with `.Collapsible(false)`.
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.test.tsx`: Added unit test verifying uncollapsed context in main content.
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx`: Added unit test verifying full list view when `collapsible={false}`.
- `src/Ivy.Tendril.Test/Apps/Chat/ChatSearchDialogTests.cs`: Added unit test verifying search dialog builds non-collapsible section with titles, tags, and icons.

## Manual Testing

1. Run the Tendril application (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse`).
2. Collapse the sidebar rail using Cmd/Ctrl+B or by clicking the collapse toggle button.
3. Open the Search Chats dialog by pressing Cmd/Ctrl+K or clicking the search button.
4. Verify that each search result displays its full title and date tag, rather than only the date tag in a narrow chip.
5. Perform the same verification for the Search Plans dialog.

---
## Commits

- a4ccec29 [00247] Set Collapsible(false) on search dialogs and add tests
- 2703d5c6 [00247] Scope ShellContext and add collapsible prop to ShellSidebarSection

---
Created using [Ivy Tendril](https://ivy.app).
