### PR TITLE
[00248] Add Structured Date Fields to Dashboard Month Value Dto

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -448,20 +448,75 @@ public class DashboardAppViewModelTests
         Assert.Equal(6, result.Count);
         Assert.Equal("Aug 3", result[0].Label);
         Assert.Equal(5, result[0].Value);
+        Assert.Equal(2026, result[0].Year);
+        Assert.Equal(8, result[0].Month);
+        Assert.Equal(3, result[0].Day);
+        Assert.Equal("2026-08-03", result[0].Date);
 
         Assert.Equal("Aug 10", result[1].Label);
         Assert.Equal(0, result[1].Value);
+        Assert.Equal(2026, result[1].Year);
+        Assert.Equal(8, result[1].Month);
+        Assert.Equal(10, result[1].Day);
+        Assert.Equal("2026-08-10", result[1].Date);
 
         Assert.Equal("Aug 17", result[2].Label);
         Assert.Equal(4, result[2].Value);
+        Assert.Equal(2026, result[2].Year);
+        Assert.Equal(8, result[2].Month);
+        Assert.Equal(17, result[2].Day);
+        Assert.Equal("2026-08-17", result[2].Date);
 
         Assert.Equal("Aug 24", result[3].Label);
         Assert.Equal(7, result[3].Value);
+        Assert.Equal(2026, result[3].Year);
+        Assert.Equal(8, result[3].Month);
+        Assert.Equal(24, result[3].Day);
+        Assert.Equal("2026-08-24", result[3].Date);
 
         Assert.Equal("Aug 31", result[4].Label);
         Assert.Equal(3, result[4].Value);
+        Assert.Equal(2026, result[4].Year);
+        Assert.Equal(8, result[4].Month);
+        Assert.Equal(31, result[4].Day);
+        Assert.Equal("2026-08-31", result[4].Date);
 
         Assert.Equal("Sep 7", result[5].Label);
         Assert.Equal(6, result[5].Value);
+        Assert.Equal(2026, result[5].Year);
+        Assert.Equal(9, result[5].Month);
+        Assert.Equal(7, result[5].Day);
+        Assert.Equal("2026-09-07", result[5].Date);
+    }
+
+    [Fact]
+    public void BuildMonthlyPullRequests_PopulatesStructuredDateFields()
+    {
+        var months = new List<DashboardMonthStats>
+        {
+            new(2026, 4, 10, 8, 100m, 1000),
+            new(2026, 5, 12, 15, 150m, 1500),
+            new(2026, 6, 8, 6, 80m, 800),
+            new(2026, 7, 14, 12, 120m, 1200),
+            new(2026, 8, 18, 20, 200m, 2000),
+            new(2026, 9, 7, 5, 60m, 600),
+        };
+
+        var result = DashboardApp.BuildMonthlyPullRequests(months, 6);
+
+        Assert.Equal(6, result.Count);
+        Assert.Equal("Apr", result[0].Label);
+        Assert.Equal(8, result[0].Value);
+        Assert.Equal(2026, result[0].Year);
+        Assert.Equal(4, result[0].Month);
+        Assert.Equal(1, result[0].Day);
+        Assert.Equal("2026-04-01", result[0].Date);
+
+        Assert.Equal("Sep", result[5].Label);
+        Assert.Equal(5, result[5].Value);
+        Assert.Equal(2026, result[5].Year);
+        Assert.Equal(9, result[5].Month);
+        Assert.Equal(1, result[5].Day);
+        Assert.Equal("2026-09-01", result[5].Date);
     }
 }

--- a/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
+++ b/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
@@ -12,7 +12,13 @@ public record DashboardKpiDto(
     string? Hint = null,
     string? Id = null);
 
