### PR TITLE
[00256] Clarify Window Metric as Remaining Capacity in Coding Agent Settings

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -288,7 +288,7 @@ public class CodingAgentSetupView : ViewBase
             };
 
             var valueText = Text.Block(p is { } pct
-                ? $"{pct:0.#}%"
+                ? $"{pct:0.#}% remaining"
                 : $"{UsageWindowCalculator.FormatTokens(w.TotalTokens)} tokens").Small();
 
             if (valueColor.HasValue)
@@ -302,7 +302,7 @@ public class CodingAgentSetupView : ViewBase
                     : new Progress((int)Math.Round(progVal)).Small())
                 : null;
 
-            return Layout.Vertical().Gap(0).Width(Size.Units(36))
+            return Layout.Vertical().Gap(0).Width(Size.Units(38))
                 | Text.Muted($"{UsageWindowCalculator.FormatWindow(w.WindowMinutes)} window").Small()
                 | valueText
                 | (progress != null ? progress : null!)


### PR DESCRIPTION
# Summary

## Changes

Clarified the rate limit window metric in the Coding Agent Settings view by appending "remaining" to the percentage text (e.g. "90.8% remaining" instead of "90.8%"). In addition, adjusted the metric container width from 36 to 38 units to ensure the text fits comfortably without wrapping.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs`: Updated `WindowMetric` value label to append "remaining" to percentage and enlarged layout width to `Size.Units(38)`.

## Manual Testing

1. Launch Tendril and navigate to Settings -> Coding Agent.
2. Select an agent profile that reports usage window metrics (such as Claude Code or Antigravity).
3. Observe the window metric display: the percentage should explicitly read `<pct>% remaining` (e.g., `100% remaining` or `95.4% remaining`), and the text should fit cleanly without wrapping.

---
- 7cb9ddc6 [00256] Clarify window metric percentage as remaining capacity in CodingAgentSetupView

---
Created using [Ivy Tendril](https://ivy.app).
