### PR TITLE
[00250] Show Remaining Quota Instead of Usage for Rate Limit Windows

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Abstractions/AgentUsageTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Abstractions/AgentUsageTests.cs
@@ -97,4 +97,63 @@ public class AgentUsageTests
         Assert.Equal(0, entry.OutputTokens);
         Assert.Null(entry.CostUsd);
     }
+
+    [Fact]
+    public void AgentUsageWindow_ComputesRemainingPercent_FromUsedPercent()
+    {
+        var window = new AgentUsageWindow { WindowMinutes = 300, UsedPercent = 25.5 };
+
+        Assert.Equal(25.5, window.UsedPercent);
+        Assert.NotNull(window.RemainingPercent);
+        Assert.Equal(74.5, window.RemainingPercent.Value, precision: 4);
+    }
+
+    [Fact]
+    public void AgentUsageWindow_ComputesUsedPercent_FromRemainingPercent()
+    {
+        var window = new AgentUsageWindow { WindowMinutes = 300, RemainingPercent = 69.3 };
+
+        Assert.Equal(69.3, window.RemainingPercent);
+        Assert.NotNull(window.UsedPercent);
+        Assert.Equal(30.7, window.UsedPercent.Value, precision: 4);
+    }
+
+    [Fact]
+    public void AgentUsageWindow_WhenBothSet_PreservesBoth()
+    {
+        var window = new AgentUsageWindow
+        {
+            WindowMinutes = 300,
+            UsedPercent = 30.0,
+            RemainingPercent = 70.0,
+        };
+
+        Assert.Equal(30.0, window.UsedPercent);
+        Assert.Equal(70.0, window.RemainingPercent);
+    }
+
+    [Fact]
+    public void AgentUsageWindow_WhenNeitherSet_BothNull()
+    {
+        var window = new AgentUsageWindow { WindowMinutes = 300 };
+
+        Assert.Null(window.UsedPercent);
+        Assert.Null(window.RemainingPercent);
+    }
+
+    [Fact]
+    public void AgentUsageWindow_ClampsValues_BetweenZeroAndOneHundred()
+    {
+        var high = new AgentUsageWindow { WindowMinutes = 300, UsedPercent = 120.0 };
+        Assert.Equal(0.0, high.RemainingPercent);
+
+        var low = new AgentUsageWindow { WindowMinutes = 300, UsedPercent = -10.0 };
+        Assert.Equal(100.0, low.RemainingPercent);
+
+        var highRem = new AgentUsageWindow { WindowMinutes = 300, RemainingPercent = 150.0 };
+        Assert.Equal(0.0, highRem.UsedPercent);
+
+        var lowRem = new AgentUsageWindow { WindowMinutes = 300, RemainingPercent = -20.0 };
+        Assert.Equal(100.0, lowRem.UsedPercent);
+    }
 }

--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityUsageProviderTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityUsageProviderTests.cs
@@ -40,15 +40,21 @@ public class AntigravityUsageProviderTests
         // 5h window (300m) - Gemini is lower (0.9858 < 1.0)
         var w5h = snapshot.Windows.Single(w => w.WindowMinutes == 300);
         var expectedUsed5h = (1.0 - 0.985869824886322) * 100.0;
+        var expectedRemaining5h = 0.985869824886322 * 100.0;
         Assert.NotNull(w5h.UsedPercent);
         Assert.Equal(expectedUsed5h, w5h.UsedPercent.Value, precision: 4);
+        Assert.NotNull(w5h.RemainingPercent);
+        Assert.Equal(expectedRemaining5h, w5h.RemainingPercent.Value, precision: 4);
         Assert.Equal(DateTimeOffset.Parse("2026-09-09T15:06:03Z"), w5h.ResetsAt);
 
         // Weekly window (10080m) - Gemini is lower (0.73099 < 1.0)
         var wWeekly = snapshot.Windows.Single(w => w.WindowMinutes == 10080);
         var expectedUsedWeekly = (1.0 - 0.7309908270835876) * 100.0;
+        var expectedRemainingWeekly = 0.7309908270835876 * 100.0;
         Assert.NotNull(wWeekly.UsedPercent);
         Assert.Equal(expectedUsedWeekly, wWeekly.UsedPercent.Value, precision: 4);
+        Assert.NotNull(wWeekly.RemainingPercent);
+        Assert.Equal(expectedRemainingWeekly, wWeekly.RemainingPercent.Value, precision: 4);
         Assert.Equal(DateTimeOffset.Parse("2026-09-11T05:39:20Z"), wWeekly.ResetsAt);
 
         // Note tags the losing group

--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexUsageProviderTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexUsageProviderTests.cs
@@ -46,11 +46,13 @@ public class CodexUsageProviderTests : IDisposable
         var primary = snapshot.Windows[0];
         Assert.Equal(300, primary.WindowMinutes);
         Assert.Equal(25.5, primary.UsedPercent);
+        Assert.Equal(74.5, primary.RemainingPercent);
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1789391057), primary.ResetsAt);
 
         var secondary = snapshot.Windows[1];
         Assert.Equal(10080, secondary.WindowMinutes);
         Assert.Equal(50.0, secondary.UsedPercent);
+        Assert.Equal(50.0, secondary.RemainingPercent);
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1789400000), secondary.ResetsAt);
     }
 

