### PR TITLE
[00257] Display Direct API Forecast and Subsidized Usage Analysis on Dashboard

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -236,16 +236,16 @@ public class DashboardAppViewModelTests
     }
 
     [Fact]
-    public void BuildKpis_ForecastComputesCalendarProjection()
+    public void BuildKpis_ForecastWithDirectApiSpend_ShowsApiHeadlineAndTotalSubValue()
     {
         // August 2026 has 31 days. Ten days of history, three of which cost anything: the calendar
         // basis divides by 10.
         var today = new DateTime(2026, 8, 31);
         var dailyCosts = new List<DashboardDailyCost>
         {
-            new(DateOnly.FromDateTime(today.AddDays(-9)), 10m, 1000),
-            new(DateOnly.FromDateTime(today.AddDays(-5)), 20m, 2000),
-            new(DateOnly.FromDateTime(today), 30m, 3000)
+            new(DateOnly.FromDateTime(today.AddDays(-9)), 10m, 1000, ApiCost: 10m, ApiTokens: 1000),
+            new(DateOnly.FromDateTime(today.AddDays(-5)), 20m, 2000, ApiCost: 20m, ApiTokens: 2000),
+            new(DateOnly.FromDateTime(today), 30m, 3000, ApiCost: 30m, ApiTokens: 3000)
         };
         var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 0m, [], []);
         var activity = new DashboardActivityStats([], 0, dailyCosts);
@@ -253,9 +253,56 @@ public class DashboardAppViewModelTests
         var forecast = DashboardApp.BuildKpis(stats, activity, [], today)
             .Single(k => k.Label == "Forecast This Month");
 
-        // 60 over 10 days times 31, rounded by FormatCost above 100.
-        Assert.Equal("$186", forecast.Value);
-        Assert.Null(forecast.Hint);
+        // 60 over 10 days times 31 = $186 API projection and total projection
+        Assert.Equal("$186 API", forecast.Value);
+        Assert.Equal("$186 total", forecast.SubValue);
+        Assert.Equal("0% subsidized via subscription", forecast.Hint);
+    }
+
+    [Fact]
+    public void BuildKpis_ForecastWithSubsidizedUsage_ShowsZeroApiAndSubsidizedHint()
+    {
+        var today = new DateTime(2026, 8, 31);
+        var dailyCosts = new List<DashboardDailyCost>
+        {
+            new(DateOnly.FromDateTime(today.AddDays(-9)), 10m, 1000, SubsidizedCost: 10m, SubsidizedTokens: 1000),
+            new(DateOnly.FromDateTime(today.AddDays(-5)), 20m, 2000, SubsidizedCost: 20m, SubsidizedTokens: 2000),
+            new(DateOnly.FromDateTime(today), 30m, 3000, SubsidizedCost: 30m, SubsidizedTokens: 3000)
+        };
+        var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 0m, [], []);
+        var activity = new DashboardActivityStats([], 0, dailyCosts);
+
+        var forecast = DashboardApp.BuildKpis(stats, activity, [], today)
+            .Single(k => k.Label == "Forecast This Month");
+
+        Assert.Equal("$0 API", forecast.Value);
+        Assert.Equal("$186 total", forecast.SubValue);
+        Assert.Equal("100% subsidized via subscription", forecast.Hint);
+    }
+
+    [Fact]
+    public void BuildKpis_ForecastWithMixedUsage_ShowsDirectApiAndSubsidizedPercentage()
+    {
+        var today = new DateTime(2026, 8, 31);
+        var dailyCosts = new List<DashboardDailyCost>
+        {
+            // Day 1: 10 API spend (1000 tokens), 10 subsidized value (1000 tokens) -> 20 total, 2000 tokens
+            new(DateOnly.FromDateTime(today.AddDays(-9)), 20m, 2000, ApiCost: 10m, ApiTokens: 1000, SubsidizedCost: 10m, SubsidizedTokens: 1000),
+            // Day 2: 20 API spend (2000 tokens), 60 subsidized value (6000 tokens) -> 80 total, 8000 tokens
+            new(DateOnly.FromDateTime(today), 80m, 8000, ApiCost: 20m, ApiTokens: 2000, SubsidizedCost: 60m, SubsidizedTokens: 6000)
+        };
+        var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 0m, [], []);
+        var activity = new DashboardActivityStats([], 0, dailyCosts);
+
+        var forecast = DashboardApp.BuildKpis(stats, activity, [], today)
+            .Single(k => k.Label == "Forecast This Month");
+
+        // Total: 100 over 10 days * 31 = $310 total
+        // API: 30 over 10 days * 31 = $93.00 API (< 100 formats with decimals)
+        // Subsidized tokens: 7000 out of 10000 = 70%
+        Assert.Equal("$93.00 API", forecast.Value);
+        Assert.Equal("$310 total", forecast.SubValue);
+        Assert.Equal("70% subsidized via subscription", forecast.Hint);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/JobServiceLogCostTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceLogCostTests.cs
@@ -16,27 +16,27 @@ public class JobServiceLogCostTests : IDisposable
     [Fact]
     public void LogCostToCsv_CreatesFileWithHeaders()
     {
-        JobService.LogCostToCsv(_tempDir.Path, "ExecutePlan", 150000, 0.4500m, "claude-opus-5");
+        JobService.LogCostToCsv(_tempDir.Path, "ExecutePlan", 150000, 0.4500m, "claude-opus-5", "agent");
 
         var csvPath = Path.Combine(_tempDir.Path, "costs.csv");
         Assert.True(File.Exists(csvPath));
 
         var lines = File.ReadAllLines(csvPath);
-        Assert.Equal("Promptware,Tokens,Cost,Model", lines[0]);
-        Assert.Equal("ExecutePlan,150000,0.4500,claude-opus-5", lines[1]);
+        Assert.Equal("Promptware,Tokens,Cost,Model,CostSource", lines[0]);
+        Assert.Equal("ExecutePlan,150000,0.4500,claude-opus-5,agent", lines[1]);
     }
 
     [Fact]
     public void LogCostToCsv_AppendsToExistingFile()
     {
-        JobService.LogCostToCsv(_tempDir.Path, "ExecutePlan", 150000, 0.4500m, "claude-opus-5");
-        JobService.LogCostToCsv(_tempDir.Path, "CreatePlan", 25000, 0.0750m, "claude-sonnet-5");
+        JobService.LogCostToCsv(_tempDir.Path, "ExecutePlan", 150000, 0.4500m, "claude-opus-5", "agent");
+        JobService.LogCostToCsv(_tempDir.Path, "CreatePlan", 25000, 0.0750m, "claude-sonnet-5", "computed");
 
         var lines = ReadCsv();
         Assert.Equal(3, lines.Length);
-        Assert.Equal("Promptware,Tokens,Cost,Model", lines[0]);
-        Assert.Equal("ExecutePlan,150000,0.4500,claude-opus-5", lines[1]);
-        Assert.Equal("CreatePlan,25000,0.0750,claude-sonnet-5", lines[2]);
+        Assert.Equal("Promptware,Tokens,Cost,Model,CostSource", lines[0]);
+        Assert.Equal("ExecutePlan,150000,0.4500,claude-opus-5,agent", lines[1]);
+        Assert.Equal("CreatePlan,25000,0.0750,claude-sonnet-5,computed", lines[2]);
     }
 
     [Fact]
