### PR TITLE
[00246] Fix Chat Agent Idle Timeout and Make Chat Timeout Configurable

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/06_Config.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/06_Config.md
@@ -32,6 +32,7 @@ Get and set top-level Tendril settings stored in `config.yaml` — the same valu
 |-----|------|--------|
 | `codingAgent` | string | — |
 | `jobTimeout` | int (minutes) | 1–480 |
+| `chatTimeout` | int (minutes) | 0–480 |
 | `staleOutputTimeout` | int (minutes) | 1–60 |
 | `gitTimeout` | int (minutes) | 1–30 |
 | `maxConcurrentJobs` | int | 1–100 |

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/03_MCP.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/03_MCP.md
@@ -73,7 +73,7 @@ All tools are prefixed with `tendril_` and provide the same capabilities as the 
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `tendril_get_config` | `key` | Get a top-level config value. Supported keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate` |
+| `tendril_get_config` | `key` | Get a top-level config value. Supported keys: `codingAgent`, `jobTimeout`, `chatTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate` |
 | `tendril_set_config` | `key`, `value` | Set a top-level config value. Integer fields are bounds-checked; `planTemplate` may be long or multiline. Same keys as `tendril_get_config` |
 
 ## Claude Code Configuration

--- a/src/Ivy.Tendril.Test/ConfigCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigCliCommandTests.cs
@@ -40,6 +40,18 @@ public class ConfigCliCommandTests : IDisposable
     }
 
     [Fact]
+    public void Set_ChatTimeout_Persists()
+    {
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "chatTimeout", "60");
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal(60, reloaded.Settings.ChatTimeout);
+        Assert.Equal("60", ConfigGetCommand.ReadField(reloaded.Settings, "chatTimeout"));
+    }
+
+    [Fact]
     public void Set_CodingAgent_Persists()
     {
         var config = CreateConfig();
@@ -130,6 +142,8 @@ public class ConfigCliCommandTests : IDisposable
     [Theory]
     [InlineData("jobTimeout", "999")]
     [InlineData("jobTimeout", "0")]
+    [InlineData("chatTimeout", "481")]
+    [InlineData("chatTimeout", "-1")]
     [InlineData("gitTimeout", "31")]
     [InlineData("staleOutputTimeout", "0")]
     [InlineData("maxConcurrentJobs", "513")]

--- a/src/Ivy.Tendril.Test/Helpers/AgentLaunchHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/AgentLaunchHelperTests.cs
@@ -150,7 +150,7 @@ public class AgentLaunchHelperTests : IDisposable
         Assert.True(context.ExtraEnvironment.ContainsKey("TENDRIL_HOME"));
         Assert.NotNull(context.TimeoutPolicy);
         Assert.Equal(TimeSpan.FromMinutes(config.Settings.JobTimeout), context.TimeoutPolicy.TotalTimeout);
-        Assert.Equal(TimeoutPolicy.Default.IdleTimeout, context.TimeoutPolicy.IdleTimeout);
+        Assert.Equal(TimeSpan.FromMinutes(config.Settings.StaleOutputTimeout), context.TimeoutPolicy.IdleTimeout);
         Assert.Equal(TimeoutPolicy.Default.StartupTimeout, context.TimeoutPolicy.StartupTimeout);
 
         // AGENTS.md should be written to the working directory for Antigravity
@@ -192,5 +192,79 @@ public class AgentLaunchHelperTests : IDisposable
 
         Assert.NotNull(context.TimeoutPolicy);
         Assert.Equal(TimeSpan.FromMinutes(30), context.TimeoutPolicy.TotalTimeout);
+    }
+
+    [Fact]
+    public void PrepareResolutionContext_WithCustomChatTimeout_UsesChatTimeoutOverJobTimeout()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        config.Settings.JobTimeout = 30;
+        config.Settings.ChatTimeout = 60;
+        var runner = TestAgentRunner.Create();
+
+        var context = AgentLaunchHelper.PrepareResolutionContext(
+            config,
+            runner,
+            "antigravity",
+            "Do a task"
+        );
+
+        Assert.NotNull(context.TimeoutPolicy);
+        Assert.Equal(TimeSpan.FromMinutes(60), context.TimeoutPolicy.TotalTimeout);
+    }
+
+    [Fact]
+    public void PrepareResolutionContext_WithZeroChatTimeout_FallsBackToJobTimeout()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        config.Settings.JobTimeout = 40;
+        config.Settings.ChatTimeout = 0;
+        var runner = TestAgentRunner.Create();
+
+        var context = AgentLaunchHelper.PrepareResolutionContext(
+            config,
+            runner,
+            "antigravity",
+            "Do a task"
+        );
+
+        Assert.NotNull(context.TimeoutPolicy);
+        Assert.Equal(TimeSpan.FromMinutes(40), context.TimeoutPolicy.TotalTimeout);
+    }
+
+    [Fact]
+    public void PrepareResolutionContext_WithCustomStaleOutputTimeout_SetsIdleTimeout()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        config.Settings.StaleOutputTimeout = 25;
+        var runner = TestAgentRunner.Create();
+
+        var context = AgentLaunchHelper.PrepareResolutionContext(
+            config,
+            runner,
+            "antigravity",
+            "Do a task"
+        );
+
+        Assert.NotNull(context.TimeoutPolicy);
+        Assert.Equal(TimeSpan.FromMinutes(25), context.TimeoutPolicy.IdleTimeout);
+    }
+
+    [Fact]
+    public void PrepareResolutionContext_WithZeroStaleOutputTimeout_DisablesIdleTimeout()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        config.Settings.StaleOutputTimeout = 0;
+        var runner = TestAgentRunner.Create();
+
+        var context = AgentLaunchHelper.PrepareResolutionContext(
+            config,
+            runner,
+            "antigravity",
+            "Do a task"
+        );
+
+        Assert.NotNull(context.TimeoutPolicy);
+        Assert.Null(context.TimeoutPolicy.IdleTimeout);
     }
 }

--- a/src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs
@@ -53,6 +53,16 @@ public class ConfigToolsTests : IDisposable
     }
 
     [Fact]
+    public void SetConfig_ChatTimeout_UpdatesAndPersists()
+    {
+        var result = _tools.SetConfig("chatTimeout", "60");
+        Assert.StartsWith("Updated chatTimeout", result);
+
+        Assert.Equal("60", _tools.GetConfig("chatTimeout"));
+        Assert.Equal(60, new ConfigService().Settings.ChatTimeout);
+    }
+
+    [Fact]
     public void SetConfig_PlanTemplate_MultilineRoundTrips()
     {
         var template = "# Plan\n\n- step [one]\n- step two with -flag\n";

--- a/src/Ivy.Tendril/Apps/Settings/AdvancedSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AdvancedSetupView.cs
@@ -11,6 +11,7 @@ public class AdvancedSetupView : ViewBase
         var client = UseService<IClientProvider>();
 
         var jobTimeout = UseState(config.Settings.JobTimeout);
+        var chatTimeout = UseState(config.Settings.ChatTimeout);
         var staleOutputTimeout = UseState(config.Settings.StaleOutputTimeout);
         var maxConcurrentJobs = UseState(config.Settings.MaxConcurrentJobs);
         var editorCommand = UseState(config.Settings.Editor.Command);
@@ -18,6 +19,7 @@ public class AdvancedSetupView : ViewBase
         var beta = UseState(config.Settings.Beta);
 
         var hasChanges = jobTimeout.Value != config.Settings.JobTimeout
+                         || chatTimeout.Value != config.Settings.ChatTimeout
                          || staleOutputTimeout.Value != config.Settings.StaleOutputTimeout
                          || maxConcurrentJobs.Value != config.Settings.MaxConcurrentJobs
                          || editorCommand.Value != config.Settings.Editor.Command
@@ -30,6 +32,9 @@ public class AdvancedSetupView : ViewBase
                    | Text.Block("Timeouts").Bold()
                    | jobTimeout.ToNumberInput().Min(1).Max(120).Suffix("min")
                        .WithField().Label("Job Timeout")
+                   | chatTimeout.ToNumberInput().Min(0).Max(480).Suffix("min")
+                       .WithField().Label("Chat Timeout")
+                       .Description("Total timeout for interactive chat sessions. Set to 0 to use Job Timeout.")
                    | staleOutputTimeout.ToNumberInput().Min(1).Max(60).Suffix("min")
                        .WithField().Label("Stale Output Timeout")
                    | maxConcurrentJobs.ToNumberInput().Min(1).Max(512)
@@ -51,6 +56,7 @@ public class AdvancedSetupView : ViewBase
                        .OnClick(() =>
                        {
                            config.Settings.JobTimeout = jobTimeout.Value;
+                           config.Settings.ChatTimeout = chatTimeout.Value;
                            config.Settings.StaleOutputTimeout = staleOutputTimeout.Value;
                            config.Settings.MaxConcurrentJobs = maxConcurrentJobs.Value;
                            config.Settings.Editor.Command = editorCommand.Value;

--- a/src/Ivy.Tendril/Commands/ConfigCommand.cs
+++ b/src/Ivy.Tendril/Commands/ConfigCommand.cs
@@ -12,9 +12,9 @@ namespace Ivy.Tendril.Commands;
 public class ConfigGetSettings : CommandSettings
 {
     internal static readonly string[] ValidFields =
-        ["codingAgent", "jobTimeout", "staleOutputTimeout", "gitTimeout", "maxConcurrentJobs", "planTemplate", "theme", "themeMode"];
+        ["codingAgent", "jobTimeout", "chatTimeout", "staleOutputTimeout", "gitTimeout", "maxConcurrentJobs", "planTemplate", "theme", "themeMode"];
 
-    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")]
+    [Description("Config key (codingAgent, jobTimeout, chatTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")]
     [CommandArgument(0, "<key>")]
     public string Key { get; set; } = "";
 
@@ -26,7 +26,7 @@ public class ConfigGetSettings : CommandSettings
 
 public class ConfigSetSettings : CommandSettings
 {
-    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")]
+    [Description("Config key (codingAgent, jobTimeout, chatTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")]
     [CommandArgument(0, "<key>")]
     public string Key { get; set; } = "";
 
@@ -71,6 +71,7 @@ public class ConfigGetCommand : Command<ConfigGetSettings>
     {
         "codingagent" => s.CodingAgent,
         "jobtimeout" => s.JobTimeout.ToString(),
+        "chattimeout" => s.ChatTimeout.ToString(),
         "staleoutputtimeout" => s.StaleOutputTimeout.ToString(),
         "gittimeout" => s.GitTimeout.ToString(),
         "maxconcurrentjobs" => s.MaxConcurrentJobs.ToString(),
@@ -112,6 +113,7 @@ public class ConfigSetCommand(IAgentRunner runner) : Command<ConfigSetSettings>
         {
             case "codingagent": s.CodingAgent = ValidateCodingAgent(value, validCodingAgents); break;
             case "jobtimeout": s.JobTimeout = ParseBoundedInt(value, "jobTimeout", 1, 480); break;
+            case "chattimeout": s.ChatTimeout = ParseBoundedInt(value, "chatTimeout", 0, 480); break;
             case "staleoutputtimeout": s.StaleOutputTimeout = ParseBoundedInt(value, "staleOutputTimeout", 1, 60); break;
             case "gittimeout": s.GitTimeout = ParseBoundedInt(value, "gitTimeout", 1, 30); break;
             case "maxconcurrentjobs": s.MaxConcurrentJobs = ParseBoundedInt(value, "maxConcurrentJobs", 1, 512); break;

--- a/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
+++ b/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
@@ -139,15 +139,22 @@ public static class AgentLaunchHelper
         var resolvedEffort = effortOverride ?? ResolveEffort(config, runner, agentId);
         var env = GetEnvironment(config, agentId);
 
-        var jobTimeoutMinutes = config.Settings.JobTimeout;
-        var totalTimeout = jobTimeoutMinutes > 0
-            ? TimeSpan.FromMinutes(jobTimeoutMinutes)
+        var effectiveChatTimeoutMinutes = config.Settings.ChatTimeout > 0
+            ? config.Settings.ChatTimeout
+            : config.Settings.JobTimeout;
+
+        var totalTimeout = effectiveChatTimeoutMinutes > 0
+            ? TimeSpan.FromMinutes(effectiveChatTimeoutMinutes)
             : TimeSpan.FromMinutes(30);
+
+        var idleTimeout = config.Settings.StaleOutputTimeout > 0
+            ? TimeSpan.FromMinutes(config.Settings.StaleOutputTimeout)
+            : (TimeSpan?)null;
 
         var timeoutPolicy = new TimeoutPolicy
         {
             TotalTimeout = totalTimeout,
-            IdleTimeout = TimeoutPolicy.Default.IdleTimeout,
+            IdleTimeout = idleTimeout,
             StartupTimeout = TimeoutPolicy.Default.StartupTimeout,
         };
 

--- a/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
@@ -20,7 +20,7 @@ public sealed class ConfigTools : AuthenticatedToolBase
 
     [McpServerTool(Name = "tendril_get_config"), Description("Get a top-level Tendril config value")]
     public string GetConfig(
-        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")] string key)
+        [Description("Config key (codingAgent, jobTimeout, chatTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")] string key)
     {
         // Reuses the same field switch as `tendril config get` so the two surfaces never drift.
         return ExecuteAuthenticated(() => ConfigGetCommand.ReadField(_configService.Settings, key));
@@ -28,7 +28,7 @@ public sealed class ConfigTools : AuthenticatedToolBase
 
     [McpServerTool(Name = "tendril_set_config"), Description("Set a top-level Tendril config value")]
     public string SetConfig(
-        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")] string key,
+        [Description("Config key (codingAgent, jobTimeout, chatTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")] string key,
         [Description("New value. Integer fields are bounds-checked; planTemplate may be long or multiline.")] string value)
     {
         return ExecuteAuthenticated(() =>

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -265,7 +265,7 @@ These commands are for internal use by other promptwares (e.g., a verification s
 | `tendril config get <key>` | Print a top-level config value |
 | `tendril config set <key> <value>` | Set a top-level config value (use `--file`/`--stdin` for multiline values) |
 
-Valid keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`, `theme`. Example: `tendril config get planTemplate` prints the configured Plan Template.
+Valid keys: `codingAgent`, `jobTimeout`, `chatTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`, `theme`. Example: `tendril config get planTemplate` prints the configured Plan Template.
 
 ## Adding & Configuring Projects
 

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -258,6 +258,7 @@ public class TendrilSettings
 {
     public string CodingAgent { get; set; } = "claude";
     public int JobTimeout { get; set; } = 30;
+    public int ChatTimeout { get; set; } = 0;
     public int StaleOutputTimeout { get; set; } = 10;
     public int GitTimeout { get; set; } = 10;
     public int MaxConcurrentJobs { get; set; } = 20;
@@ -588,6 +589,14 @@ public class ConfigService : IConfigService, IDisposable
             _logger.LogWarning("JobTimeout {Value} is out of bounds (1-480 minutes). Using default 30.",
                 Settings.JobTimeout);
             Settings.JobTimeout = 30;
+        }
+
+        // ChatTimeout: 0-480 minutes (0 = use JobTimeout)
+        if (Settings.ChatTimeout < 0 || Settings.ChatTimeout > 480)
+        {
+            _logger.LogWarning("ChatTimeout {Value} is out of bounds (0-480 minutes). Using default 0.",
+                Settings.ChatTimeout);
+            Settings.ChatTimeout = 0;
         }
 
         // StaleOutputTimeout: 1-60 minutes


