### PR TITLE
[00253] Fix Markdown Code Block Width and Overflow in Chat App

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -2353,3 +2353,111 @@ describe("ChatWidget embedded mode", () => {
     expect(screen.queryByRole("button", { name: "Chat options" })).not.toBeInTheDocument();
   });
 });
+
+describe("ChatWidget Markdown Code Blocks", () => {
+  beforeEach(() => {
+    window.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as any;
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("renders assistant markdown code blocks inside pmv-code-block with copy button", () => {
+    const session: ChatSessionDto = {
+      id: "s-code",
+      title: "Code block test",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: "",
+      updatedAt: "",
+      messages: [
+        {
+          id: "m-user",
+          role: "user",
+          content: "Show me a code snippet",
+          timestamp: "",
+        },
+        {
+          id: "m-assistant",
+          role: "assistant",
+          content: "Here is a TypeScript snippet:\n\n```typescript\nconst greeting = 'hello world';\nconsole.log(greeting);\n```\n\nAnd here is an untagged block:\n\n```\necho 'plain text block'\n```\n\nAnd an inline `const foo = 42;` value.",
+          timestamp: "",
+        },
+      ],
+    };
+
+    const { container } = render(<ChatWidget id="test-chat" activeSessionId="s-code" sessions={[session]} />);
+
+    const assistantRow = container.querySelector(".chat-message-row.assistant");
+    expect(assistantRow).toBeInTheDocument();
+
+    const markdownBody = assistantRow?.querySelector(".chat-markdown-body");
+    expect(markdownBody).toBeInTheDocument();
+
+    const codeBlocks = assistantRow?.querySelectorAll(".pmv-code-block");
+    expect(codeBlocks?.length).toBe(2);
+
+    // Verify first code block (tagged)
+    const firstBlock = codeBlocks?.[0];
+    expect(firstBlock).toBeInTheDocument();
+    expect(firstBlock?.querySelector("button.pmv-code-copy")).toBeInTheDocument();
+    expect(firstBlock?.querySelector("pre")).toBeInTheDocument();
+    expect(firstBlock?.textContent).toContain("const greeting = 'hello world';");
+
+    // Verify second code block (untagged)
+    const secondBlock = codeBlocks?.[1];
+    expect(secondBlock).toBeInTheDocument();
+    expect(secondBlock?.querySelector("button.pmv-code-copy")).toBeInTheDocument();
+    expect(secondBlock?.querySelector("pre")).toBeInTheDocument();
+    expect(secondBlock?.querySelector("pre code")).toBeInTheDocument();
+    expect(secondBlock?.textContent).toContain("echo 'plain text block'");
+
+    // Verify inline code is rendered as standalone code tag outside pmv-code-block
+    const allCodeTags = assistantRow?.querySelectorAll("code");
+    const inlineCode = Array.from(allCodeTags || []).find((el) => el.textContent === "const foo = 42;");
+    expect(inlineCode).toBeInTheDocument();
+    expect(inlineCode?.closest(".pmv-code-block")).toBeNull();
+  });
+
+  it("renders assistant streaming turns with code blocks inside pmv-code-block", () => {
+    const rawStream = JSON.stringify({
+      kind: "text",
+      text: "Streaming code block:\n\n```python\ndef add(a, b):\n    return a + b\n```",
+      delta: false,
+    });
+
+    const session: ChatSessionDto = {
+      id: "s-stream",
+      title: "Streaming code block test",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: "",
+      updatedAt: "",
+      messages: [
+        {
+          id: "m-stream-assistant",
+          role: "assistant",
+          content: "",
+          rawStream,
+          timestamp: "",
+        },
+      ],
+    };
+
+    const { container } = render(<ChatWidget id="test-chat" activeSessionId="s-stream" sessions={[session]} />);
+
+    const assistantRow = container.querySelector(".chat-message-row.assistant");
+    expect(assistantRow).toBeInTheDocument();
+
+    const turn = assistantRow?.querySelector(".chat-turn");
+    expect(turn).toBeInTheDocument();
+
+    const codeBlock = assistantRow?.querySelector(".pmv-code-block");
+    expect(codeBlock).toBeInTheDocument();
+    expect(codeBlock?.querySelector("button.pmv-code-copy")).toBeInTheDocument();
+    expect(codeBlock?.textContent).toContain("def add(a, b):");
+  });
+});
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -564,9 +564,10 @@
   justify-content: flex-start;
 }
 
-/* Every entry, whichever side it sits on, is capped at 60% of the thread's width. */
+/* Assistant turns take the full thread width for structured content (code blocks, tables, questions). */
 .chat-message-row.assistant > * {
-  width: 60%;
+  width: 100%;
+  max-width: 100%;
   min-width: 0;
 }
 
@@ -658,6 +659,9 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .chat-tools {
@@ -811,6 +815,7 @@ button.chat-system-event-plan {
 /* ---------- Markdown ---------- */
 
 .chat-markdown-body {
+  width: 100%;
   min-width: 0;
   max-width: 100%;
   color: var(--tch-fg);
@@ -897,6 +902,92 @@ button.chat-system-event-plan {
   font-family: var(--tch-mono);
   font-size: 0.8125rem;
   overflow-wrap: break-word;
+}
+
+/* Code blocks */
+.pmv-code-block {
+  position: relative;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid var(--tch-border);
+  background: var(--tch-surface);
+}
+
+.chat-markdown-body .pmv-code-block {
+  margin: 0.75rem 0;
+}
+
+.chat-markdown-body .pmv-code-block pre {
+  margin: 0;
+  min-width: 0;
+  max-width: 100%;
+  background: transparent;
+  padding: 1rem;
+  padding-right: 3rem;
+  overflow-x: auto;
+  border-radius: 0;
+}
+
+.chat-markdown-body pre code,
+.chat-markdown-body .pmv-code-block code {
+  background: none;
+  border: none;
+  padding: 0;
+  border-radius: 0;
+  display: block;
+  max-width: none;
+  white-space: pre;
+  font-size: inherit;
+}
+
+.pmv-code-copy {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.375rem;
+  border-radius: 6px;
+  border: 1px solid var(--tch-border);
+  background: var(--tch-surface);
+  color: var(--tch-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+}
+
+.pmv-code-block:hover .pmv-code-copy,
+.pmv-code-copy:focus-visible,
+.pmv-code-copy:focus-within {
+  opacity: 1;
+}
+
+.pmv-code-copy:hover {
+  background: var(--tch-surface-hover);
+  color: var(--tch-fg);
+}
+
+.pmv-code-copy--copied {
+  background: var(--tch-cta-bg);
+  color: var(--tch-cta-fg);
+  border-color: var(--tch-cta-bg);
+  opacity: 1;
+}
+
+.pmv-code-copy--copied:hover {
+  background: var(--tch-cta-bg);
+  color: var(--tch-cta-fg);
+}
+
+.pmv-code-copy svg {
+  width: 14px;
+  height: 14px;
 }
 
 .chat-markdown-body pre {


### PR DESCRIPTION
Fixes #2485

# Summary

## Changes

Fixed markdown code block width and overflow issues in the Chat App. Assistant message rows now use the full reading column width, code blocks are properly styled with copy buttons and container boundaries, and code elements inside pre blocks have reset styling to prevent broken inline styles.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css`: Updated assistant row, turn, and markdown container widths to 100%; styled `.pmv-code-block` and `.pmv-code-copy`; added reset rules for code inside pre.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Added unit tests verifying assistant message code blocks, copy buttons, and streaming code blocks.

## Manual Testing

1. Launch Tendril or run the widget sample app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse`.
2. Open a chat session and prompt the assistant to output a code snippet with long lines of code (or open an existing chat containing code blocks).
3. Observe that assistant message rows span the full width of the chat column instead of being constrained to 60%.
4. Observe that code blocks have rounded borders, background styling, a copy button in the top right, and clean horizontal scrolling for long lines without broken inline code styling.

---
## Commits
- f7c127c9 Fix markdown code block width and overflow in Chat App (Plan 00253)

---
Created using [Ivy Tendril](https://ivy.app).
