### PR TITLE
[00255] Add Help Tooltips and Empty States for Ports and Environment Files

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Settings/ProjectPortsAndEnvFilesGuidanceTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Settings/ProjectPortsAndEnvFilesGuidanceTests.cs
@@ -1,0 +1,114 @@
+using Ivy;
+using Ivy.Core.Hooks;
+using Ivy.Tendril.Apps.Settings;
+using Ivy.Tendril.Apps.Settings.Blades;
+using Ivy.Tendril.Apps.Settings.Dialogs;
+using Ivy.Tendril.Services;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Settings;
+
+public class ProjectPortsAndEnvFilesGuidanceTests
+{
+    [Fact]
+    public void ProjectPortsTableView_WhenEmpty_RendersHelpfulEmptyStateGuidance()
+    {
+        var ports = new State<Dictionary<string, ProjectPortConfig>>(new Dictionary<string, ProjectPortConfig>());
+        var view = new ProjectPortsTableView(ports, _ => { });
+        var result = view.Build();
+
+        Assert.NotNull(result);
+        var textBuilder = Assert.IsType<TextBuilder>(result);
+        var textBlock = Assert.IsType<TextBlock>(textBuilder.Build());
+        Assert.Contains("No service ports configured", textBlock.Content);
+        Assert.Contains("dynamic port allocation across concurrent plan reviews", textBlock.Content);
+    }
+
+    [Fact]
+    public void ProjectEnvFilesTableView_WhenEmpty_RendersHelpfulEmptyStateGuidance()
+    {
+        var envFiles = new State<List<ProjectEnvFileConfig>>(new List<ProjectEnvFileConfig>());
+        var view = new ProjectEnvFilesTableView(envFiles, _ => { });
+        var result = view.Build();
+
+        Assert.NotNull(result);
+        var textBuilder = Assert.IsType<TextBuilder>(result);
+        var textBlock = Assert.IsType<TextBlock>(textBuilder.Build());
+        Assert.Contains("No environment files configured", textBlock.Content);
+        Assert.Contains("materialize .env templates and inject variables into plan worktrees", textBlock.Content);
+    }
+
+    [Fact]
+    public void EditProjectPortDialog_BuildForm_ConfiguresHelpTooltipsOnAllFields()
+    {
+        var editName = new State<string>("");
+        var editPort = new State<int>(3000);
+        var editDescription = new State<string>("");
+
+        var form = EditProjectPortDialog.BuildForm(editName, editPort, editDescription);
+
+        Assert.NotNull(form);
+        var layout = Assert.IsAssignableFrom<Ivy.Core.AbstractWidget>(form.Build());
+        var fields = layout.Children.OfType<Field>().ToList();
+        Assert.Equal(3, fields.Count);
+
+        var nameField = fields[0];
+        Assert.Equal("Name", nameField.Label);
+        Assert.Equal("Port identifier referenced in environment overrides via ${ports.<name>} placeholders.", nameField.Help);
+
+        var defaultPortField = fields[1];
+        Assert.Equal("Default Port", defaultPortField.Label);
+        Assert.Equal("Preferred port to allocate. If already in use by another plan or process, Tendril dynamically falls back to an available free port.", defaultPortField.Help);
+
+        var descriptionField = fields[2];
+        Assert.Equal("Description", descriptionField.Label);
+        Assert.Equal("Optional summary of the service listening on this port.", descriptionField.Help);
+    }
+
+    [Fact]
+    public void EditProjectEnvFileDialog_BuildForm_ConfiguresHelpTooltipsOnAllFields()
+    {
+        var editPath = new State<string>("");
+        var editTemplate = new State<string>("");
+        var editOverrides = new State<string>("");
+
+        var form = EditProjectEnvFileDialog.BuildForm(editPath, editTemplate, editOverrides);
+
+        Assert.NotNull(form);
+        var layout = Assert.IsAssignableFrom<Ivy.Core.AbstractWidget>(form.Build());
+        var fields = layout.Children.OfType<Field>().ToList();
+        Assert.Equal(3, fields.Count);
+
+        var pathField = fields[0];
+        Assert.Equal("Path", pathField.Label);
+        Assert.Equal("Relative path to the environment file recreated inside the plan worktree (e.g. apps/web/.env).", pathField.Help);
+
+        var templateField = fields[1];
+        Assert.Equal("Template", templateField.Label);
+        Assert.Equal("Optional base template file (e.g. .env.example) copied into the worktree before applying overrides.", templateField.Help);
+
+        var overridesField = fields[2];
+        Assert.Equal("Overrides", overridesField.Label);
+        Assert.Equal("KEY=VALUE override lines supporting ${ports.<name>}, ${env.<VAR>}, and %VAR% placeholder substitutions.", overridesField.Help);
+    }
+
+    [Fact]
+    public void ProjectDetailView_Headers_IncludeInfoTooltipsWithGuidance()
+    {
+        var portsHeader = ProjectDetailView.BuildPortsHeader();
+        var portsLayout = Assert.IsType<LayoutView>(portsHeader);
+        var portsWidget = Assert.IsAssignableFrom<Ivy.Core.AbstractWidget>(portsLayout.Build());
+        var portsTooltip = Assert.Single(portsWidget.Children.OfType<Tooltip>());
+        var portsContentSlot = Assert.Single(portsTooltip.Children.OfType<Slot>().Where(s => s.Name == "Content"));
+        var portsGuidance = Assert.IsType<string>(Assert.Single(portsContentSlot.Children));
+        Assert.Equal("Named service ports dynamically allocated in plan worktrees to enable concurrent reviews without port conflicts.", portsGuidance);
+
+        var envFilesHeader = ProjectDetailView.BuildEnvFilesHeader();
+        var envFilesLayout = Assert.IsType<LayoutView>(envFilesHeader);
+        var envFilesWidget = Assert.IsAssignableFrom<Ivy.Core.AbstractWidget>(envFilesLayout.Build());
+        var envFilesTooltip = Assert.Single(envFilesWidget.Children.OfType<Tooltip>());
+        var envFilesContentSlot = Assert.Single(envFilesTooltip.Children.OfType<Slot>().Where(s => s.Name == "Content"));
+        var envFilesGuidance = Assert.IsType<string>(Assert.Single(envFilesContentSlot.Children));
+        Assert.Equal("Environment files recreated in plan worktrees from templates and variable overrides.", envFilesGuidance);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
@@ -432,7 +432,10 @@ public class ProjectPortsTableView(
     public override object? Build()
     {
         var current = ports.Value;
-        if (current.Count == 0) return null;
+        if (current.Count == 0)
+        {
+            return Text.Block("No service ports configured. Define named ports for dynamic port allocation across concurrent plan reviews.").Muted().Small();
+        }
 
         var rows = current.Select((p, i) => new PortRow(p.Key, p.Value.DefaultPort, p.Value.Description, i)).ToList();
 
@@ -471,7 +474,10 @@ public class ProjectEnvFilesTableView(
     public override object? Build()
     {
         var list = envFiles.Value;
-        if (list.Count == 0) return null;
+        if (list.Count == 0)
+        {
+            return Text.Block("No environment files configured. Define environment files to materialize .env templates and inject variables into plan worktrees.").Muted().Small();
+        }
 
         var rows = list
             .Select((f, i) => new EnvFileRow(f.Path, f.Template ?? "", string.Join(", ", f.Overrides.Keys), i))

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectEnvFileDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectEnvFileDialog.cs
@@ -38,10 +38,7 @@ internal class EditProjectEnvFileDialog(
             _ => isOpen.Set(false),
             new DialogHeader(isNew ? "Add Environment File" : "Edit Environment File"),
             new DialogBody(
-                Layout.Vertical()
-                | editPath.ToTextInput("e.g. apps/web/.env").WithField().Label("Path").Required()
-                | editTemplate.ToTextInput("e.g. .env.example").WithField().Label("Template")
-                | editOverrides.ToCodeInput("PORT=${ports.backend}").Height(Size.Units(40)).WithField().Label("Overrides")
+                BuildForm(editPath, editTemplate, editOverrides)
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => isOpen.Set(false)),
@@ -101,5 +98,13 @@ internal class EditProjectEnvFileDialog(
         foreach (var (key, value) in overrides)
             sb.Append(key).Append('=').Append(value).Append('\n');
         return sb.ToString().TrimEnd('\n');
+    }
+
+    internal static LayoutView BuildForm(IState<string> editPath, IState<string> editTemplate, IState<string> editOverrides)
+    {
+        return Layout.Vertical()
+            | editPath.ToTextInput("e.g. apps/web/.env").WithField().Label("Path").Required().Help("Relative path to the environment file recreated inside the plan worktree (e.g. apps/web/.env).")
+            | editTemplate.ToTextInput("e.g. .env.example").WithField().Label("Template").Help("Optional base template file (e.g. .env.example) copied into the worktree before applying overrides.")
+            | editOverrides.ToCodeInput("PORT=${ports.backend}").Height(Size.Units(40)).WithField().Label("Overrides").Help("KEY=VALUE override lines supporting ${ports.<name>}, ${env.<VAR>}, and %VAR% placeholder substitutions.");
     }
 }

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectPortDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectPortDialog.cs
@@ -34,10 +34,7 @@ internal class EditProjectPortDialog(
             _ => isOpen.Set(false),
             new DialogHeader(isNew ? "Add Port" : "Edit Port"),
             new DialogBody(
-                Layout.Vertical()
-                | editName.ToTextInput("e.g. backend").WithField().Label("Name").Required()
-                | editPort.ToNumberInput().Min(1).Max(65535).WithField().Label("Default Port").Required()
-                | editDescription.ToTextInput("What listens here...").WithField().Label("Description")
+                BuildForm(editName, editPort, editDescription)
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => isOpen.Set(false)),
@@ -65,5 +62,13 @@ internal class EditProjectPortDialog(
                 })
             )
         ).Width(Size.Rem(30));
+    }
+
+    internal static LayoutView BuildForm(IState<string> editName, IState<int> editPort, IState<string> editDescription)
+    {
+        return Layout.Vertical()
+            | editName.ToTextInput("e.g. backend").WithField().Label("Name").Required().Help("Port identifier referenced in environment overrides via ${ports.<name>} placeholders.")
+            | editPort.ToNumberInput().Min(1).Max(65535).WithField().Label("Default Port").Required().Help("Preferred port to allocate. If already in use by another plan or process, Tendril dynamically falls back to an available free port.")
+            | editDescription.ToTextInput("What listens here...").WithField().Label("Description").Help("Optional summary of the service listening on this port.");
     }
 }

--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -329,12 +329,12 @@ public class ProjectDetailView(
             | new Button("Add Verification").Icon(Icons.Plus).Outline().OnClick(() => showVerificationTrigger(null))
 
             // Section 5: Ports
-            | Text.H4("Ports").Bold()
+            | BuildPortsHeader()
             | new ProjectPortsTableView(ports, name => showPortTrigger(name))
             | new Button("Add Port").Icon(Icons.Plus).Outline().OnClick(() => showPortTrigger(null))
 
             // Section 6: Environment Files
-            | Text.H4("Environment Files").Bold()
+            | BuildEnvFilesHeader()
             | new ProjectEnvFilesTableView(envFiles, idx => showEnvFileTrigger(idx))
             | new Button("Add Environment File").Icon(Icons.Plus).Outline().OnClick(() => showEnvFileTrigger(null))
 
@@ -467,5 +467,19 @@ public class ProjectDetailView(
                 return false;
         }
         return true;
+    }
+
+    internal static object BuildPortsHeader()
+    {
+        return Layout.Horizontal().AlignContent(Align.Left)
+            | Text.H4("Ports").Bold()
+            | Icons.Info.ToIcon().Color(Colors.Muted).WithTooltip("Named service ports dynamically allocated in plan worktrees to enable concurrent reviews without port conflicts.");
+    }
+
+    internal static object BuildEnvFilesHeader()
+    {
+        return Layout.Horizontal().AlignContent(Align.Left)
+            | Text.H4("Environment Files").Bold()
+            | Icons.Info.ToIcon().Color(Colors.Muted).WithTooltip("Environment files recreated in plan worktrees from templates and variable overrides.");
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added contextual info tooltips and empty-state guidance for Ports and Environment Files in Project Settings. Section headers now pair with info icon tooltips, empty tables display helpful explanation text, and dialog fields provide inline help on placeholder syntax and dynamic allocation.

## API Changes

None.

## Files Modified

- **UI & Views**:
  - `src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs`: Added `BuildPortsHeader()` and `BuildEnvFilesHeader()` with info icon tooltips.
  - `src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs`: Added empty-state text guidance to `ProjectPortsTableView` and `ProjectEnvFilesTableView`.
  - `src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectPortDialog.cs`: Extracted `BuildForm` and added field help tooltips.
  - `src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectEnvFileDialog.cs`: Extracted `BuildForm` and added field help tooltips.
- **Tests**:
  - `src/Ivy.Tendril.Test/Apps/Settings/ProjectPortsAndEnvFilesGuidanceTests.cs`: New test suite covering empty states, field help tooltips, and header tooltips.

## Manual Testing

1. Open Tendril and navigate to Settings -> Projects.
2. Select a project that has no ports or environment files configured.
3. Observe the Ports and Environment Files sections:
   - Each section header has an info (i) icon displaying a tooltip when hovered.
   - The tables display informative muted text explaining their purpose rather than empty space.
4. Click "Add Port":
   - Hover over the help question marks or inspect field hints to verify guidance on name placeholders and default fallback port allocation.
5. Click "Add Environment File":
   - Hover over the help question marks or inspect field hints to verify guidance on path, base templates, and placeholder syntax overrides.

---
### Commits
- 30ed77b3 Add help tooltips and empty states for ports and environment files (Plan 00255)

---
Created using [Ivy Tendril](https://ivy.app).