### PR DESCRIPTION
Fixes #2476

# Summary

## Changes

Fixed premature chat agent aborts by connecting chat session idle timeout to the configured `StaleOutputTimeout` (disabling it when 0, and extending it beyond 5 minutes when configured). Added a dedicated `ChatTimeout` setting that allows users to independently configure the total timeout for interactive chat sessions via configuration, CLI, MCP, and the Settings UI.

## API Changes

- Added `public int ChatTimeout { get; set; } = 0;` to `TendrilSettings`.
- Added `chatTimeout` (integer, bounded 0-480) as a valid key for `tendril config get` and `tendril config set`.
- Added `chatTimeout` to MCP tools `tendril_get_config` and `tendril_set_config`.

## Files Modified

- **Configuration & CLI**:
  - `src/Ivy.Tendril/Services/ConfigService.cs`: Added `ChatTimeout` property to `TendrilSettings` with bounds validation in `ValidateSettings()`.
  - `src/Ivy.Tendril/Commands/ConfigCommand.cs`: Added `chatTimeout` to valid fields, read mapping, and set mapping with bounded integer parsing.
  - `src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs`: Updated MCP parameter descriptions to include `chatTimeout`.
  - `src/Ivy.Tendril/Apps/Settings/AdvancedSetupView.cs`: Added Chat Timeout numeric input, state tracking, and persistence.