-public record DashboardMonthValueDto(string Label, double Value);
+public record DashboardMonthValueDto(
+    string Label,
+    double Value,
+    int? Year = null,
+    int? Month = null,
+    int? Day = null,
+    string? Date = null);
 
 public record DashboardActivityDayDto(string Date, int Count);
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/PillBars.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/PillBars.tsx
@@ -6,6 +6,65 @@ interface PillBarsProps {
   items: DashboardMonthValueDto[];
 }
 
+export function getAccessibleBarLabel(item: DashboardMonthValueDto): string {
+  const prText = `${item.value} pull request${item.value === 1 ? "" : "s"} merged`;
+  let year = item.year;
+  let month = item.month;
+  let day = item.day;
+
+  if ((!year || !month) && item.date) {
+    const parts = item.date.split("-").map(Number);
+    if (parts.length >= 2 && !isNaN(parts[0]) && !isNaN(parts[1])) {
+      year = parts[0];
+      month = parts[1];
+      if (parts.length >= 3 && !isNaN(parts[2])) {
+        day = parts[2];
+      }
+    }
+  }
+
+  if (year && month) {
+    const date = new Date(Date.UTC(year, month - 1, day ?? 1));
+    const monthName = date.toLocaleDateString("en-US", { month: "long", timeZone: "UTC" });
+    const isWeekly = item.label.includes(" ") || /\d/.test(item.label) || (day !== undefined && day > 1);
+    if (isWeekly && day !== undefined) {
+      return `Week of ${monthName} ${day}, ${year}: ${prText}`;
+    }
+    return `${monthName} ${year}: ${prText}`;
+  }
+
+  return `${item.label}: ${prText}`;
+}
+
+export function getBarTooltipHeader(item: DashboardMonthValueDto): string {
+  let year = item.year;
+  let month = item.month;
+  let day = item.day;
+
+  if ((!year || !month) && item.date) {
+    const parts = item.date.split("-").map(Number);
+    if (parts.length >= 2 && !isNaN(parts[0]) && !isNaN(parts[1])) {
+      year = parts[0];
+      month = parts[1];
+      if (parts.length >= 3 && !isNaN(parts[2])) {
+        day = parts[2];
+      }
+    }
+  }
+
+  if (year && month) {
+    const date = new Date(Date.UTC(year, month - 1, day ?? 1));
+    const monthName = date.toLocaleDateString("en-US", { month: "long", timeZone: "UTC" });
+    const isWeekly = item.label.includes(" ") || /\d/.test(item.label) || (day !== undefined && day > 1);
+    if (isWeekly && day !== undefined) {
+      return `Week of ${monthName} ${day}, ${year}`;
+    }
+    return `${monthName} ${year}`;
+  }
+
+  return item.label;
+}
+
 /** Rounded pill bars shaded by value intensity, with a small y-axis. */
 export const PillBars: React.FC<PillBarsProps> = ({ items }) => {
   const { wrapRef, tip, showTip, hideTip } = useHoverTip();
@@ -30,24 +89,29 @@ export const PillBars: React.FC<PillBarsProps> = ({ items }) => {
             <span key={tick}>{tick}</span>
           ))}
         </div>
