### PR TITLE
[00244] Fix X-Axis Tick Label Overflow and Alignment in Pull Requests Chart

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/PillBars.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/PillBars.tsx
@@ -45,7 +45,7 @@ export const PillBars: React.FC<PillBarsProps> = ({ items }) => {
                   onMouseLeave={hideTip}
                 />
               </div>
-              <span className="tdb-bar-label">{item.label}</span>
+              <span className="tdb-bar-label">{item.label.replace(" ", "\n")}</span>
             </div>
           ))}
         </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
@@ -340,4 +340,30 @@ describe("TendrilDashboard pull requests week/month toggle", () => {
     expect(screen.getByText("Apr")).toBeInTheDocument();
     expect(screen.queryByText("Aug 24")).not.toBeInTheDocument();
   });
+
+  it("renders weekly labels with formatted two-line date wrapping while remaining accessible", () => {
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={vi.fn()}
+        pullRequests={monthlyPrs}
+        pullRequestsWeekly={weeklyPrs}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Week" }));
+
+    const labelAug3 = screen.getByText("Aug 3");
+    const labelAug10 = screen.getByText("Aug 10");
+    const labelSep7 = screen.getByText("Sep 7");
+
+    expect(labelAug3).toBeInTheDocument();
+    expect(labelAug10).toBeInTheDocument();
+    expect(labelSep7).toBeInTheDocument();
+
+    expect(labelAug3.textContent).toBe("Aug\n3");
+    expect(labelAug10.textContent).toBe("Aug\n10");
+    expect(labelSep7.textContent).toBe("Sep\n7");
+  });
 });
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx
@@ -123,3 +123,28 @@ describe("TrendChart rolling average curve", () => {
     expect(screen.queryByText(/7-day average/)).not.toBeInTheDocument();
   });
 });