@@ -53,25 +53,25 @@ public class JobServiceLogCostTests : IDisposable
 
         // Cost is written to 4 decimal places with the invariant culture, so the file parses the same
         // way on a machine whose decimal separator is a comma.
-        Assert.Equal("CreatePr,99999,1.2346,", ReadCsv()[1]);
+        Assert.Equal("CreatePr,99999,1.2346,,", ReadCsv()[1]);
     }
 
     [Fact]
     public void LogCostToCsv_NullCost_WritesEmptyField()
     {
-        JobService.LogCostToCsv(_tempDir.Path, "ExecutePlan", 150000, null, "claude-opus-5");
+        JobService.LogCostToCsv(_tempDir.Path, "ExecutePlan", 150000, null, "claude-opus-5", "estimated");
 
         // Not "0.0000": a subscription run that charged nothing observable is unknown, not free, and
         // the parser turns this empty field into a SQL NULL the aggregates skip.
-        Assert.Equal("ExecutePlan,150000,,claude-opus-5", ReadCsv()[1]);
+        Assert.Equal("ExecutePlan,150000,,claude-opus-5,estimated", ReadCsv()[1]);
     }
 
     [Fact]
     public void LogCostToCsv_ZeroCost_WritesZeroDistinctFromNull()
     {
-        JobService.LogCostToCsv(_tempDir.Path, "ExecutePlan", 150000, 0m, "claude-opus-5");
+        JobService.LogCostToCsv(_tempDir.Path, "ExecutePlan", 150000, 0m, "claude-opus-5", "agent");
 
-        Assert.Equal("ExecutePlan,150000,0.0000,claude-opus-5", ReadCsv()[1]);
+        Assert.Equal("ExecutePlan,150000,0.0000,claude-opus-5,agent", ReadCsv()[1]);
     }
 
     [Fact]
@@ -80,8 +80,8 @@ public class JobServiceLogCostTests : IDisposable
         JobService.LogCostToCsv(_tempDir.Path, "ExecutePlan", 150000, 0.4500m);
 
         var lines = ReadCsv();
-        Assert.Equal("ExecutePlan,150000,0.4500,", lines[1]);
-        Assert.Equal(4, lines[1].Split(',').Length);
+        Assert.Equal("ExecutePlan,150000,0.4500,,", lines[1]);
+        Assert.Equal(5, lines[1].Split(',').Length);
     }
 
     [Fact]
@@ -90,13 +90,13 @@ public class JobServiceLogCostTests : IDisposable
         var csvPath = Path.Combine(_tempDir.Path, "costs.csv");
         File.WriteAllText(csvPath, "Promptware,Tokens,Cost\nExecutePlan,50000,1.5000\n");
 
-        JobService.LogCostToCsv(_tempDir.Path, "CreatePr", 99999, 1.2346m, "claude-opus-5");
+        JobService.LogCostToCsv(_tempDir.Path, "CreatePr", 99999, 1.2346m, "claude-opus-5", "agent");
 
         var lines = ReadCsv();
         // The header is left as it was found: rewriting it would mean rewriting the whole file, and
         // the parser reads by position anyway, so a short header over long rows is harmless.
         Assert.Equal("Promptware,Tokens,Cost", lines[0]);
         Assert.Equal("ExecutePlan,50000,1.5000", lines[1]);
-        Assert.Equal("CreatePr,99999,1.2346,claude-opus-5", lines[2]);
+        Assert.Equal("CreatePr,99999,1.2346,claude-opus-5,agent", lines[2]);
     }
 }

--- a/src/Ivy.Tendril.Test/Models/CostForecastCalculatorTests.cs
+++ b/src/Ivy.Tendril.Test/Models/CostForecastCalculatorTests.cs
@@ -160,4 +160,114 @@ public class CostForecastCalculatorTests
             Assert.True(result.CalendarProjection <= result.ActivityProjection);
         }
     }