- **Agent Infrastructure**:
  - `src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs`: Wired `ChatTimeout` and `StaleOutputTimeout` into `TimeoutPolicy`.
- **Tests & Documentation**:
  - `src/Ivy.Tendril.Test/Helpers/AgentLaunchHelperTests.cs`: Added unit tests for custom chat timeout, job timeout fallback, and idle timeout behavior.
  - `src/Ivy.Tendril.Test/ConfigCliCommandTests.cs`: Added unit tests for getting, setting, and validating `chatTimeout`.
  - `src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs`: Added unit test for `tendril_set_config` with `chatTimeout`.
  - `src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/06_Config.md`, `src/Ivy.Tendril.Docs/Docs/09_Advanced/03_MCP.md`, `src/Ivy.Tendril/Prompts/AgentPrompt.md`: Documented `chatTimeout`.

## Manual Testing

1. Open Tendril and navigate to Settings > Advanced.
2. Verify the "Chat Timeout" field is present under the "Timeouts" section with label and description.
3. Change the value to `45`, click "Save", and verify the toast confirms saved settings.
4. In terminal, run `tendril config get chatTimeout` and verify it outputs `45`.
5. Run `tendril config set chatTimeout 0` and verify it resets to `0`.

---
## Commits

- c01ef151 Make chat timeout configurable and fix idle timeout in chat sessions (Plan 00246)

---
Created using [Ivy Tendril](https://ivy.app).