-        <div className="tdb-bars-plot">
-          {items.map((item, index) => (
-            <div className="tdb-bar-item" key={index}>
-              <div className="tdb-bar-track">
-                <div
-                  className="tdb-bar"
-                  data-level={rampLevel(item.value, scaleMax)}
-                  style={{ height: `${(item.value / scaleMax) * 100}%` }}
-                  onMouseEnter={showTip(
-                    item.label,
-                    `${item.value} PR${item.value === 1 ? "" : "s"} merged`,
-                  )}
-                  onMouseLeave={hideTip}
-                />
+        <div className="tdb-bars-plot" role="list">
+          {items.map((item, index) => {
+            const accessibleLabel = getAccessibleBarLabel(item);
+            return (
+              <div className="tdb-bar-item" key={index} role="listitem">
+                <div className="tdb-bar-track">
+                  <div
+                    className="tdb-bar"
+                    role="img"
+                    aria-label={accessibleLabel}
+                    data-level={rampLevel(item.value, scaleMax)}
+                    style={{ height: `${(item.value / scaleMax) * 100}%` }}
+                    onMouseEnter={showTip(
+                      getBarTooltipHeader(item),
+                      `${item.value} PR${item.value === 1 ? "" : "s"} merged`,
+                    )}
+                    onMouseLeave={hideTip}
+                  />
+                </div>
+                <span className="tdb-bar-label">{item.label.replace(" ", "\n")}</span>
               </div>
-              <span className="tdb-bar-label">{item.label.replace(" ", "\n")}</span>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
       <HoverTip tip={tip} />

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
@@ -365,5 +365,52 @@ describe("TendrilDashboard pull requests week/month toggle", () => {
     expect(labelAug10.textContent).toBe("Aug\n10");
     expect(labelSep7.textContent).toBe("Sep\n7");
   });
+
+  it("renders bars with proper aria-label incorporating structured date fields", () => {
+    const structuredMonthlyPrs: DashboardMonthValueDto[] = [
+      { label: "Aug", value: 15, year: 2026, month: 8, day: 1, date: "2026-08-01" },
+      { label: "Sep", value: 1, year: 2026, month: 9, day: 1, date: "2026-09-01" },
+    ];
+
+    const structuredWeeklyPrs: DashboardMonthValueDto[] = [
+      { label: "Aug 24", value: 7, year: 2026, month: 8, day: 24, date: "2026-08-24" },
+      { label: "Aug 31", value: 1, year: 2026, month: 8, day: 31, date: "2026-08-31" },
+    ];
+
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={vi.fn()}
+        pullRequests={structuredMonthlyPrs}
+        pullRequestsWeekly={structuredWeeklyPrs}
+      />,
+    );
+
+    expect(screen.getByLabelText("August 2026: 15 pull requests merged")).toBeInTheDocument();
+    expect(screen.getByLabelText("September 2026: 1 pull request merged")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Week" }));
+
+    expect(screen.getByLabelText("Week of August 24, 2026: 7 pull requests merged")).toBeInTheDocument();
+    expect(screen.getByLabelText("Week of August 31, 2026: 1 pull request merged")).toBeInTheDocument();
+  });
+
+  it("renders accessible labels with backward compatibility when structured date fields are absent", () => {
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={vi.fn()}
+        pullRequests={monthlyPrs}
+        pullRequestsWeekly={weeklyPrs}
+      />,
+    );
+
+    expect(screen.getByLabelText("Aug: 20 pull requests merged")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Week" }));
+
+    expect(screen.getByLabelText("Aug 24: 5 pull requests merged")).toBeInTheDocument();
+  });
 });
+
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -12,6 +12,10 @@ export interface DashboardKpiDto {
 export interface DashboardMonthValueDto {
   label: string;
   value: number;
+  year?: number;
+  month?: number;
+  day?: number;
+  date?: string;
 }
 
 export interface DashboardActivityDayDto {

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -135,10 +135,7 @@ public class DashboardApp : ViewBase
             .Kpis(BuildKpis(stats, activity, prDays, today))
             .Trend(BuildTrend(activity, today))
             .TrendWeekly(BuildWeeklyTrend(activity, today))
-            .PullRequests(activity.Months
-                .TakeLast(6)
-                .Select(m => new DashboardMonthValueDto(MonthLabel(m.Month), m.PrsMerged))
-                .ToList())
+            .PullRequests(BuildMonthlyPullRequests(activity.Months))
             .PullRequestsWeekly(BuildWeeklyPullRequests(prDays, today))
             .Activity(BuildActivityMonths(prDays, firstActivityMonth))
             .Jobs(BuildActiveJobs(jobs, planService))
@@ -203,6 +200,21 @@ public class DashboardApp : ViewBase
     private static string MonthLabel(int month) =>
         CultureInfo.InvariantCulture.DateTimeFormat.GetAbbreviatedMonthName(month);
 
+    internal static List<DashboardMonthValueDto> BuildMonthlyPullRequests(
+        IEnumerable<DashboardMonthStats> months, int count = 6)
+    {
+        return months
+            .TakeLast(count)
+            .Select(m => new DashboardMonthValueDto(
+                MonthLabel(m.Month),
+                m.PrsMerged,
+                m.Year,
+                m.Month,
+                1,
+                $"{m.Year:D4}-{m.Month:D2}-01"))
+            .ToList();
+    }
+
     internal static List<DashboardMonthValueDto> BuildWeeklyPullRequests(
         List<(DateOnly Date, int Count)> prDays, DateTime today, int weeks = 6)
     {
@@ -216,7 +228,13 @@ public class DashboardApp : ViewBase
             var weekEnd = weekStart.AddDays(6);
             var count = prDays.Where(p => p.Date >= weekStart && p.Date <= weekEnd).Sum(p => p.Count);
             var label = $"{MonthLabel(weekStart.Month)} {weekStart.Day}";
-            result.Add(new DashboardMonthValueDto(label, count));
+            result.Add(new DashboardMonthValueDto(
+                label,
+                count,
+                weekStart.Year,
+                weekStart.Month,
+                weekStart.Day,
+                weekStart.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
         }
 
         return result;


### PR DESCRIPTION
# Summary

## Changes

Added structured calendar date fields (year, month, day, and ISO date string) to `DashboardMonthValueDto` across backend C# and frontend TypeScript interfaces. Updated `DashboardApp` to populate these fields for both weekly and monthly pull request series, and enhanced `PillBars` with comprehensive accessible `aria-label` screen reader announcements and tooltip formatting.

## API Changes

- `Ivy.Tendril.Widgets.DashboardMonthValueDto`: Added optional constructor parameters `int? Year = null`, `int? Month = null`, `int? Day = null`, and `string? Date = null`.
- `DashboardMonthValueDto` (TypeScript): Added optional properties `year?: number`, `month?: number`, `day?: number`, and `date?: string`.

## Files Modified

- **Backend DTO & Services:**
  - `src/Ivy.Tendril.Widgets/TendrilDashboard.cs`: Extended `DashboardMonthValueDto` record with optional structured date fields.
  - `src/Ivy.Tendril/Apps/DashboardApp.cs`: Populated structured date fields in `BuildWeeklyPullRequests` and added `BuildMonthlyPullRequests`.
- **Frontend Types & Widgets:**
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`: Extended TypeScript `DashboardMonthValueDto` interface.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/PillBars.tsx`: Added `getAccessibleBarLabel` and `getBarTooltipHeader` helpers, added `aria-label` attributes to `.tdb-bar`, and added `role="listitem"` to `.tdb-bar-item`.
- **Unit Tests:**
  - `src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs`: Extended weekly pull request tests and added monthly pull request structured date verification.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx`: Added tests for structured date aria-labels and backward compatibility without structured dates.

## Manual Testing

1. Launch Tendril application or run the widget sample playground:
   ```bash
   dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port
   ```
2. Navigate to the Dashboard view.
3. Observe the Pull Requests card in the right sidebar.
4. Toggle between the "Month" and "Week" tabs.
5. Inspect the bars using browser developer tools or a screen reader:
   - In Month view: observe that each bar has an `aria-label` announcing the full month and year (e.g., "August 2026: 15 pull requests merged").
   - In Week view: observe that each bar announces the start week (e.g., "Week of August 24, 2026: 7 pull requests merged").
6. Hover over the bars to confirm the tooltip headers display the formatted dates correctly.

---
### Commits

- 2d2b1e7a: Add structured date fields to DashboardMonthValueDto (Plan 00248)

---
Created using [Ivy Tendril](https://ivy.app).