+
+    [Fact]
+    public void HundredPercentApiSpend_ComputesIdenticalDualProjectionsAndZeroSubsidized()
+    {
+        var daily = new List<DashboardDailyCost>
+        {
+            new(new DateOnly(2026, 8, 31), 20m, 2000, ApiCost: 20m, ApiTokens: 2000),
+            new(new DateOnly(2026, 8, 30), 10m, 1000, ApiCost: 10m, ApiTokens: 1000)
+        };
+
+        var result = CostForecastCalculator.Project(daily, August);
+
+        Assert.Equal(2, result.CalendarDays);
+        Assert.Equal(2, result.ActivityDays);
+        Assert.Equal(30m / 2 * 31, result.CalendarProjection);
+        Assert.Equal(30m / 2 * 31, result.ActivityProjection);
+        Assert.Equal(result.CalendarProjection, result.ApiCalendarProjection);
+        Assert.Equal(result.ActivityProjection, result.ApiActivityProjection);
+        Assert.Equal(30m, result.TotalApiSpend);
+        Assert.Equal(0m, result.TotalSubsidizedSpend);
+        Assert.Equal(3000, result.TotalApiTokens);
+        Assert.Equal(0, result.TotalSubsidizedTokens);
+        Assert.Equal(0.0, result.SubsidizedTokenPercent);
+        Assert.Equal(0.0, result.SubsidizedCostPercent);
+    }
+
+    [Fact]
+    public void HundredPercentSubsidized_ComputesTotalProjectionWithNullApiProjection()
+    {
+        var daily = new List<DashboardDailyCost>
+        {
+            new(new DateOnly(2026, 8, 31), 25m, 5000, ApiCost: 0m, ApiTokens: 0, SubsidizedCost: 25m, SubsidizedTokens: 5000),
+            new(new DateOnly(2026, 8, 30), 15m, 3000, ApiCost: 0m, ApiTokens: 0, SubsidizedCost: 15m, SubsidizedTokens: 3000)
+        };
+
+        var result = CostForecastCalculator.Project(daily, August);
+
+        Assert.Equal(2, result.CalendarDays);
+        Assert.Equal(2, result.ActivityDays);
+        Assert.NotNull(result.CalendarProjection);
+        Assert.NotNull(result.ActivityProjection);
+        Assert.Null(result.ApiCalendarProjection);
+        Assert.Null(result.ApiActivityProjection);
+        Assert.Equal(0m, result.TotalApiSpend);
+        Assert.Equal(40m, result.TotalSubsidizedSpend);
+        Assert.Equal(0, result.TotalApiTokens);
+        Assert.Equal(8000, result.TotalSubsidizedTokens);
+        Assert.Equal(100.0, result.SubsidizedTokenPercent);
+        Assert.Equal(100.0, result.SubsidizedCostPercent);
+    }
+
+    [Fact]
+    public void MixedUsage_CalculatesAccurateSubsidizedPercentsAndDualProjections()
+    {
+        var daily = new List<DashboardDailyCost>
+        {
+            // Day 1: 10 API spend (1000 tokens), 30 subsidized value (3000 tokens) -> Total 40 cost, 4000 tokens
+            new(new DateOnly(2026, 8, 31), 40m, 4000, ApiCost: 10m, ApiTokens: 1000, SubsidizedCost: 30m, SubsidizedTokens: 3000),
+            // Day 2: 0 API spend, 10 subsidized value (1000 tokens) -> Total 10 cost, 1000 tokens
+            new(new DateOnly(2026, 8, 30), 10m, 1000, ApiCost: 0m, ApiTokens: 0, SubsidizedCost: 10m, SubsidizedTokens: 1000)
+        };
+
+        var result = CostForecastCalculator.Project(daily, August);
+
+        Assert.Equal(2, result.CalendarDays);
+        Assert.Equal(2, result.ActivityDays);
+        Assert.Equal(50m, result.TotalSpend);
+        Assert.Equal(10m, result.TotalApiSpend);
+        Assert.Equal(40m, result.TotalSubsidizedSpend);
+        Assert.Equal(1000, result.TotalApiTokens);
+        Assert.Equal(4000, result.TotalSubsidizedTokens);
+
+        // 4000 subsidized out of 5000 total tokens = 80%
+        Assert.Equal(80.0, result.SubsidizedTokenPercent);
+        // 40 subsidized out of 50 total spend = 80%
+        Assert.Equal(80.0, result.SubsidizedCostPercent);
+
+        // Total projections
+        Assert.Equal(50m / 2 * 31, result.CalendarProjection);
+        Assert.Equal(50m / 2 * 31, result.ActivityProjection);
+
+        // API projections: 10 API spend across 2 calendar days, 1 active API day
+        Assert.Equal(10m / 2 * 31, result.ApiCalendarProjection);
+        Assert.Equal(10m / 1 * 31, result.ApiActivityProjection);
+    }
+
+    [Fact]
+    public void EmptyAndZeroCostWindows_HandleSubsidizedFieldsSafely()
+    {
+        var emptyResult = CostForecastCalculator.Project([], August);
+        Assert.Null(emptyResult.CalendarProjection);
+        Assert.Null(emptyResult.ApiCalendarProjection);
+        Assert.Equal(0m, emptyResult.TotalSpend);
+        Assert.Equal(0m, emptyResult.TotalApiSpend);
+        Assert.Equal(0m, emptyResult.TotalSubsidizedSpend);
+        Assert.Equal(0, emptyResult.SubsidizedTokenPercent);
+        Assert.Equal(0, emptyResult.SubsidizedCostPercent);
+
+        var zeroDaily = new List<DashboardDailyCost>
+        {
+            new(new DateOnly(2026, 8, 31), 0m, 0),
+            new(new DateOnly(2026, 8, 30), 0m, 0)
+        };
+        var zeroResult = CostForecastCalculator.Project(zeroDaily, August);
+        Assert.Null(zeroResult.CalendarProjection);
+        Assert.Null(zeroResult.ApiCalendarProjection);
+        Assert.Equal(0m, zeroResult.TotalSpend);
+        Assert.Equal(0, zeroResult.SubsidizedTokenPercent);
+        Assert.Equal(0, zeroResult.SubsidizedCostPercent);
+    }
 }

--- a/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
+++ b/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
@@ -86,6 +86,24 @@ public class KpiBreakdownSheetTests
     }
 
     [Fact]
+    public void KpiBreakdownSheet_RendersForecastMonthBreakdown_WithSubsidizedAnalysis()
+    {
+        var dailyCosts = new List<DashboardDailyCost>
+        {
+            new(new DateOnly(2026, 8, 31), 40.00m, 4000, ApiCost: 10m, ApiTokens: 1000, SubsidizedCost: 30m, SubsidizedTokens: 3000),
+            new(new DateOnly(2026, 8, 25), 20.00m, 2000, ApiCost: 0m, ApiTokens: 0, SubsidizedCost: 20m, SubsidizedTokens: 2000)
+        };
+        var activity = new DashboardActivityStats([], 0m, dailyCosts);
+        var sheet = new KpiBreakdownSheet("forecastMonth", _stats, activity, _prDays, _today, _fakeService);
+        var result = sheet.Build();
+
+        Assert.NotNull(result);
+        var tableContent = ExtractTableContent(result);
+        Assert.NotNull(tableContent);
+        Assert.StartsWith("DataTableBuilder", tableContent.GetType().Name);
+    }
+
+    [Fact]
     public void KpiBreakdownSheet_RendersAvgCostPlanBreakdown()
     {
         var sheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, _today, _fakeService);

