### PR TITLE
[00252] Allow Dropping Files Anywhere on Chat App to Attach

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -464,6 +464,82 @@ describe("ChatWidget File Uploads and Attachments", () => {
     });
   });
 
+  it("activates dragging state and renders drop overlay when dragging over the root widget or message area", () => {
+    const { container } = render(<ChatWidget id="test-chat" />);
+    const root = container.querySelector(".chat-widget-root")!;
+    expect(root).toBeInTheDocument();
+
+    // Drag enter on root
+    fireEvent.dragEnter(root, {
+      dataTransfer: { dropEffect: "none" },
+    });
+    expect(root).toHaveClass("dragging");
+    expect(screen.getByText("Drop files here to attach to message")).toBeInTheDocument();
+
+    // Drag leave on root
+    fireEvent.dragLeave(root);
+    expect(root).not.toHaveClass("dragging");
+    expect(screen.queryByText("Drop files here to attach to message")).not.toBeInTheDocument();
+
+    // Drag over messages container activates overlay
+    const messagesArea = container.querySelector(".chat-thread") || root;
+    fireEvent.dragEnter(messagesArea, {
+      dataTransfer: { dropEffect: "none" },
+    });
+    expect(root).toHaveClass("dragging");
+    expect(screen.getByText("Drop files here to attach to message")).toBeInTheDocument();
+  });
+
+  it("supports dropping a file anywhere on the chat widget to add attachment", async () => {
+    const { container } = render(<ChatWidget id="test-chat" />);
+    const root = container.querySelector(".chat-widget-root")!;
+    const messagesArea = container.querySelector(".chat-thread") || root;
+
+    // Drag over chat area
+    fireEvent.dragEnter(messagesArea, {
+      dataTransfer: { dropEffect: "none" },
+    });
+    expect(root).toHaveClass("dragging");
+
+    // Drop file on messages area
+    const droppedFile = new File(["test docx content"], "specs.docx", { type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" });
+    fireEvent.drop(messagesArea, {
+      dataTransfer: { files: [droppedFile] },
+    });
+    expect(root).not.toHaveClass("dragging");
+    expect(screen.queryByText("Drop files here to attach to message")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("specs.docx")).toBeInTheDocument();
+      expect(screen.getByText("DOCX")).toBeInTheDocument();
+    });
+  });
+
+  it("calls preventDefault on dragover and drop events to block browser file navigation", () => {
+    const { container } = render(<ChatWidget id="test-chat" />);
+    const root = container.querySelector(".chat-widget-root")!;
+
+    // Drag over root prevents default
+    const dragOverEvent = new Event("dragover", { bubbles: true, cancelable: true });
+    root.dispatchEvent(dragOverEvent);
+    expect(dragOverEvent.defaultPrevented).toBe(true);
+
+    // Drop on root prevents default
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true });
+    root.dispatchEvent(dropEvent);
+    expect(dropEvent.defaultPrevented).toBe(true);
+
+    // Window-level dragover prevents default
+    const windowDragOverEvent = new Event("dragover", { bubbles: true, cancelable: true });
+    window.dispatchEvent(windowDragOverEvent);
+    expect(windowDragOverEvent.defaultPrevented).toBe(true);
+
+    // Window-level drop prevents default
+    const windowDropEvent = new Event("drop", { bubbles: true, cancelable: true });
+    window.dispatchEvent(windowDropEvent);
+    expect(windowDropEvent.defaultPrevented).toBe(true);
+  });
+
   it("supports removing an attached file via its thumbnail remove button", async () => {
     render(<ChatWidget id="test-chat" />);
     const textarea = screen.getByPlaceholderText(/Ask/i);

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -13,6 +13,7 @@ import {
   Sparkles,
   Square,
   Trash2,
+  Upload,
   X,
   XCircle,
 } from "lucide-react";
@@ -524,24 +525,58 @@ export function ChatWidget({
     }
   };
 
+  const dragCounterRef = useRef(0);
+
+  useEffect(() => {
+    const handleWindowDragOver = (e: DragEvent) => {
+      e.preventDefault();
+    };
+    const handleWindowDrop = (e: DragEvent) => {
+      e.preventDefault();
+      dragCounterRef.current = 0;
+      setIsDragging(false);
+    };
+
+    window.addEventListener("dragover", handleWindowDragOver);
+    window.addEventListener("drop", handleWindowDrop);
+
+    return () => {
+      window.removeEventListener("dragover", handleWindowDragOver);
+      window.removeEventListener("drop", handleWindowDrop);
+    };
+  }, []);
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current += 1;
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    setIsDragging(true);
+  };
+
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
-    setIsDragging(true);
+    if (dragCounterRef.current === 0) dragCounterRef.current = 1;
+    if (!isDragging) setIsDragging(true);
   };
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    setIsDragging(false);
+    dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+    if (dragCounterRef.current === 0) {
+      setIsDragging(false);
+    }
   };
 
   const handleDrop = async (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    dragCounterRef.current = 0;
     setIsDragging(false);
-    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+    if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
       await addFiles(e.dataTransfer.files);
     }
   };