--- a/src/Ivy.Tendril.Agents/Abstractions/AgentUsage.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/AgentUsage.cs
@@ -55,9 +55,24 @@ public sealed record SessionCostResult
 
 public sealed record AgentUsageWindow
 {
+    private readonly double? _usedPercent;
+    private readonly double? _remainingPercent;
+
     /// <summary>Window length as the agent reports it. 300 = 5h, 10080 = 7d, 43200 = 30d.</summary>
     public required int WindowMinutes { get; init; }
-    public double? UsedPercent { get; init; }
+
+    public double? UsedPercent
+    {
+        get => _usedPercent ?? (_remainingPercent.HasValue ? Math.Clamp(100.0 - _remainingPercent.Value, 0.0, 100.0) : null);
+        init => _usedPercent = value;
+    }
+
+    public double? RemainingPercent
+    {
+        get => _remainingPercent ?? (_usedPercent.HasValue ? Math.Clamp(100.0 - _usedPercent.Value, 0.0, 100.0) : null);
+        init => _remainingPercent = value;
+    }
+
     public long? TotalTokens { get; init; }
     public decimal? CostUsd { get; init; }
     public DateTimeOffset? ResetsAt { get; init; }

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityUsageProvider.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityUsageProvider.cs
@@ -96,11 +96,13 @@ public sealed class AntigravityUsageProvider : IAgentUsageProvider
             {
                 var worst = wg.OrderBy(b => b.RemainingFraction).First();
                 var usedPercent = (1.0 - worst.RemainingFraction) * 100.0;
+                var remainingPercent = worst.RemainingFraction * 100.0;
 
                 windows.Add(new AgentUsageWindow
                 {
                     WindowMinutes = worst.WindowMinutes,
                     UsedPercent = usedPercent,
+                    RemainingPercent = remainingPercent,
                     ResetsAt = worst.ResetTime,
                 });
 

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexUsageProvider.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexUsageProvider.cs
@@ -143,6 +143,7 @@ public sealed class CodexUsageProvider : IAgentUsageProvider
         {
             WindowMinutes = windowMinutes,
             UsedPercent = usedPercent,
+            RemainingPercent = usedPercent.HasValue ? 100.0 - usedPercent.Value : null,
             ResetsAt = resetsAt,
         };
     }

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -279,11 +279,11 @@ public class CodingAgentSetupView : ViewBase
 
         object? WindowMetric(AgentUsageWindow w)
         {
-            var p = w.UsedPercent;
+            var p = w.RemainingPercent ?? (w.UsedPercent.HasValue ? 100.0 - w.UsedPercent.Value : null);
             var valueColor = p switch
             {
-                >= 90f => Colors.Destructive,
-                >= 75f => Colors.Warning,
+                <= 10f => Colors.Destructive,
+                <= 25f => Colors.Warning,
                 _ => (Colors?)null
             };
 


### PR DESCRIPTION
Fixes #2483

# Summary

## Changes

Updated rate limit window displays in Coding Agent settings to show remaining quota percentage rather than used percentage. Extended `AgentUsageWindow` with a `RemainingPercent` property and reciprocal calculation, populated remaining metrics in Antigravity and Codex providers, and inverted warning thresholds in the UI to alert when remaining capacity is low.

## API Changes

- Added `public double? RemainingPercent { get; init; }` to `AgentUsageWindow` with reciprocal computation falling back to `Math.Clamp(100.0 - UsedPercent.Value, 0.0, 100.0)`.

## Files Modified

- **Core and Abstractions**:
  - `src/Ivy.Tendril.Agents/Abstractions/AgentUsage.cs`: Added `RemainingPercent` property with reciprocal calculation and clamping.
  - `src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityUsageProvider.cs`: Populated both `RemainingPercent` and `UsedPercent` on created windows.
  - `src/Ivy.Tendril.Agents/Providers/Codex/CodexUsageProvider.cs`: Populated `RemainingPercent` from parsed session usage.

- **UI and Views**:
  - `src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs`: Displayed `RemainingPercent` in `WindowMetric` and inverted color thresholds for remaining capacity.

- **Tests**:
  - `src/Ivy.Tendril.Agents.Test/Abstractions/AgentUsageTests.cs`: Added unit tests for `AgentUsageWindow` reciprocal calculations and boundary clamping.
  - `src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityUsageProviderTests.cs`: Added assertions for 5h and weekly remaining percentages.
  - `src/Ivy.Tendril.Agents.Test/Codex/CodexUsageProviderTests.cs`: Added assertions for primary and secondary remaining percentages.

## Manual Testing

1. Launch the Tendril desktop application or run `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse`.
2. Navigate to Settings -> Coding Agents -> Antigravity (or Codex).
3. Observe the rate limit window metrics in the usage strip:
   - The 5h and weekly limit metrics should display remaining quota percentages (e.g. `90.8%` and `69.3%` remaining instead of `9.2%` and `30.7%` used).
   - The progress bar should be filled proportionally to the remaining capacity.
   - The warning color thresholds should trigger only when capacity is low (Warning when <= 25%, Destructive when <= 10%).

---
## Commits
- 1d316033 Add unit and provider tests for remaining quota calculations (Plan 00250)
- 7bbcaafa Show remaining quota instead of usage for rate limit windows (Plan 00250)

---
Created using [Ivy Tendril](https://ivy.app).