--- a/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
+++ b/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
@@ -10,7 +10,8 @@ public record DashboardKpiDto(
     string? Delta = null,
     string? Direction = null,
     string? Hint = null,
-    string? Id = null);
+    string? Id = null,
+    string? SubValue = null);
 
 public record DashboardMonthValueDto(
     string Label,

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
@@ -268,6 +268,24 @@ describe("TendrilDashboard KPI card interactions and accessibility", () => {
 
     expect(eventHandler).toHaveBeenCalledWith("OnSelectKpi", "dash", ["dailyPrs"]);
   });
+
+  it("renders subValue when provided on a KPI card", () => {
+    const kpisWithSubValue = [
+      { id: "forecastMonth", label: "Forecast This Month", value: "$42.50", subValue: "$85.00 total", hint: "50% subsidized" },
+    ];
+
+    render(
+      <TendrilDashboard
+        id="dash"
+        eventHandler={vi.fn()}
+        kpis={kpisWithSubValue}
+      />,
+    );
+
+    const subValueEl = screen.getByText("$85.00 total");
+    expect(subValueEl).toBeInTheDocument();
+    expect(subValueEl).toHaveClass("tdb-kpi-subvalue");
+  });
 });
 
 describe("TendrilDashboard pull requests week/month toggle", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -165,6 +165,7 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
                       <div className="tdb-kpi-label">{kpi.label}</div>
                       <div className="tdb-kpi-row">
                         <span className="tdb-kpi-value">{kpi.value}</span>
+                        {kpi.subValue && <span className="tdb-kpi-subvalue">{kpi.subValue}</span>}
                         {kpi.delta && (
                           <span className="tdb-kpi-delta">
                             {kpi.delta}

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -253,6 +253,13 @@
   white-space: nowrap;
 }
 
+.tdb-kpi-subvalue {
+  font-size: 13px;
+  font-weight: 500;
+  opacity: 0.75;
+  white-space: nowrap;
+}
+
 .tdb-kpi-delta {
   display: flex;
   align-items: center;

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -31,6 +31,12 @@ describe("dashboard.css KPI grid", () => {
     expect(css).toMatch(/\.tdb-kpi-hint\s*\{[^}]*opacity: 0\.7;/);
   });
 
+  it("styles the subvalue alongside the primary value", () => {
+    expect(css).toContain(".tdb-kpi-subvalue {");
+    expect(css).toMatch(/\.tdb-kpi-subvalue\s*\{[^}]*font-size:\s*13px;/);
+    expect(css).toMatch(/\.tdb-kpi-subvalue\s*\{[^}]*opacity:\s*0\.75;/);
+  });
+
   it("defines cursor pointer, transition, hover, and focus-visible on .tdb-kpi", () => {
     expect(css).toMatch(/\.tdb-kpi\s*\{[^}]*cursor:\s*pointer;/);
     expect(css).toMatch(/\.tdb-kpi\s*\{[^}]*transition:\s*[^;]*transform/);

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -7,6 +7,7 @@ export interface DashboardKpiDto {
   delta?: string | null;
   direction?: "up" | "down" | null;
   hint?: string | null;
+  subValue?: string | null;
 }
 
 export interface DashboardMonthValueDto {

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -287,10 +287,25 @@ public class DashboardApp : ViewBase
         const string label = "Forecast This Month";
 
         var forecast = CostForecastCalculator.Project(dailyCosts ?? [], today);
-        if (forecast.CalendarProjection is not { } projection)
+        if (forecast.CalendarProjection is not { } totalProjection)
             return new DashboardKpiDto(label, "-", Hint: "No cost data in the last 30 days", Id: "forecastMonth");
 
-        return new DashboardKpiDto(label, FormatCost(projection), Id: "forecastMonth");
+        if (forecast.ApiCalendarProjection is { } apiProjection && forecast.TotalApiSpend > 0)
+        {
+            return new DashboardKpiDto(
+                label,
+                $"{FormatCost(apiProjection)} API",
+                Hint: $"{forecast.SubsidizedTokenPercent:0}% subsidized via subscription",
+                Id: "forecastMonth",
+                SubValue: $"{FormatCost(totalProjection)} total");
+        }
+
+        return new DashboardKpiDto(
+            label,
+            "$0 API",
+            Hint: "100% subsidized via subscription",
+            Id: "forecastMonth",
+            SubValue: $"{FormatCost(totalProjection)} total");
     }
 
     private static (decimal Last, decimal Previous) LastTwo(

--- a/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
@@ -182,44 +182,72 @@ public class KpiBreakdownSheet(
     private object BuildForecastMonthBreakdown()
     {
         var forecast = CostForecastCalculator.Project(activity.DailyCosts ?? [], today);
-        var mtdSpend = activity.DailyCosts?
+        var mtdRecords = (activity.DailyCosts ?? [])
             .Where(d => d.Date.Year == today.Year && d.Date.Month == today.Month)
-            .Sum(d => d.Cost) ?? 0m;
+            .ToList();
+        var mtdTotalSpend = mtdRecords.Sum(d => d.Cost);
+        var mtdApiSpend = mtdRecords.Sum(d => d.ApiCost);
+        var mtdSubsidizedSpend = mtdRecords.Sum(d => d.SubsidizedCost);
         var daysInMonth = DateTime.DaysInMonth(today.Year, today.Month);
         var daysRemaining = Math.Max(0, daysInMonth - today.Day);
+
+        var calloutMessage = forecast.SubsidizedTokenPercent > 0
+            ? $"Forecast This Month projects month-end spend using daily activity over the last 30 days. {forecast.SubsidizedTokenPercent:0}% of tokens in this window were subsidized via subscription ({FormatCost(forecast.TotalSubsidizedSpend)} equivalent value) with {FormatCost(forecast.TotalApiSpend)} in direct API charges."
+            : "Forecast This Month projects month-end spend using daily activity over the last 30 days. Direct API projections estimate billed out-of-pocket spend, while total projections reflect overall token market value.";
 
         var details = new
         {
             Metric = "Forecast This Month",
-            MonthToDateSpend = FormatCost(mtdSpend),
-            DaysRemainingInMonth = $"{daysRemaining} day(s)",
-            DaysInCurrentMonth = $"{daysInMonth} day(s)",
+            DirectApiCalendarProjection = forecast.ApiCalendarProjection.HasValue ? FormatCost(forecast.ApiCalendarProjection.Value) : "$0",
+            DirectApiActivityProjection = forecast.ApiActivityProjection.HasValue ? FormatCost(forecast.ApiActivityProjection.Value) : "$0",
+            TotalCalendarProjection = forecast.CalendarProjection.HasValue ? FormatCost(forecast.CalendarProjection.Value) : "No data",
+            TotalActivityProjection = forecast.ActivityProjection.HasValue ? FormatCost(forecast.ActivityProjection.Value) : "No data",
+            SubsidizedTokenShare = $"{forecast.SubsidizedTokenPercent:0}% of tokens",
+            SubsidizedCostShare = $"{forecast.SubsidizedCostPercent:0}% of value",
+            MonthToDateApiSpend = FormatCost(mtdApiSpend),
+            MonthToDateSubsidizedValue = FormatCost(mtdSubsidizedSpend),
+            MonthToDateTotalSpend = FormatCost(mtdTotalSpend),
             ObservedCalendarDays = $"{forecast.CalendarDays} day(s)",
             ActiveSpendDays = $"{forecast.ActivityDays} day(s)",
-            TotalSpendInWindow = FormatCost(forecast.TotalSpend),
-            CalendarBasisProjection = forecast.CalendarProjection.HasValue ? FormatCost(forecast.CalendarProjection.Value) : "No data",
-            ActivityBasisProjection = forecast.ActivityProjection.HasValue ? FormatCost(forecast.ActivityProjection.Value) : "No data"
+            DaysRemainingInMonth = $"{daysRemaining} day(s)",
+            DaysInCurrentMonth = $"{daysInMonth} day(s)"
         }
             .ToDetails()
             .Label(x => x.Metric, "Metric")
-            .Label(x => x.MonthToDateSpend, "Month-to-Date Spend")
-            .Label(x => x.DaysRemainingInMonth, "Days Remaining")
-            .Label(x => x.DaysInCurrentMonth, "Days in Month")
+            .Label(x => x.DirectApiCalendarProjection, "Direct API Forecast (Calendar Basis)")
+            .Label(x => x.DirectApiActivityProjection, "Direct API Forecast (Activity Basis)")
+            .Label(x => x.TotalCalendarProjection, "Total Forecast (Calendar Basis)")
+            .Label(x => x.TotalActivityProjection, "Total Forecast (Activity Basis)")
+            .Label(x => x.SubsidizedTokenShare, "Subsidized Token Share")
+            .Label(x => x.SubsidizedCostShare, "Subsidized Value Share")
+            .Label(x => x.MonthToDateApiSpend, "Month-to-Date Direct API Spend")
+            .Label(x => x.MonthToDateSubsidizedValue, "Month-to-Date Subsidized Value")
+            .Label(x => x.MonthToDateTotalSpend, "Month-to-Date Total Market Value")
             .Label(x => x.ObservedCalendarDays, "Calendar Days in Window")
             .Label(x => x.ActiveSpendDays, "Active Days with Spend")
-            .Label(x => x.TotalSpendInWindow, "Total Window Spend")
-            .Label(x => x.CalendarBasisProjection, "Calendar Basis (Lower Bound)")
-            .Label(x => x.ActivityBasisProjection, "Activity Basis (Upper Bound)");
+            .Label(x => x.DaysRemainingInMonth, "Days Remaining")
+            .Label(x => x.DaysInCurrentMonth, "Days in Month");
 
         var cutoff = DateOnly.FromDateTime(today.AddDays(-29));
         var daily = (activity.DailyCosts ?? [])
             .Where(d => d.Date >= cutoff)
             .OrderByDescending(d => d.Date)
-            .Select(d => new DailyCostRow
+            .Select(d =>
             {
-                Date = d.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-                Spend = FormatCost(d.Cost),
-                Tokens = FormatHelper.FormatCount(d.Tokens)
+                var totalTokens = d.Tokens > 0 ? d.Tokens : d.ApiTokens + d.SubsidizedTokens;
+                var subPct = totalTokens > 0
+                    ? (double)d.SubsidizedTokens / totalTokens * 100.0
+                    : (d.Cost > 0 ? (double)(d.SubsidizedCost / d.Cost) * 100.0 : 0.0);
+
+                return new DailyCostRow
+                {
+                    Date = d.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    TotalSpend = FormatCost(d.Cost),
+                    ApiSpend = FormatCost(d.ApiCost),
+                    SubsidizedSpend = FormatCost(d.SubsidizedCost),
+                    TotalTokens = FormatHelper.FormatCount(totalTokens),
+                    SubsidizedPercent = $"{subPct:0}%"
+                };
             })
             .ToList();
 
@@ -229,8 +257,11 @@ public class KpiBreakdownSheet(
                 .AsQueryable()
                 .ToDataTable(x => x.Date)
                 .Header(x => x.Date, "Date")
-                .Header(x => x.Spend, "Daily Spend")
-                .Header(x => x.Tokens, "Tokens")
+                .Header(x => x.TotalSpend, "Total Spend")
+                .Header(x => x.ApiSpend, "API Spend")
+                .Header(x => x.SubsidizedSpend, "Subsidized Spend")
+                .Header(x => x.TotalTokens, "Total Tokens")
+                .Header(x => x.SubsidizedPercent, "Subsidized %")
                 .Width(Size.Full())
                 .Height(Size.Px(360))
                 .Config(c =>
@@ -242,7 +273,7 @@ public class KpiBreakdownSheet(
                 });
 
         return Layout.Vertical().Gap(4)
-               | Callout.Info("Forecast This Month projects month-end spend using daily activity over the last 30 days. Dual projections indicate uncertainty: Calendar Basis assumes idle days continue at the observed rate, while Activity Basis projects from active spend days only.", "Dual Projections")
+               | Callout.Info(calloutMessage, "Usage & Subsidized Analysis")
                | details
                | (Layout.Vertical().Gap(2)
                   | Text.H4("Daily Spend (Last 30 Days)")
@@ -355,8 +386,11 @@ public class KpiBreakdownSheet(
     private sealed record DailyCostRow
     {
         public required string Date { get; init; }
-        public required string Spend { get; init; }
-        public required string Tokens { get; init; }
+        public required string TotalSpend { get; init; }
+        public required string ApiSpend { get; init; }
+        public required string SubsidizedSpend { get; init; }
+        public required string TotalTokens { get; init; }
+        public required string SubsidizedPercent { get; init; }
     }
 
     private sealed record PlanCostRow

--- a/src/Ivy.Tendril/Database/DashboardRepository.cs
+++ b/src/Ivy.Tendril/Database/DashboardRepository.cs
@@ -269,7 +269,12 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
             {
                 cmd.CommandText = """
                     SELECT DATE(COALESCE(c.LogTimestamp, p.Updated)) AS d,
-                           COALESCE(SUM(c.Cost), 0), COALESCE(SUM(c.Tokens), 0)
+                           COALESCE(SUM(c.Cost), 0),
+                           COALESCE(SUM(c.Tokens), 0),
+                           COALESCE(SUM(CASE WHEN c.CostSource IN ('agent', 'computed') OR (c.CostSource IS NULL AND c.Cost > 0) THEN c.Cost ELSE 0 END), 0),
+                           COALESCE(SUM(CASE WHEN c.CostSource IN ('agent', 'computed') OR (c.CostSource IS NULL AND c.Cost > 0) THEN c.Tokens ELSE 0 END), 0),
+                           COALESCE(SUM(CASE WHEN c.CostSource = 'estimated' THEN c.Cost ELSE 0 END), 0),
+                           COALESCE(SUM(CASE WHEN c.CostSource = 'estimated' OR (c.CostSource IS NULL AND (c.Cost IS NULL OR c.Cost = 0)) THEN c.Tokens ELSE 0 END), 0)
                     FROM Costs c JOIN Plans p ON p.Id = c.PlanId
                     WHERE COALESCE(c.LogTimestamp, p.Updated) >= @cutoff
                     GROUP BY d ORDER BY d
@@ -284,7 +289,11 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                     dailyCosts.Add(new DashboardDailyCost(
                         day,
                         Convert.ToDecimal(r.GetValue(1), CultureInfo.InvariantCulture),
-                        Convert.ToInt64(r.GetValue(2), CultureInfo.InvariantCulture)));
+                        Convert.ToInt64(r.GetValue(2), CultureInfo.InvariantCulture),
+                        Convert.ToDecimal(r.GetValue(3), CultureInfo.InvariantCulture),
+                        Convert.ToInt64(r.GetValue(4), CultureInfo.InvariantCulture),
+                        Convert.ToDecimal(r.GetValue(5), CultureInfo.InvariantCulture),
+                        Convert.ToInt64(r.GetValue(6), CultureInfo.InvariantCulture)));
                 }
             }
 

--- a/src/Ivy.Tendril/Database/Migrations/Migration_024_CostsCostSource.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_024_CostsCostSource.cs
@@ -1,0 +1,64 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_024_CostsCostSource : IMigration
+{
+    public int Version => 24;
+    public string Description => "Add CostSource column to Costs table";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        var hasColumn = false;
+        using (var checkCmd = connection.CreateCommand())
+        {
+            checkCmd.CommandText = "PRAGMA table_info(Costs);";
+            using var reader = checkCmd.ExecuteReader();
+            while (reader.Read())
+            {
+                if (string.Equals(reader.GetString(reader.GetOrdinal("name")), "CostSource", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasColumn = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasColumn)
+        {
+            using var alterCmd = connection.CreateCommand();
+            alterCmd.CommandText = "ALTER TABLE Costs ADD COLUMN CostSource TEXT;";
+            alterCmd.ExecuteNonQuery();
+        }
+
+        // Populate existing Costs.CostSource where possible by correlating against Jobs
+        using (var updateCmd = connection.CreateCommand())
+        {
+            updateCmd.CommandText = """
+                UPDATE Costs
+                SET CostSource = (
+                    SELECT j.CostSource
+                    FROM Jobs j
+                    LEFT JOIN Plans p ON p.Id = Costs.PlanId
+                    WHERE j.CostSource IS NOT NULL
+                      AND j.Type = Costs.Promptware
+                      AND (
+                          j.ReportedPlanId = CAST(Costs.PlanId AS TEXT)
+                          OR (p.FolderPath IS NOT NULL AND j.PlanFile = p.FolderPath)
+                          OR (p.FolderName IS NOT NULL AND j.PlanFile = p.FolderName)
+                          OR j.PlanFile LIKE '%' || PRINTF('%05d', Costs.PlanId) || '%'
+                      )
+                    ORDER BY j.CompletedAt DESC
+                    LIMIT 1
+                )
+                WHERE CostSource IS NULL;
+                """;
+            updateCmd.ExecuteNonQuery();
+        }
+
+        using var versionCmd = connection.CreateCommand();
+        versionCmd.CommandText = "PRAGMA user_version = 24;";
+        versionCmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -202,17 +202,17 @@ internal static class PlanYamlHelper
     ///         the aggregates skip it instead of averaging a zero in.
     ///     </para>
     /// </summary>
-    internal static void LogCostToCsv(string planFolder, string jobType, int tokens, decimal? cost, string? model = null)
+    internal static void LogCostToCsv(string planFolder, string jobType, int tokens, decimal? cost, string? model = null, string? costSource = null)
     {
         if (!Directory.Exists(planFolder)) return;
 
         var csvPath = Path.Combine(planFolder, "costs.csv");
         // An existing file keeps whatever header it was created with, including the 3 column one: the
         // parser reads by position and tolerates a short header with long rows appended under it.
-        if (!File.Exists(csvPath)) FileHelper.WriteAllText(csvPath, "Promptware,Tokens,Cost,Model\n");
+        if (!File.Exists(csvPath)) FileHelper.WriteAllText(csvPath, "Promptware,Tokens,Cost,Model,CostSource\n");
 
         var costField = cost?.ToString("F4", System.Globalization.CultureInfo.InvariantCulture) ?? "";
-        var line = $"{jobType},{tokens},{costField},{model}\n";
+        var line = $"{jobType},{tokens},{costField},{model},{costSource}\n";
         FileHelper.AppendAllText(csvPath, line);
     }
 

--- a/src/Ivy.Tendril/Models/CostForecast.cs
+++ b/src/Ivy.Tendril/Models/CostForecast.cs
@@ -23,7 +23,15 @@ public record CostForecast(
     decimal? ActivityProjection,
     int ActivityDays,
     decimal TotalSpend,
-    int DaysInMonth);
+    int DaysInMonth,
+    decimal? ApiCalendarProjection = null,
+    decimal? ApiActivityProjection = null,
+    decimal TotalApiSpend = 0m,
+    decimal TotalSubsidizedSpend = 0m,
+    long TotalApiTokens = 0,
+    long TotalSubsidizedTokens = 0,
+    double SubsidizedTokenPercent = 0,
+    double SubsidizedCostPercent = 0);
 
 /// <summary>
 ///     Projects a month's spend from a daily series. Pure on purpose: no clock of its own, no
@@ -55,9 +63,32 @@ public static class CostForecastCalculator
         var window = dailyCosts.Where(d => d.Date >= cutoff).ToList();
         var spendDays = window.Where(d => d.Cost != 0m).ToList();
         var totalSpend = window.Sum(d => d.Cost);
+        var totalApiSpend = window.Sum(d => d.ApiCost);
+        var totalSubsidizedSpend = window.Sum(d => d.SubsidizedCost);
+        var totalApiTokens = window.Sum(d => d.ApiTokens);
+        var totalSubsidizedTokens = window.Sum(d => d.SubsidizedTokens);
+        var totalTokens = window.Sum(d => Math.Max(d.Tokens, d.ApiTokens + d.SubsidizedTokens));
+        var subsidizedTokenPercent = totalTokens > 0 ? (double)totalSubsidizedTokens / totalTokens * 100.0 : 0.0;
+        var subsidizedCostPercent = totalSpend > 0 ? (double)(totalSubsidizedSpend / totalSpend) * 100.0 : 0.0;
 
         if (spendDays.Count == 0)
-            return new CostForecast(null, 0, null, 0, totalSpend, daysInMonth);
+        {
+            return new CostForecast(
+                null,
+                0,
+                null,
+                0,
+                totalSpend,
+                daysInMonth,
+                null,
+                null,
+                totalApiSpend,
+                totalSubsidizedSpend,
+                totalApiTokens,
+                totalSubsidizedTokens,
+                subsidizedTokenPercent,
+                subsidizedCostPercent);
+        }
 
         // Floored at 1: a series whose first record is a few hours old must divide by one day rather
         // than by a fraction, which would project an absurd month. Measured from the earliest day on
@@ -67,12 +98,28 @@ public static class CostForecastCalculator
         var calendarDays = Math.Max(1, elapsed);
         var activityDays = spendDays.Count;
 
+        var apiSpendDays = window.Where(d => d.ApiCost != 0m).ToList();
+        decimal? apiCalendarProjection = apiSpendDays.Count > 0
+            ? totalApiSpend / calendarDays * daysInMonth
+            : null;
+        decimal? apiActivityProjection = apiSpendDays.Count > 0
+            ? totalApiSpend / apiSpendDays.Count * daysInMonth
+            : null;
+
         return new CostForecast(
             totalSpend / calendarDays * daysInMonth,
             calendarDays,
             totalSpend / activityDays * daysInMonth,
             activityDays,
             totalSpend,
-            daysInMonth);
+            daysInMonth,
+            apiCalendarProjection,
+            apiActivityProjection,
+            totalApiSpend,
+            totalSubsidizedSpend,
+            totalApiTokens,
+            totalSubsidizedTokens,
+            subsidizedTokenPercent,
+            subsidizedCostPercent);
     }
 }

--- a/src/Ivy.Tendril/Models/DashboardModels.cs
+++ b/src/Ivy.Tendril/Models/DashboardModels.cs
@@ -47,7 +47,14 @@ public record DashboardActivityStats(
 ///     One day's spend. Days with no <c>Costs</c> row are absent rather than present as zero, so a
 ///     reader of the series can tell "no activity" from "activity that cost nothing".
 /// </summary>
-public record DashboardDailyCost(DateOnly Date, decimal Cost, long Tokens);
+public record DashboardDailyCost(
+    DateOnly Date,
+    decimal Cost,
+    long Tokens,
+    decimal ApiCost = 0m,
+    long ApiTokens = 0,
+    decimal SubsidizedCost = 0m,
+    long SubsidizedTokens = 0);
 
 public record DashboardMonthStats(
     int Year,

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -309,7 +309,7 @@ internal class JobCompletionHandler
                     }
 
                     if (jobPlanFolder != null)
-                        PlanYamlHelper.LogCostToCsv(jobPlanFolder, jobType, usage.Tokens, usage.Cost, usage.Model);
+                        PlanYamlHelper.LogCostToCsv(jobPlanFolder, jobType, usage.Tokens, usage.Cost, usage.Model, usage.CostSource);
                 }
             }
             catch (Exception ex)
@@ -410,7 +410,7 @@ internal class JobCompletionHandler
 
         var jobPlanFolder = job.TypedArgs?.PlanFolder;
         if (jobPlanFolder != null)
-            PlanYamlHelper.LogCostToCsv(jobPlanFolder, job.Type, usage.Tokens, usage.Cost, usage.Model);
+            PlanYamlHelper.LogCostToCsv(jobPlanFolder, job.Type, usage.Tokens, usage.Cost, usage.Model, usage.CostSource);
     }
 
     /// <summary>

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -1628,8 +1628,8 @@ public class JobService : IJobService
     internal void WriteJobLog(JobItem job)
         => _completionHandler.WriteJobLog(job);
 
-    internal static void LogCostToCsv(string planFolder, string jobType, int tokens, decimal? cost, string? model = null)
-        => PlanYamlHelper.LogCostToCsv(planFolder, jobType, tokens, cost, model);
+    internal static void LogCostToCsv(string planFolder, string jobType, int tokens, decimal? cost, string? model = null, string? costSource = null)
+        => PlanYamlHelper.LogCostToCsv(planFolder, jobType, tokens, cost, model, costSource);
 
     /// <summary>
     /// Writes a cost <see cref="Services.Telemetry.CostBackfillService" /> worked out after the fact

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -77,4 +77,4 @@ public interface IPlanDatabaseService : IDisposable
 ///     What the tokens went on, carried through the CSV because <c>PurgeOldJobs</c> drops the
 ///     <c>Jobs</c> row long before the plan folder is archived. Null for a pre v2 file.
 /// </param>
-public record CostEntry(string Promptware, int Tokens, decimal? Cost, DateTime? LogTimestamp, string? Model = null);
+public record CostEntry(string Promptware, int Tokens, decimal? Cost, DateTime? LogTimestamp, string? Model = null, string? CostSource = null);

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -569,8 +569,8 @@ public class PlanDatabaseService : IPlanDatabaseService
 
             using var insertCmd = _connection.CreateCommand();
             insertCmd.CommandText = """
-                                    INSERT INTO Costs (PlanId, Promptware, Tokens, Cost, Model, LogTimestamp)
-                                    VALUES (@planId, @promptware, @tokens, @cost, @model, @logTimestamp)
+                                    INSERT INTO Costs (PlanId, Promptware, Tokens, Cost, Model, LogTimestamp, CostSource)
+                                    VALUES (@planId, @promptware, @tokens, @cost, @model, @logTimestamp, @costSource)
                                     """;
             insertCmd.Parameters.AddWithValue("@planId", planId);
             insertCmd.Parameters.AddWithValue("@promptware", string.Empty);
@@ -578,6 +578,7 @@ public class PlanDatabaseService : IPlanDatabaseService
             insertCmd.Parameters.AddWithValue("@cost", DBNull.Value);
             insertCmd.Parameters.AddWithValue("@model", DBNull.Value);
             insertCmd.Parameters.AddWithValue("@logTimestamp", DBNull.Value);
+            insertCmd.Parameters.AddWithValue("@costSource", DBNull.Value);
 
             foreach (var cost in costs)
             {
@@ -591,6 +592,7 @@ public class PlanDatabaseService : IPlanDatabaseService
                 insertCmd.Parameters["@logTimestamp"].Value = cost.LogTimestamp.HasValue
                     ? cost.LogTimestamp.Value.ToString("O", CultureInfo.InvariantCulture)
                     : DBNull.Value;
+                insertCmd.Parameters["@costSource"].Value = (object?)cost.CostSource ?? DBNull.Value;
                 insertCmd.ExecuteNonQuery();
             }
         }

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
@@ -204,6 +204,9 @@ public class PlanDatabaseSyncService : IDisposable
                 // Fourth column since costs.csv v2; files written before it have three.
                 var model = parts.Length > 3 && !string.IsNullOrWhiteSpace(parts[3]) ? parts[3].Trim() : null;
 
+                // Fifth column since costs.csv v3; files written before it have three or four.
+                var costSource = parts.Length > 4 && !string.IsNullOrWhiteSpace(parts[4]) ? parts[4].Trim() : null;
+
                 DateTime? timestamp = null;
                 if (logsByPromptware.TryGetValue(promptware, out var queue) && queue.Count > 0)
                 {
@@ -211,7 +214,7 @@ public class PlanDatabaseSyncService : IDisposable
                     timestamp = ExtractCompletedTimestamp(logEntry.Path);
                 }
 
-                costs.Add(new CostEntry(promptware, tokens, cost, timestamp, model));
+                costs.Add(new CostEntry(promptware, tokens, cost, timestamp, model, costSource));
             }
 
             _database.UpsertCosts(plan.Id, costs);


### PR DESCRIPTION
# Summary

## Changes

Added direct API cost forecasting and subsidized subscription usage analysis across Tendril:
1. **Cost Provenance Tracking**:
   - Updated `LogCostToCsv` to record `CostSource` as a 5th column in `costs.csv`.
   - Forwarded `usage.CostSource` from `JobCompletionHandler` and `JobService`.
   - Created database migration `Migration_024_CostsCostSource` adding `CostSource` to `Costs` table and backfilling existing records from `Jobs`.
   - Updated `PlanDatabaseService` and `PlanDatabaseSyncService` to persist and load `CostSource`.
2. **Data Models and Projections**:
   - Expanded `DashboardDailyCost` to track `ApiCost`, `ApiTokens`, `SubsidizedCost`, and `SubsidizedTokens`.
   - Updated `DashboardRepository.GetDailyCosts` to bucket costs and tokens by `CostSource` ('agent'/'computed' vs 'estimated').
   - Enhanced `CostForecast` and `CostForecastCalculator` to calculate dual projections (direct API billed spend and total market spend) along with subsidized token and dollar percentages.
3. **Frontend Widgets**:
   - Added `subValue` support to `DashboardKpiDto` in C# and TypeScript definitions.
   - Rendered `subValue` in `TendrilDashboard.tsx` alongside primary KPI value and styled it in `dashboard.css`.
   - Updated `DashboardApp` to display the direct API forecast as the primary KPI value, total market forecast as `subValue`, and subsidized percentage as hint.
4. **KPI Breakdown Sheet**:
   - Overhauled `BuildForecastMonthBreakdown` in `KpiBreakdownSheet.cs` with an informational callout explaining direct API charges vs subscription subsidies.
   - Displayed dual projection metrics (direct API vs total market value) and subsidized share.
   - Updated the 30-day table to show 6 columns: Date, Total Spend, API Spend, Subsidized Spend, Total Tokens, and Subsidized %.

## API Changes

- Added `SubValue` property to `DashboardKpiDto`.
- Expanded `CostForecast` record with `ApiCalendarProjection`, `ApiActivityProjection`, `TotalApiSpend`, `TotalSubsidizedSpend`, `TotalApiTokens`, `TotalSubsidizedTokens`, `SubsidizedTokenPercent`, and `SubsidizedCostPercent`.
- Expanded `DashboardDailyCost` record with `ApiCost`, `ApiTokens`, `SubsidizedCost`, and `SubsidizedTokens`.
- Added `costSource` parameter to `PlanYamlHelper.LogCostToCsv`.

## Files Modified

- `src/Ivy.Tendril/Models/DashboardModels.cs`
- `src/Ivy.Tendril/Models/CostForecast.cs`
- `src/Ivy.Tendril/Helpers/PlanYamlHelper.cs`
- `src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs`
- `src/Ivy.Tendril/Services/Jobs/JobService.cs`
- `src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs`
- `src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs`
- `src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs`
- `src/Ivy.Tendril/Database/Migrations/Migration_024_CostsCostSource.cs`
- `src/Ivy.Tendril/Database/DashboardRepository.cs`
- `src/Ivy.Tendril.Widgets/TendrilDashboard.cs`
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx`
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`
- `src/Ivy.Tendril/Apps/DashboardApp.cs`
- `src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs`
- `src/Ivy.Tendril.Test/Models/CostForecastCalculatorTests.cs`
- `src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs`
- `src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs`
- `src/Ivy.Tendril.Test/JobServiceLogCostTests.cs`
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx`
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`

## Manual Testing

1. Start Tendril and navigate to Dashboard.
2. View the "Forecast This Month" KPI card:
   - Primary value displays the direct API projected cost (e.g. "$0 API" or "$45.20 API").
   - Subvalue displays total market value (e.g. "$120 total").
   - Footnote hint displays subsidized percentage (e.g. "96% subsidized via subscription").
3. Click the "Forecast This Month" KPI card to open the KPI Breakdown Sheet.
4. Verify the sheet contains:
   - Informational callout on direct API charges vs subscription-covered usage.
   - Dual projection comparisons (Direct API projection vs Total Market Value projection).
   - Subsidized share metrics.
   - 30-day table displaying Total Spend, API Spend, Subsidized Spend, Total Tokens, and Subsidized %.

---
## Commits

- `8059150e`: feat(00257): record and persist costSource in costs csv and database
- `46859ed0`: feat(00257): add direct api and subsidized usage forecasting models
- `d0108238`: feat(00257): display direct api forecast and subsidized usage breakdown on dashboard

---
Created using [Ivy Tendril](https://ivy.app).