@@ -562,8 +597,24 @@ export function ChatWidget({
   const title = (activeSession && pendingRenames[activeSession.id]) || activeSession?.title || "New Chat";
 
   return (
-    <div className="chat-widget-root" data-embedded={embedded}>
+    <div
+      className={`chat-widget-root ${isDragging ? "dragging" : ""}`}
+      data-embedded={embedded}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
       <input ref={fileInputRef} type="file" multiple style={{ display: "none" }} onChange={handleFileSelect} />
+
+      {isDragging && (
+        <div className="chat-drop-overlay" aria-hidden="true">
+          <div className="chat-drop-overlay-content">
+            <Upload size={36} className="chat-drop-overlay-icon" />
+            <span className="chat-drop-overlay-text">Drop files here to attach to message</span>
+          </div>
+        </div>
+      )}
 
       {embedded ? (
         activeSession &&
@@ -785,10 +836,6 @@ export function ChatWidget({
 
           <div
             className={`chat-input-box ${isDragging ? "dragging" : ""} ${isPayloadOversized ? "oversized" : ""}`}
-            onDragEnter={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDragOver={handleDragOver}
-            onDrop={handleDrop}
           >
             {isPayloadOversized && (
               <div className="chat-payload-warning" role="alert">

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -40,6 +40,7 @@
 }
 
 .chat-widget-root {
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -971,6 +972,44 @@ button.chat-system-event-plan {
 .chat-input-box.dragging {
   border-color: var(--tch-fg);
   border-style: dashed;
+}
+
+.chat-drop-overlay {
+  position: absolute;
+  inset: 8px;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--tch-bg) 88%, transparent);
+  backdrop-filter: blur(4px);
+  border: 2px dashed color-mix(in srgb, var(--tch-fg) 40%, transparent);
+  border-radius: 16px;
+  pointer-events: none;
+}
+
+.chat-widget-root.dragging .chat-drop-overlay {
+  border-color: var(--tch-fg);
+}
+
+.chat-drop-overlay-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  color: var(--tch-fg);
+  text-align: center;
+}
+
+.chat-drop-overlay-icon {
+  color: var(--tch-fg);
+  opacity: 0.8;
+}
+
+.chat-drop-overlay-text {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--tch-fg);
 }
 
 .chat-input-box.oversized {


### PR DESCRIPTION
Fixes #2484

# Summary

## Changes

Enabled drag-and-drop file attachment across the entire Chat widget rather than restricting it to the input box container. Added window-level navigation guards to prevent accidental browser file previews or navigation, along with a visual drop overlay displaying an upload icon and helpful drop guidance.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx`: Added drag-and-drop handlers to `.chat-widget-root`, drag nesting counter ref, window navigation guards, and drop overlay rendering.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css`: Added styles for `.chat-drop-overlay` with dashed border, backdrop blur, centered icon/text, and `pointer-events: none`.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Added unit tests for widget-wide dragging, dropping attachments anywhere, and preventDefault execution.

## Manual Testing

1. Open the Chat application or run `tendril --browse`.
2. Open any chat session or start a new chat.
3. Drag a file from your file manager over the chat message history or empty chat area.
4. Observe that the drop overlay appears with "Drop files here to attach to message" and dashed border styling.
5. Drop the file anywhere over the chat widget.
6. Observe that the file is attached to the composer without triggering browser file navigation.

---
## Commits
- 69abeca2 Allow dropping files anywhere on chat app to attach (Plan 00252)

---
Created using [Ivy Tendril](https://ivy.app).