+
+describe("TrendChart x-axis tick suppression", () => {
+  beforeEach(() => {
+    Element.prototype.getBoundingClientRect = vi.fn(
+      () => ({ width: CHART_WIDTH, height: 236, top: 0, left: 0, right: CHART_WIDTH, bottom: 236, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect,
+    );
+    globalThis.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as unknown as typeof ResizeObserver;
+  });
+
+  it("suppresses ticks that are too close to the pinned final tick to prevent overlapping", () => {
+    const dates = days(26);
+    const { container } = renderChart({ dates });
+
+    const axisTexts = Array.from(container.querySelectorAll("text.tdb-axis-text")).map(
+      (t) => t.textContent,
+    );
+    expect(axisTexts).toContain("Sep 6");
+    expect(axisTexts).not.toContain("Sep 5");
+  });
+});
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
@@ -196,7 +196,8 @@ export const TrendChart: React.FC<TrendChartProps> = ({
           {dates.map((date, i) => {
             const maxVisible = Math.max(4, Math.floor(plotWidth / 60));
             const step = n > maxVisible ? Math.ceil((n - 1) / maxVisible) : 1;
-            const isVisible = i === 0 || i === n - 1 || i % step === 0;
+            const isCloseToEnd = i !== n - 1 && (n - 1) - i < step * 0.5;
+            const isVisible = i === 0 || i === n - 1 || (i % step === 0 && !isCloseToEnd);
             if (!isVisible) return null;
             return (
               <text

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -548,7 +548,7 @@
 
 .tdb-bars {
   display: flex;
-  gap: 16px;
+  gap: 10px;
   flex: 1;
   min-height: 0;
 }
@@ -560,14 +560,14 @@
   font-size: 12px;
   color: var(--tdb-muted);
   text-align: left;
-  padding-bottom: 26px;
+  padding-bottom: 36px;
 }
 
 .tdb-bars-plot {
   flex: 1;
   display: flex;
   align-items: flex-end;
-  gap: 16px;
+  gap: 8px;
 }
 
 .tdb-bar-item {
@@ -575,9 +575,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   height: 100%;
   justify-content: flex-end;
+  min-width: 0;
 }
 
 .tdb-bar-track {
@@ -601,8 +602,17 @@
 .tdb-bar[data-level="4"] { background: var(--tdb-ramp-4); }
 
 .tdb-bar-label {
-  font-size: 12px;
+  font-size: 11px;
+  line-height: 1.2;
   color: var(--tdb-muted);
+  text-align: center;
+  white-space: pre-line;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  min-height: 28px;
 }
 
 /* ---------- Active jobs ---------- */

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -109,3 +109,24 @@ describe("dashboard.css side tabs", () => {
     expect(css).toMatch(/\.tdb-side-tab\s*\{[^}]*border-radius:\s*6px;/);
   });
 });
+
+describe("dashboard.css pull request bars layout and alignment", () => {
+  it("defines centered text alignment, controlled line height, and consistent min-height for bar labels", () => {
+    expect(css).toContain(".tdb-bar-label {");
+    expect(css).toMatch(/\.tdb-bar-label\s*\{[^}]*text-align:\s*center;/);
+    expect(css).toMatch(/\.tdb-bar-label\s*\{[^}]*line-height:\s*1\.2;/);
+    expect(css).toMatch(/\.tdb-bar-label\s*\{[^}]*min-height:\s*28px;/);
+    expect(css).toMatch(/\.tdb-bar-label\s*\{[^}]*white-space:\s*pre-line;/);
+  });
+
+  it("uses a compact gap on .tdb-bars-plot to prevent horizontal overflow", () => {
+    expect(css).toContain(".tdb-bars-plot {");
+    expect(css).toMatch(/\.tdb-bars-plot\s*\{[^}]*gap:\s*8px;/);
+  });
+
+  it("sets min-width 0 on .tdb-bar-item and aligns Y-axis zero tick with 36px padding-bottom", () => {
+    expect(css).toMatch(/\.tdb-bar-item\s*\{[^}]*min-width:\s*0;/);
+    expect(css).toMatch(/\.tdb-bars-y\s*\{[^}]*padding-bottom:\s*36px;/);
+  });
+});
+


### PR DESCRIPTION
Fixes #2474

# Summary

## Changes

Fixed x-axis tick label overflow and vertical baseline misalignment in the Pull Requests chart. Date labels in Week view now consistently wrap across two lines (month on line 1, day number on line 2) within a fixed-height container, aligning all bar baselines with the y-axis zero tick. Additionally, narrowed inter-bar gaps and added tick suppression in TrendChart to prevent adjacent label collisions near the chart end point.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/PillBars.tsx`: Formatted date labels to wrap cleanly across two lines with newlines while preserving testing library compatibility.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`: Reduced bar plot gap, established 28px min-height for bar labels, added min-width 0 to bar items, and set 36px bottom padding on the y-axis to align with the bar baseline.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx`: Added tick suppression for points too close to the pinned final tick.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`: Added unit tests covering pull request bars CSS layout, gap reduction, label alignment, and baseline padding.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx`: Added unit test verifying weekly date label formatting and accessibility in Week view.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx`: Added unit test verifying suppression of x-axis ticks near the final tick.

## Manual Testing

1. Launch the Tendril desktop application or run `tendril --web` and open the Dashboard view in a browser.
2. In the "Pull Requests" side card, toggle from "Month" to "Week" view.
3. Observe the x-axis weekly labels (e.g. "Aug 3", "Aug 10", "Aug 17", "Aug 24", "Aug 31", "Sep 7"):
   - Each label displays the month on the top line and day number on the bottom line without overlapping adjacent labels or spilling beyond the card container.
   - All bar tracks start at the exact same horizontal zero baseline, aligned with the "0" mark on the y-axis.
4. Switch back to "Month" view and verify that single-line month labels ("Apr", "May", etc.) also align at the same baseline.

---
### Commits

- 3ab24cc1 Plan 00244: Fix x-axis tick label overflow and alignment in pull requests chart

---
Created using [Ivy Tendril](https://ivy.app).
