### PR TITLE
[00260] Split ChatWidget Tests into Dedicated Files

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.attachments.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.attachments.test.tsx
@@ -1,0 +1,912 @@
+import "./ChatWidget.testUtils";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { ChatWidget, type ChatSessionDto } from "./ChatWidget";
+import { setupChatWidgetTestEnvironment } from "./ChatWidget.testUtils";
+
+describe("ChatWidget File Uploads and Attachments", () => {
+  beforeEach(() => {
+    setupChatWidgetTestEnvironment();
+  });
+
+  it("attaches non-image files (e.g. PDF and text files) on paste and prevents default text insertion", async () => {
+    render(<ChatWidget id="test-chat" />);
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+
+    const pdfFile = new File(["dummy pdf content"], "sample.pdf", { type: "application/pdf" });
+    const textFile = new File(["line1\nline2\nline3"], "notes.txt", { type: "text/plain" });
+
+    const pasteEvent = {
+      clipboardData: {
+        files: [pdfFile, textFile],
+        items: [],
+      },
+    };
+
+    fireEvent.paste(textarea, pasteEvent);
+
+    await waitFor(() => {
+      expect(screen.getByTitle("sample.pdf")).toBeInTheDocument();
+      expect(screen.getByText("notes.txt")).toBeInTheDocument();
+      expect(screen.getByText("PDF")).toBeInTheDocument();
+      expect(screen.getByText("TXT")).toBeInTheDocument();
+    });
+  });
+
+  it("supports dragging and dropping files onto chat input container with drag styling", async () => {
+    const { container } = render(<ChatWidget id="test-chat" />);
+    const inputBox = container.querySelector(".chat-input-box")!;
+    expect(inputBox).toBeInTheDocument();
+
+    // Drag enter
+    fireEvent.dragEnter(inputBox, {
+      dataTransfer: { dropEffect: "none" },
+    });
+    expect(inputBox).toHaveClass("dragging");
+
+    // Drag leave
+    fireEvent.dragLeave(inputBox);
+    expect(inputBox).not.toHaveClass("dragging");
+
+    // Drag over
+    fireEvent.dragOver(inputBox, {
+      dataTransfer: { dropEffect: "none" },
+    });
+    expect(inputBox).toHaveClass("dragging");
+
+    // Drop file
+    const droppedFile = new File(["test data"], "report.docx", {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    fireEvent.drop(inputBox, {
+      dataTransfer: { files: [droppedFile] },
+    });
+    expect(inputBox).not.toHaveClass("dragging");
+
+    await waitFor(() => {
+      expect(screen.getByText("report.docx")).toBeInTheDocument();
+      expect(screen.getByText("DOCX")).toBeInTheDocument();
+    });
+  });
+
+  it("activates dragging state and renders drop overlay when dragging over the root widget or message area", () => {
+    const { container } = render(<ChatWidget id="test-chat" />);
+    const root = container.querySelector(".chat-widget-root")!;
+    expect(root).toBeInTheDocument();
+
+    // Drag enter on root
+    fireEvent.dragEnter(root, {
+      dataTransfer: { dropEffect: "none" },
+    });
+    expect(root).toHaveClass("dragging");
+    expect(screen.getByText("Drop files here to attach to message")).toBeInTheDocument();
+
+    // Drag leave on root
+    fireEvent.dragLeave(root);
+    expect(root).not.toHaveClass("dragging");
+    expect(screen.queryByText("Drop files here to attach to message")).not.toBeInTheDocument();
+
+    // Drag over messages container activates overlay
+    const messagesArea = container.querySelector(".chat-thread") || root;
+    fireEvent.dragEnter(messagesArea, {
+      dataTransfer: { dropEffect: "none" },
+    });
+    expect(root).toHaveClass("dragging");
+    expect(screen.getByText("Drop files here to attach to message")).toBeInTheDocument();
+  });
+
+  it("supports dropping a file anywhere on the chat widget to add attachment", async () => {
+    const { container } = render(<ChatWidget id="test-chat" />);
+    const root = container.querySelector(".chat-widget-root")!;
+    const messagesArea = container.querySelector(".chat-thread") || root;
+
+    // Drag over chat area
+    fireEvent.dragEnter(messagesArea, {
+      dataTransfer: { dropEffect: "none" },
+    });
+    expect(root).toHaveClass("dragging");
+
+    // Drop file on messages area
+    const droppedFile = new File(["test docx content"], "specs.docx", {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    fireEvent.drop(messagesArea, {
+      dataTransfer: { files: [droppedFile] },
+    });
+    expect(root).not.toHaveClass("dragging");
+    expect(screen.queryByText("Drop files here to attach to message")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("specs.docx")).toBeInTheDocument();
+      expect(screen.getByText("DOCX")).toBeInTheDocument();
+    });
+  });
+
+  it("calls preventDefault on dragover and drop events to block browser file navigation", () => {
+    const { container } = render(<ChatWidget id="test-chat" />);
+    const root = container.querySelector(".chat-widget-root")!;
+
+    // Drag over root prevents default
+    const dragOverEvent = new Event("dragover", { bubbles: true, cancelable: true });
+    root.dispatchEvent(dragOverEvent);
+    expect(dragOverEvent.defaultPrevented).toBe(true);
+
+    // Drop on root prevents default
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true });
+    root.dispatchEvent(dropEvent);
+    expect(dropEvent.defaultPrevented).toBe(true);
+
+    // Window-level dragover prevents default
+    const windowDragOverEvent = new Event("dragover", { bubbles: true, cancelable: true });
+    window.dispatchEvent(windowDragOverEvent);
+    expect(windowDragOverEvent.defaultPrevented).toBe(true);
+
+    // Window-level drop prevents default
+    const windowDropEvent = new Event("drop", { bubbles: true, cancelable: true });
+    window.dispatchEvent(windowDropEvent);
+    expect(windowDropEvent.defaultPrevented).toBe(true);
+  });
+
+  it("supports removing an attached file via its thumbnail remove button", async () => {
+    render(<ChatWidget id="test-chat" />);
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+
+    const file = new File(["content"], "delete-me.txt", { type: "text/plain" });
+    fireEvent.paste(textarea, {
+      clipboardData: { files: [file], items: [] },
+      preventDefault: vi.fn(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("delete-me.txt")).toBeInTheDocument();
+    });
+
+    const removeBtn = screen.getByRole("button", { name: /Remove attachment/i });
+    fireEvent.click(removeBtn);
+
+    expect(screen.queryByText("delete-me.txt")).not.toBeInTheDocument();
+  });
+
+  it("includes attachments in OnSendMessage event payload", async () => {
+    const handleEvent = vi.fn();
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-1"
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const sendBtn = screen.getByRole("button", { name: /Send/i });
+
+    const file = new File(["hello world"], "hello.py", { type: "text/x-python" });
+    fireEvent.paste(textarea, {
+      clipboardData: { files: [file], items: [] },
+      preventDefault: vi.fn(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("hello.py")).toBeInTheDocument();
+    });
+
+    fireEvent.change(textarea, { target: { value: "Please review this code" } });
+    fireEvent.click(sendBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnSendMessage",
+      "test-chat",
+      expect.arrayContaining([
+        expect.objectContaining({
+          prompt: "Please review this code",
+          sessionId: "sess-1",
+          attachments: expect.arrayContaining([
+            expect.objectContaining({
+              name: "hello.py",
+              contentType: "text/x-python",
+            }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it("renders user messages with attachments displaying clean badges instead of raw paths", () => {
+    const session = {
+      id: "sess-1",
+      title: "Chat with Files",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [
+        {
+          id: "m-1",
+          role: "user" as const,
+          content:
+            "Here is the log file\n\n[Attached Files]:\n- /path/to/server-error.log\n- /path/to/data-export.csv",
+          timestamp: "12:00",
+        },
+      ],
+    };
+
+    render(<ChatWidget id="test-chat" activeSessionId="sess-1" sessions={[session]} />);
+
+    expect(screen.getByText("Here is the log file")).toBeInTheDocument();
+    expect(screen.getByText("server-error.log")).toBeInTheDocument();
+    expect(screen.getByText("LOG")).toBeInTheDocument();
+    expect(screen.getByText("data-export.csv")).toBeInTheDocument();
+    expect(screen.getByText("CSV")).toBeInTheDocument();
+    expect(screen.queryByText("[Attached Files]:")).not.toBeInTheDocument();
+  });
+
+  it("renders image preview elements pointing to the /ivy/local-file endpoint for image attachments in chat history", () => {
+    const session: ChatSessionDto = {
+      id: "sess-img",
+      title: "Image Preview Test",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [
+        {
+          id: "m-img",
+          role: "user" as const,
+          content:
+            "Here is a screenshot\n\n[Attached Files]:\n- /path/to/screenshot.png\n- /path/to/photo.jpg",
+          timestamp: "12:00",
+        },
+      ],
+    };
+
+    render(<ChatWidget id="test-chat" activeSessionId="sess-img" sessions={[session]} />);
+
+    expect(screen.getByText("Here is a screenshot")).toBeInTheDocument();
+    expect(screen.getByText("screenshot.png")).toBeInTheDocument();
+    expect(screen.getByText("PNG")).toBeInTheDocument();
+    expect(screen.getByText("photo.jpg")).toBeInTheDocument();
+    expect(screen.getByText("JPG")).toBeInTheDocument();
+
+    const imgElements = screen.getAllByRole("img");
+    const previewImgs = imgElements.filter((img) =>
+      img.getAttribute("src")?.includes("/ivy/local-file?path="),
+    );
+    expect(previewImgs.length).toBe(2);
+    expect(previewImgs[0].getAttribute("src")).toContain(
+      "/ivy/local-file?path=%2Fpath%2Fto%2Fscreenshot.png",
+    );
+    expect(previewImgs[1].getAttribute("src")).toContain(
+      "/ivy/local-file?path=%2Fpath%2Fto%2Fphoto.jpg",
+    );
+  });
+
+  it("opens lightbox modal with full image view on click, and closes via Escape or close button", () => {
+    const session: ChatSessionDto = {
+      id: "sess-lightbox",
+      title: "Lightbox Test",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [
+        {
+          id: "m-lb",
+          role: "user" as const,
+          content: "Check this out\n\n[Attached Files]:\n- /path/to/preview.png",
+          timestamp: "12:00",
+        },
+      ],
+    };
+
+    render(<ChatWidget id="test-chat" activeSessionId="sess-lightbox" sessions={[session]} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    const thumbnailCard = screen.getByText("preview.png").closest(".chat-user-attachment-card");
+    expect(thumbnailCard).toBeInTheDocument();
+    fireEvent.click(thumbnailCard!);
+
+    const modal = screen.getByRole("dialog");
+    expect(modal).toBeInTheDocument();
+    const closeBtn = screen.getByRole("button", { name: /Close preview/i });
+    expect(closeBtn).toBeInTheDocument();
+
+    // Close via close button
+    fireEvent.click(closeBtn);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // Reopen and close via Escape
+    fireEvent.click(thumbnailCard!);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders PDF preview cards with PdfThumbnail for PDF attachments in chat history", () => {
+    const session: ChatSessionDto = {
+      id: "sess-pdf",
+      title: "PDF Preview Test",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [
+        {
+          id: "m-pdf",
+          role: "user" as const,
+          content: "Here is the report\n\n[Attached Files]:\n- /docs/specification.pdf",
+          timestamp: "12:00",
+        },
+      ],
+    };
+
+    render(<ChatWidget id="test-chat" activeSessionId="sess-pdf" sessions={[session]} />);
+
+    expect(screen.getByText("Here is the report")).toBeInTheDocument();
+    expect(screen.getByText("specification.pdf")).toBeInTheDocument();
+    expect(screen.getByText("PDF")).toBeInTheDocument();
+
+    const pdfCard = screen.getByText("specification.pdf").closest(".chat-user-attachment-card-pdf");
+    expect(pdfCard).toBeInTheDocument();
+  });
+
+  it("submitting a message with an attached file and empty text prompt emits OnSendMessage with empty prompt", async () => {
+    const handleEvent = vi.fn();
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-1"
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const sendBtn = screen.getByRole("button", { name: /Send/i });
+
+    // Initially disabled when empty and no attachments
+    expect(sendBtn).toBeDisabled();
+
+    const imageFile = new File(["dummy-image-bytes"], "screenshot.png", { type: "image/png" });
+    fireEvent.paste(textarea, {
+      clipboardData: { files: [imageFile], items: [] },
+      preventDefault: vi.fn(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTitle("screenshot.png")).toBeInTheDocument();
+    });
+
+    // Send button should be enabled even without prompt text
+    expect(sendBtn).not.toBeDisabled();
+    fireEvent.click(sendBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnSendMessage",
+      "test-chat",
+      expect.arrayContaining([
+        expect.objectContaining({
+          prompt: "",
+          sessionId: "sess-1",
+          attachments: expect.arrayContaining([
+            expect.objectContaining({
+              name: "screenshot.png",
+              contentType: "image/png",
+            }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it("displays payload size warning banner and disables Send button when attachments exceed 50 MB", async () => {
+    render(<ChatWidget id="test-chat" />);
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const sendBtn = screen.getByRole("button", { name: /Send/i });
+
+    // Create a 51 MB dummy file
+    const largeFile = new File(["x"], "large-dataset.bin", { type: "application/octet-stream" });
+    Object.defineProperty(largeFile, "size", { value: 51 * 1024 * 1024 });
+
+    fireEvent.paste(textarea, {
+      clipboardData: { files: [largeFile], items: [] },
+      preventDefault: vi.fn(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("large-dataset.bin")).toBeInTheDocument();
+    });
+
+    // Warning banner is displayed
+    const warning = screen.getByRole("alert");
+    expect(warning).toBeInTheDocument();
+    expect(warning).toHaveTextContent(/Attachments exceed the 50 MB limit/i);
+
+    // Send button is disabled due to oversized payload
+    expect(sendBtn).toBeDisabled();
+    expect(sendBtn).toHaveAttribute("title", "Attachments exceed the 50 MB limit");
+  });
+
+  it("uploads files via HTTP multipart POST when uploadUrl is provided and sends metadata without base64", async () => {
+    const handleEvent = vi.fn();
+    let capturedXhr: any = null;
+
+    class MockXMLHttpRequest {
+      open = vi.fn();
+      send = vi.fn();
+      upload = { onprogress: null as any };
+      onload: any = null;
+      onerror: any = null;
+      status = 200;
+      constructor() {
+        capturedXhr = this;
+      }
+    }
+
+    const origXHR = window.XMLHttpRequest;
+    (window as any).XMLHttpRequest = MockXMLHttpRequest;
+
+    try {
+      render(
+        <ChatWidget
+          id="test-chat"
+          activeSessionId="sess-1"
+          uploadUrl="/ivy/upload/conn-1/up-1"
+          events={["OnSendMessage"]}
+          eventHandler={handleEvent}
+        />,
+      );
+
+      const textarea = screen.getByPlaceholderText(/Ask/i);
+      const sendBtn = screen.getByRole("button", { name: /Send/i });
+
+      const file = new File(["test-image-content"], "photo.png", { type: "image/png" });
+      fireEvent.paste(textarea, {
+        clipboardData: { files: [file], items: [] },
+        preventDefault: vi.fn(),
+      });
+
+      await waitFor(() => {
+        expect(capturedXhr).not.toBeNull();
+        expect(capturedXhr.open).toHaveBeenCalledWith("POST", "/ivy/upload/conn-1/up-1", true);
+        expect(capturedXhr.send).toHaveBeenCalledWith(expect.any(FormData));
+      });
+
+      // While uploading, send button should be disabled
+      expect(sendBtn).toBeDisabled();
+
+      // Complete the upload
+      capturedXhr.status = 200;
+      capturedXhr.onload();
+
+      await waitFor(() => {
+        expect(sendBtn).not.toBeDisabled();
+      });
+
+      fireEvent.change(textarea, { target: { value: "Look at this photo" } });
+      fireEvent.click(sendBtn);
+
+      expect(handleEvent).toHaveBeenCalledWith(
+        "OnSendMessage",
+        "test-chat",
+        expect.arrayContaining([
+          expect.objectContaining({
+            prompt: "Look at this photo",
+            sessionId: "sess-1",
+            attachments: expect.arrayContaining([
+              expect.objectContaining({
+                name: "photo.png",
+                contentType: "image/png",
+                base64Data: undefined,
+              }),
+            ]),
+          }),
+        ]),
+      );
+    } finally {
+      window.XMLHttpRequest = origXHR;
+    }
+  });
+
+  it("displays upload progress and failure state on HTTP upload error", async () => {
+    let capturedXhr: any = null;
+
+    class MockXMLHttpRequest {
+      open = vi.fn();
+      send = vi.fn();
+      upload = { onprogress: null as any };
+      onload: any = null;
+      onerror: any = null;
+      status = 500;
+      constructor() {
+        capturedXhr = this;
+      }
+    }
+
+    const origXHR = window.XMLHttpRequest;
+    (window as any).XMLHttpRequest = MockXMLHttpRequest;
+
+    try {
+      render(
+        <ChatWidget id="test-chat" activeSessionId="sess-1" uploadUrl="/ivy/upload/conn-1/up-1" />,
+      );
+
+      const textarea = screen.getByPlaceholderText(/Ask/i);
+      const sendBtn = screen.getByRole("button", { name: /Send/i });
+
+      const file = new File(["sample data"], "data.csv", { type: "text/csv" });
+      fireEvent.paste(textarea, {
+        clipboardData: { files: [file], items: [] },
+        preventDefault: vi.fn(),
+      });
+
+      await waitFor(() => {
+        expect(capturedXhr).not.toBeNull();
+      });
+
+      // Trigger progress
+      capturedXhr.upload.onprogress?.({ lengthComputable: true, loaded: 50, total: 100 });
+
+      await waitFor(() => {
+        expect(screen.getByText("50%")).toBeInTheDocument();
+      });
+
+      // Trigger failure
+      capturedXhr.status = 500;
+      capturedXhr.onload();
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed")).toBeInTheDocument();
+      });
+
+      // Send button remains disabled when there is no text or valid finished attachments
+      expect(sendBtn).toBeDisabled();
+    } finally {
+      window.XMLHttpRequest = origXHR;
+    }
+  });
+
+  it("handles 20MB large image upload without crashing and downscales before uploading", async () => {
+    let capturedXhr: any = null;
+
+    class MockXMLHttpRequest {
+      open = vi.fn();
+      send = vi.fn();
+      upload = { onprogress: null as any };
+      onload: any = null;
+      onerror: any = null;
+      status = 200;
+      constructor() {
+        capturedXhr = this;
+      }
+    }
+
+    const origXHR = window.XMLHttpRequest;
+    (window as any).XMLHttpRequest = MockXMLHttpRequest;
+
+    try {
+      render(<ChatWidget id="test-chat" activeSessionId="sess-1" uploadUrl="/ivy/upload/test" />);
+
+      const textarea = screen.getByPlaceholderText(/Ask/i);
+      const sendBtn = screen.getByRole("button", { name: /Send/i });
+
+      const largeImage = new File(["dummy-data"], "large-photo.jpg", { type: "image/jpeg" });
+      Object.defineProperty(largeImage, "size", { value: 20 * 1024 * 1024 });
+
+      fireEvent.paste(textarea, {
+        clipboardData: { files: [largeImage], items: [] },
+        preventDefault: vi.fn(),
+      });
+
+      await waitFor(() => {
+        expect(capturedXhr).not.toBeNull();
+        expect(capturedXhr.open).toHaveBeenCalledWith("POST", "/ivy/upload/test", true);
+      });
+
+      capturedXhr.status = 200;
+      capturedXhr.onload();
+
+      await waitFor(() => {
+        expect(sendBtn).not.toBeDisabled();
+      });
+    } finally {
+      window.XMLHttpRequest = origXHR;
+    }
+  });
+
+  it("optimistically displays user message immediately upon clicking Send", async () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-empty",
+      title: "New Chat",
+      agentId: "codex",
+      modelId: "gpt-5.6-sol",
+      createdAt: "2026-09-03T10:00:00Z",
+      updatedAt: "2026-09-03T10:00:00Z",
+      messages: [],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-empty"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnSendMessage"]}
+      />,
+    );
+
+    expect(screen.getByText("What Are We Producing Today?")).toBeInTheDocument();
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    fireEvent.change(textarea, { target: { value: "test. Alive?" } });
+
+    const sendBtn = screen.getByRole("button", { name: /Send/i });
+    fireEvent.click(sendBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith("OnSendMessage", "test-chat", [
+      { prompt: "test. Alive?", attachments: [], sessionId: "sess-empty" },
+    ]);
+
+    // Optimistic message should appear immediately without waiting for props update!
+    expect(screen.getByText("test. Alive?")).toBeInTheDocument();
+    expect(screen.queryByText("What Are We Producing Today?")).not.toBeInTheDocument();
+  });
+
+  it("optimistically displays assistant Starting status and switches Send button to Stop/Queue immediately upon clicking Send", async () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-1",
+      title: "Active Chat",
+      agentId: "codex",
+      modelId: "gpt-5.6-sol",
+      createdAt: "2026-09-03T10:00:00Z",
+      updatedAt: "2026-09-03T10:00:00Z",
+      messages: [],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-1"
+        selectedAgent="codex"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnSendMessage", "OnCancelStream"]}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    fireEvent.change(textarea, { target: { value: "retry again" } });
+
+    const sendBtn = screen.getByRole("button", { name: /Send/i });
+    expect(sendBtn).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Stop/i })).not.toBeInTheDocument();
+
+    fireEvent.click(sendBtn);
+
+    // Immediately shows Stop and Queue buttons without waiting for server props
+    expect(screen.getByRole("button", { name: /Stop/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Queue/i })).toBeInTheDocument();
+
+    // Immediately shows the Thinking status indicator
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+
+    // Clicking Stop cancels optimistic stream
+    const stopBtn = screen.getByRole("button", { name: /Stop/i });
+    fireEvent.click(stopBtn);
+    expect(handleEvent).toHaveBeenCalledWith("OnCancelStream", "test-chat", []);
+    expect(screen.queryByRole("button", { name: /Stop/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Send/i })).toBeInTheDocument();
+  });
+
+  it("displays spawned jobs in header badge and emits OnSendMessage when reviewing outcomes from dropdown", () => {
+    const handleEvent = vi.fn();
+    const session: ChatSessionDto = {
+      id: "sess-jobs",
+      title: "Jobs Chat",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+      spawnedJobs: [
+        {
+          id: "job-101",
+          type: "plan",
+          status: "Completed",
+          planTitle: "Add OAuth2 authentication",
+        },
+      ],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-jobs"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnSendMessage"]}
+      />,
+    );
+
+    // Banner directly above chat is removed
+    expect(screen.queryByText(/Spawned Jobs \(/i)).not.toBeInTheDocument();
+
+    // Header badge is displayed
+    const badgeBtn = screen.getByRole("button", { name: /View running jobs/i });
+    expect(badgeBtn).toBeInTheDocument();
+    expect(within(badgeBtn).getByText(/1 job/i)).toBeInTheDocument();
+
+    // Open dropdown by clicking badge
+    fireEvent.click(badgeBtn);
+
+    expect(screen.getByText(/Spawned Jobs/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 completed/i)).toBeInTheDocument();
+    expect(screen.getByText("Add OAuth2 authentication")).toBeInTheDocument();
+
+    const reviewBtn = screen.getByRole("button", { name: /Ask agent to review outcomes/i });
+    expect(reviewBtn).toBeInTheDocument();
+
+    fireEvent.click(reviewBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnSendMessage",
+      "test-chat",
+      expect.arrayContaining([
+        expect.objectContaining({
+          prompt: expect.stringContaining("All spawned jobs have completed"),
+          sessionId: "sess-jobs",
+        }),
+      ]),
+    );
+  });
+
+  it("renders interactive questions in chat message and emits OnAnswerQuestion when user submits response", async () => {
+    const handleEvent = vi.fn();
+    const session: ChatSessionDto = {
+      id: "sess-q",
+      title: "Questions Chat",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [
+        {
+          id: "msg-q1",
+          role: "assistant",
+          content: [
+            "Please confirm your choices below:",
+            "```questions",
+            "- id: deploy_target",
+            "  title: Which environment should we deploy to?",
+            "  options:",
+            "    - title: Staging Environment",
+            "      value: staging",
+            "    - title: Production Environment",
+            "      value: prod",
+            "```",
+          ].join("\n"),
+          timestamp: "12:00 PM",
+        },
+      ],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-q"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    expect(screen.getByText("Which environment should we deploy to?")).toBeInTheDocument();
+    expect(screen.getByText("Staging Environment")).toBeInTheDocument();
+    expect(screen.getByText("Production Environment")).toBeInTheDocument();
+
+    const submitBtn = screen.getByRole("button", { name: /Submit Response/i });
+    expect(submitBtn).toBeDisabled();
+
+    // Select Staging Environment option
+    const stagingRadio = screen.getByRole("radio", { name: /Staging Environment/i });
+    fireEvent.click(stagingRadio);
+
+    // Submit button should now be enabled
+    expect(submitBtn).not.toBeDisabled();
+
+    fireEvent.click(submitBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnAnswerQuestion",
+      "test-chat",
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: "sess-q",
+          messageId: "msg-q1",
+          answers: { deploy_target: ["staging"] },
+          responseText: expect.stringContaining("Staging Environment"),
+        }),
+      ]),
+    );
+  });
+
+  it("renders running jobs header badge and toggles dropdown on click", async () => {
+    const session: ChatSessionDto = {
+      id: "sess-running",
+      title: "Active Job Session",
+      agentId: "antigravity",
+      modelId: "gemini-3.8-flash",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+      spawnedJobs: [
+        {
+          id: "00148",
+          type: "CreatePlan",
+          status: "Running",
+          planTitle: "Test job tracking",
+          statusMessage: "Researching architecture...",
+        },
+      ],
+    };
+
+    const { container } = render(
+      <ChatWidget id="test-chat" activeSessionId="sess-running" sessions={[session]} />,
+    );
+
+    // Header badge displays running count
+    const badgeBtn = screen.getByRole("button", { name: /View running jobs/i });
+    expect(badgeBtn).toBeInTheDocument();
+    expect(within(badgeBtn).getByText(/1 running/i)).toBeInTheDocument();
+
+    // Click badge to open dropdown
+    fireEvent.click(badgeBtn);
+
+    // Dropdown is open and displays job item details
+    const dropdown = container.querySelector(".chat-jobs-dropdown-menu") as HTMLElement;
+    expect(dropdown).toBeInTheDocument();
+    expect(within(dropdown).getByText("00148")).toBeInTheDocument();
+    expect(within(dropdown).getByText("CreatePlan")).toBeInTheDocument();
+    expect(within(dropdown).getByText("Researching architecture...")).toBeInTheDocument();
+  });
+
+  it("renders system event messages in chat timeline", async () => {
+    const session: ChatSessionDto = {
+      id: "sess-sys",
+      title: "System Notification Session",
+      agentId: "antigravity",
+      modelId: "gemini-3.8-flash",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [
+        {
+          id: "msg-sys-1",
+          role: "system",
+          content: "Job 00148 (CreatePlan) has completed successfully.",
+          timestamp: "10:00 AM",
+        },
+        {
+          id: "msg-ast-1",
+          role: "assistant",
+          content: "I reviewed the plan and it looks great!",
+          timestamp: "10:01 AM",
+        },
+      ],
+    };
+
+    const { container } = render(
+      <ChatWidget id="test-chat" activeSessionId="sess-sys" sessions={[session]} />,
+    );
+
+    const systemRow = container.querySelector(".chat-system-event-row");
+    expect(systemRow).toBeInTheDocument();
+    expect(
+      screen.getByText("Job 00148 (CreatePlan) has completed successfully."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("I reviewed the plan and it looks great!")).toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx
@@ -1,0 +1,324 @@
+import "./ChatWidget.testUtils";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { ChatWidget, type ChatSessionDto } from "./ChatWidget";
+import { setupChatWidgetTestEnvironment, questionsFence } from "./ChatWidget.testUtils";
+
+describe("ChatWidget Interactive Question Draft Persistence", () => {
+  beforeEach(() => {
+    setupChatWidgetTestEnvironment();
+  });
+
+  const deployQuestion = questionsFence(
+    "- id: deploy_target",
+    "  title: Which environment should we deploy to?",
+    "  options:",
+    "    - title: Staging Environment",
+    "      value: staging",
+    "    - title: Production Environment",
+    "      value: prod",
+  );
+
+  const deployQuestionWithOther = questionsFence(
+    "- id: deploy_target",
+    "  title: Which environment should we deploy to?",
+    "  other: true",
+    "  options:",
+    "    - title: Staging Environment",
+    "      value: staging",
+    "    - title: Production Environment",
+    "      value: prod",
+  );
+
+  const freeTextQuestion = questionsFence("- id: comment", "  title: Anything else?");
+
+  const twoBlockMessage = [
+    "First block:",
+    questionsFence(
+      "- id: color",
+      "  title: Favorite color?",
+      "  options:",
+      "    - title: Red",
+      "      value: red",
+      "    - title: Blue",
+      "      value: blue",
+    ),
+    "Second block:",
+    questionsFence(
+      "- id: size",
+      "  title: Favorite size?",
+      "  options:",
+      "    - title: Small",
+      "      value: small",
+      "    - title: Large",
+      "      value: large",
+    ),
+  ].join("\n\n");
+
+  const sessionWith = (id: string, content: string): ChatSessionDto => ({
+    id,
+    title: id,
+    agentId: "claude",
+    modelId: "opus",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    messages: [
+      {
+        id: `${id}-msg`,
+        role: "assistant",
+        content,
+        timestamp: "12:00 PM",
+      },
+    ],
+  });
+
+  it("keeps a selection through a streamVersion re-render (streaming chunk arriving)", () => {
+    const session = sessionWith("sess-stream", deployQuestion);
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-stream"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-stream"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText='{"kind":"text","text":"Working on it...","delta":false}'
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+    expect(screen.getByRole("button", { name: /Submit Response/i })).not.toBeDisabled();
+  });
+
+  it("never remounts the callout's input across a streamVersion re-render", () => {
+    const session = sessionWith("sess-remount", freeTextQuestion);
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-remount"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    const inputBefore = screen.getByPlaceholderText("Type your answer");
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-remount"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText='{"kind":"text","text":"Still working...","delta":false}'
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Type your answer")).toBe(inputBefore);
+  });
+
+  it("keeps typed Other text and focus through a sessionVersion re-render (runningJobs change)", () => {
+    const session = sessionWith("sess-other", deployQuestionWithOther);
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-other"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /^Other$/i }));
+    const otherInput = screen.getByPlaceholderText("Type your answer");
+    otherInput.focus();
+    fireEvent.change(otherInput, { target: { value: "A canary environment" } });
+    expect(otherInput).toHaveValue("A canary environment");
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-other"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        runningJobs={[{ id: "job-1", type: "ExecutePlan", status: "Running" }]}
+      />,
+    );
+
+    const otherInputAfter = screen.getByPlaceholderText("Type your answer");
+    expect(otherInputAfter).toBe(otherInput);
+    expect(otherInputAfter).toHaveValue("A canary environment");
+    expect(document.activeElement).toBe(otherInputAfter);
+  });
+
+  it("restores a selection from the draft store after a real remount (switching sessions and back)", () => {
+    const sessionA = sessionWith("sess-a", deployQuestion);
+    const sessionB = sessionWith("sess-b", "Just a plain message, no questions here.");
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-a"
+        sessions={[sessionA, sessionB]}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-b"
+        sessions={[sessionA, sessionB]}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+    expect(screen.queryByRole("radio", { name: /Staging Environment/i })).toBeNull();
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-a"
+        sessions={[sessionA, sessionB]}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+  });
+
+  it("clears the draft on submit, so a later remount starts empty rather than re-offering the old selection", () => {
+    const sessionA = sessionWith("sess-a", deployQuestion);
+    const sessionB = sessionWith("sess-b", "Just a plain message, no questions here.");
+    const handleEvent = vi.fn();
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-a"
+        sessions={[sessionA, sessionB]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Submit Response/i }));
+    expect(handleEvent).toHaveBeenCalled();
+
+    // Switch away and back to force a remount of the message row.
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-b"
+        sessions={[sessionA, sessionB]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-a"
+        sessions={[sessionA, sessionB]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).not.toBeChecked();
+    expect(screen.getByRole("button", { name: /Submit Response/i })).toBeDisabled();
+  });
+
+  it("keeps two question blocks in one message independent when only one is answered", () => {
+    const session = sessionWith("sess-two-blocks", twoBlockMessage);
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-two-blocks"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /^Red$/i }));
+    expect(screen.getByRole("radio", { name: /^Red$/i })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /^Small$/i })).not.toBeChecked();
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-two-blocks"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText='{"kind":"text","text":"Working...","delta":false}'
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: /^Red$/i })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /^Small$/i })).not.toBeChecked();
+  });
+
+  it("keeps a selection made inside a rawStream-rendered questions block through a re-render", () => {
+    const rawStream = JSON.stringify({ kind: "text", text: deployQuestion, delta: false });
+    const session: ChatSessionDto = {
+      id: "sess-raw",
+      title: "Raw Stream Chat",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [
+        {
+          id: "msg-raw",
+          role: "assistant",
+          content: "",
+          rawStream,
+          timestamp: "12:00 PM",
+        },
+      ],
+    };
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-raw"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-raw"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        runningJobs={[{ id: "job-2", type: "ExecutePlan", status: "Running" }]}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.queuing.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.queuing.test.tsx
@@ -1,0 +1,308 @@
+import "./ChatWidget.testUtils";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { ChatWidget } from "./ChatWidget";
+import { setupChatWidgetTestEnvironment } from "./ChatWidget.testUtils";
+
+describe("ChatWidget Queued Messages UI", () => {
+  beforeEach(() => {
+    setupChatWidgetTestEnvironment();
+  });
+
+  it("renders queued messages panel when isStreaming and user queues messages", () => {
+    const handleEvent = vi.fn();
+    render(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    // Queue first message
+    fireEvent.change(textarea, { target: { value: "test message 1" } });
+    fireEvent.click(queueBtn);
+
+    // Queue second message
+    fireEvent.change(textarea, { target: { value: "test message 2" } });
+    fireEvent.click(queueBtn);
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Sends after agent finishes working")).toBeInTheDocument();
+
+    expect(screen.getByText("test message 1")).toBeInTheDocument();
+    expect(screen.getByText("test message 2")).toBeInTheDocument();
+  });
+
+  it("allows collapsing and expanding the queued messages list", () => {
+    render(<ChatWidget id="test-chat" isStreaming={true} />);
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "queued task" } });
+    fireEvent.click(queueBtn);
+
+    const toggleBtn = screen.getByRole("button", { name: /Collapse queued messages/i });
+    fireEvent.click(toggleBtn);
+
+    expect(screen.queryByText("queued task")).not.toBeInTheDocument();
+
+    const expandBtn = screen.getByRole("button", { name: /Expand queued messages/i });
+    fireEvent.click(expandBtn);
+
+    expect(screen.getByText("queued task")).toBeInTheDocument();
+  });
+
+  it("supports editing a queued message", () => {
+    render(<ChatWidget id="test-chat" isStreaming={true} />);
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "original prompt" } });
+    fireEvent.click(queueBtn);
+
+    const editBtn = screen.getByRole("button", { name: /Edit message/i });
+    fireEvent.click(editBtn);
+
+    const editInput = screen.getByDisplayValue("original prompt");
+    fireEvent.change(editInput, { target: { value: "updated prompt" } });
+
+    const saveBtn = screen.getByRole("button", { name: /Save/i });
+    fireEvent.click(saveBtn);
+
+    expect(screen.getByText("updated prompt")).toBeInTheDocument();
+    expect(screen.queryByText("original prompt")).not.toBeInTheDocument();
+  });
+
+  it("supports sending a queued message immediately and deleting a queued message", () => {
+    const handleEvent = vi.fn();
+    render(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "message to send now" } });
+    fireEvent.click(queueBtn);
+
+    fireEvent.change(textarea, { target: { value: "message to delete" } });
+    fireEvent.click(queueBtn);
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+
+    // Delete second message
+    const deleteBtns = screen.getAllByRole("button", { name: /Delete message/i });
+    fireEvent.click(deleteBtns[1]);
+
+    expect(screen.queryByText("message to delete")).not.toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+
+    // Send first message now
+    const sendNowBtn = screen.getByRole("button", { name: /Send now/i });
+    fireEvent.click(sendNowBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnSendMessage",
+      "test-chat",
+      expect.arrayContaining([expect.objectContaining({ prompt: "message to send now" })]),
+    );
+    expect(screen.queryByText("Queued Messages")).not.toBeInTheDocument();
+  });
+
+  it("renders queued messages passed via props upon mount and handles session switches", () => {
+    const queuedItems = [
+      { id: "q-1", prompt: "persisted queued prompt 1" },
+      { id: "q-2", prompt: "persisted queued prompt 2" },
+    ];
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-1"
+        isStreaming={true}
+        queuedMessages={queuedItems}
+      />,
+    );
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("persisted queued prompt 1")).toBeInTheDocument();
+    expect(screen.getByText("persisted queued prompt 2")).toBeInTheDocument();
+
+    // Rerender with empty queue (e.g. switched to another session)
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-2"
+        isStreaming={false}
+        queuedMessages={[]}
+      />,
+    );
+
+    expect(screen.queryByText("Queued Messages")).not.toBeInTheDocument();
+    expect(screen.queryByText("persisted queued prompt 1")).not.toBeInTheDocument();
+  });
+
+  it("emits backend sync events OnDeleteQueuedMessage, OnUpdateQueuedMessage, and OnSendQueuedNow", () => {
+    const handleEvent = vi.fn();
+    const queuedItems = [
+      { id: "q-edit", prompt: "to be edited" },
+      { id: "q-del", prompt: "to be deleted" },
+      { id: "q-send", prompt: "to be sent now" },
+    ];
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-1"
+        sessions={[
+          {
+            id: "sess-1",
+            title: "Session 1",
+            agentId: "claude",
+            modelId: "sonnet",
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            messages: [],
+          },
+        ]}
+        isStreaming={true}
+        queuedMessages={queuedItems}
+        events={["OnDeleteQueuedMessage", "OnUpdateQueuedMessage", "OnSendQueuedNow"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    // Edit item
+    const editBtns = screen.getAllByRole("button", { name: /Edit message/i });
+    fireEvent.click(editBtns[0]);
+    const editInput = screen.getByDisplayValue("to be edited");
+    fireEvent.change(editInput, { target: { value: "edited content" } });
+    const saveBtn = screen.getByRole("button", { name: /Save/i });
+    fireEvent.click(saveBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith("OnUpdateQueuedMessage", "test-chat", [
+      ["q-edit", "edited content"],
+    ]);
+
+    // Delete item
+    const deleteBtns = screen.getAllByRole("button", { name: /Delete message/i });
+    fireEvent.click(deleteBtns[1]);
+
+    expect(handleEvent).toHaveBeenCalledWith("OnDeleteQueuedMessage", "test-chat", ["q-del"]);
+
+    // Send item now
+    const sendNowBtns = screen.getAllByRole("button", { name: /Send now/i });
+    fireEvent.click(sendNowBtns[1]);
+
+    expect(handleEvent).toHaveBeenCalledWith("OnSendQueuedNow", "test-chat", ["q-send"]);
+    expect(screen.getByText("to be sent now")).toBeInTheDocument();
+  });
+
+  it("preserves optimistically queued message when in-flight queuedMessages prop is empty", () => {
+    const handleEvent = vi.fn();
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        activeSessionId="sess-1"
+        queuedMessages={[]}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "optimistic prompt" } });
+    fireEvent.click(queueBtn);
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
+
+    // Simulate in-flight SignalR update where server hasn't yet included the queued message
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        activeSessionId="sess-1"
+        queuedMessages={[]}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    // Should still be visible optimistically!
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
+
+    // When server confirms the queued message
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        activeSessionId="sess-1"
+        queuedMessages={[{ id: "guid-server-123", prompt: "optimistic prompt" }]}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
+  });
+
+  it("does not drop queued message when its content matches an existing historical message", () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-repeat",
+      title: "Repeat Test",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [
+        { id: "m-1", role: "user" as const, content: "what can you do?", timestamp: "10:00" },
+      ],
+      status: "generating" as const,
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        activeSessionId="sess-repeat"
+        sessions={[session]}
+        queuedMessages={[]}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "what can you do?" } });
+    fireEvent.click(queueBtn);
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    // Verify it is inside the queued panel
+    const queuedItem = document.querySelector(".chat-queued-item-text");
+    expect(queuedItem).toHaveTextContent("what can you do?");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.streaming.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.streaming.test.tsx
@@ -1,0 +1,199 @@
+import "./ChatWidget.testUtils";
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { ChatWidget } from "./ChatWidget";
+
+describe("ChatWidget Streaming Scroll Behavior", () => {
+  const session = {
+    id: "sess-scroll",
+    title: "Scroll Test Chat",
+    agentId: "codex",
+    modelId: "gpt-5",
+    createdAt: "2026-09-03T10:00:00Z",
+    updatedAt: "2026-09-03T10:00:00Z",
+    messages: [
+      {
+        id: "m-1",
+        role: "user" as const,
+        content: "Explain markdown streaming",
+        timestamp: "10:00 AM",
+      },
+    ],
+  };
+
+  it("scrolls to bottom without triggering continuous smooth scroll calls when container is at bottom", () => {
+    const scrollIntoViewMock = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"First chunk"}'
+      />,
+    );
+
+    const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
+    expect(container).toBeInTheDocument();
+
+    let currentScrollTop = 600;
+    Object.defineProperty(container, "scrollHeight", {
+      value: 1000,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      value: 400,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(container, "scrollTop", {
+      get: () => currentScrollTop,
+      set: (v: number) => {
+        currentScrollTop = v;
+      },
+      configurable: true,
+    });
+
+    // Reset any initial scrollIntoView calls from mount
+    scrollIntoViewMock.mockClear();
+
+    // Stream next chunk
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"First chunk and second chunk"}'
+      />,
+    );
+
+    // Should update scrollTop to bottom (1000 - 400 = 600) instantly without calling scrollIntoView smooth
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(currentScrollTop).toBe(600);
+  });
+
+  it("does not force scroll down when user is scrolled up", () => {
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Initial streaming"}'
+      />,
+    );
+
+    const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
+    let currentScrollTop = 600;
+    Object.defineProperty(container, "scrollHeight", {
+      value: 1000,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      value: 400,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(container, "scrollTop", {
+      get: () => currentScrollTop,
+      set: (v: number) => {
+        currentScrollTop = v;
+      },
+      configurable: true,
+    });
+
+    // User scrolls up to 200px (distance to bottom is 1000 - 200 - 400 = 400px > 50px threshold)
+    currentScrollTop = 200;
+    fireEvent.scroll(container);
+
+    // New stream chunk arrives
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Initial streaming with more tokens"}'
+      />,
+    );
+
+    // Container should remain at user scroll offset (200px) and not be forced down
+    expect(currentScrollTop).toBe(200);
+  });
+
+  it("re-enables auto-scroll when user scrolls back to bottom", () => {
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Starting stream"}'
+      />,
+    );
+
+    const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
+    let currentScrollTop = 600;
+    let height = 1000;
+    Object.defineProperty(container, "scrollHeight", {
+      get: () => height,
+      set: (v: number) => {
+        height = v;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      value: 400,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(container, "scrollTop", {
+      get: () => currentScrollTop,
+      set: (v: number) => {
+        currentScrollTop = v;
+      },
+      configurable: true,
+    });
+
+    // User scrolls up
+    currentScrollTop = 150;
+    fireEvent.scroll(container);
+
+    // New chunk while scrolled up: stays at 150
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Starting stream..."}'
+      />,
+    );
+    expect(currentScrollTop).toBe(150);
+
+    // User scrolls back near bottom: 580px (1000 - 580 - 400 = 20px <= 50px threshold)
+    currentScrollTop = 580;
+    fireEvent.scroll(container);
+
+    // Height increases with new tokens
+    height = 1200;
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Starting stream... more tokens generated"}'
+      />,
+    );
+
+    // Auto-scroll is re-enabled and pins to bottom (1200 - 400 = 800)
+    expect(currentScrollTop).toBe(800);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -1,1801 +1,13 @@
-import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./ChatWidget.testUtils";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom";
-
-vi.mock("pdfjs-dist", () => ({ GlobalWorkerOptions: {}, getDocument: vi.fn() }));
-vi.mock("pdfjs-dist/build/pdf.worker.mjs?url", () => ({ default: "" }));
-
 import { ChatWidget, type ChatSessionDto } from "./ChatWidget";
-
-describe("ChatWidget Queued Messages UI", () => {
-  beforeEach(() => {
-    window.ResizeObserver = class {
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    } as any;
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
-  });
-
-  it("renders queued messages panel when isStreaming and user queues messages", () => {
-    const handleEvent = vi.fn();
-    render(
-      <ChatWidget
-        id="test-chat"
-        isStreaming={true}
-        events={["OnSendMessage"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
-
-    // Queue first message
-    fireEvent.change(textarea, { target: { value: "test message 1" } });
-    fireEvent.click(queueBtn);
-
-    // Queue second message
-    fireEvent.change(textarea, { target: { value: "test message 2" } });
-    fireEvent.click(queueBtn);
-
-    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
-    expect(screen.getByText("2")).toBeInTheDocument();
-    expect(screen.getByText("Sends after agent finishes working")).toBeInTheDocument();
-
-    expect(screen.getByText("test message 1")).toBeInTheDocument();
-    expect(screen.getByText("test message 2")).toBeInTheDocument();
-  });
-
-  it("allows collapsing and expanding the queued messages list", () => {
-    render(<ChatWidget id="test-chat" isStreaming={true} />);
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
-
-    fireEvent.change(textarea, { target: { value: "queued task" } });
-    fireEvent.click(queueBtn);
-
-    const toggleBtn = screen.getByRole("button", { name: /Collapse queued messages/i });
-    fireEvent.click(toggleBtn);
-
-    expect(screen.queryByText("queued task")).not.toBeInTheDocument();
-
-    const expandBtn = screen.getByRole("button", { name: /Expand queued messages/i });
-    fireEvent.click(expandBtn);
-
-    expect(screen.getByText("queued task")).toBeInTheDocument();
-  });
-
-  it("supports editing a queued message", () => {
-    render(<ChatWidget id="test-chat" isStreaming={true} />);
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
-
-    fireEvent.change(textarea, { target: { value: "original prompt" } });
-    fireEvent.click(queueBtn);
-
-    const editBtn = screen.getByRole("button", { name: /Edit message/i });
-    fireEvent.click(editBtn);
-
-    const editInput = screen.getByDisplayValue("original prompt");
-    fireEvent.change(editInput, { target: { value: "updated prompt" } });
-
-    const saveBtn = screen.getByRole("button", { name: /Save/i });
-    fireEvent.click(saveBtn);
-
-    expect(screen.getByText("updated prompt")).toBeInTheDocument();
-    expect(screen.queryByText("original prompt")).not.toBeInTheDocument();
-  });
-
-  it("supports sending a queued message immediately and deleting a queued message", () => {
-    const handleEvent = vi.fn();
-    render(
-      <ChatWidget
-        id="test-chat"
-        isStreaming={true}
-        events={["OnSendMessage"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
-
-    fireEvent.change(textarea, { target: { value: "message to send now" } });
-    fireEvent.click(queueBtn);
-
-    fireEvent.change(textarea, { target: { value: "message to delete" } });
-    fireEvent.click(queueBtn);
-
-    expect(screen.getByText("2")).toBeInTheDocument();
-
-    // Delete second message
-    const deleteBtns = screen.getAllByRole("button", { name: /Delete message/i });
-    fireEvent.click(deleteBtns[1]);
-
-    expect(screen.queryByText("message to delete")).not.toBeInTheDocument();
-    expect(screen.getByText("1")).toBeInTheDocument();
-
-    // Send first message now
-    const sendNowBtn = screen.getByRole("button", { name: /Send now/i });
-    fireEvent.click(sendNowBtn);
-
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnSendMessage",
-      "test-chat",
-      expect.arrayContaining([expect.objectContaining({ prompt: "message to send now" })])
-    );
-    expect(screen.queryByText("Queued Messages")).not.toBeInTheDocument();
-  });
-
-  it("renders queued messages passed via props upon mount and handles session switches", () => {
-    const queuedItems = [
-      { id: "q-1", prompt: "persisted queued prompt 1" },
-      { id: "q-2", prompt: "persisted queued prompt 2" },
-    ];
-
-    const { rerender } = render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-1"
-        isStreaming={true}
-        queuedMessages={queuedItems}
-      />
-    );
-
-    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
-    expect(screen.getByText("2")).toBeInTheDocument();
-    expect(screen.getByText("persisted queued prompt 1")).toBeInTheDocument();
-    expect(screen.getByText("persisted queued prompt 2")).toBeInTheDocument();
-
-    // Rerender with empty queue (e.g. switched to another session)
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-2"
-        isStreaming={false}
-        queuedMessages={[]}
-      />
-    );
-
-    expect(screen.queryByText("Queued Messages")).not.toBeInTheDocument();
-    expect(screen.queryByText("persisted queued prompt 1")).not.toBeInTheDocument();
-  });
-
-  it("emits backend sync events OnDeleteQueuedMessage, OnUpdateQueuedMessage, and OnSendQueuedNow", () => {
-    const handleEvent = vi.fn();
-    const queuedItems = [
-      { id: "q-edit", prompt: "to be edited" },
-      { id: "q-del", prompt: "to be deleted" },
-      { id: "q-send", prompt: "to be sent now" },
-    ];
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-1"
-        sessions={[{
-          id: "sess-1",
-          title: "Session 1",
-          agentId: "claude",
-          modelId: "sonnet",
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-          messages: [],
-        }]}
-        isStreaming={true}
-        queuedMessages={queuedItems}
-        events={["OnDeleteQueuedMessage", "OnUpdateQueuedMessage", "OnSendQueuedNow"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    // Edit item
-    const editBtns = screen.getAllByRole("button", { name: /Edit message/i });
-    fireEvent.click(editBtns[0]);
-    const editInput = screen.getByDisplayValue("to be edited");
-    fireEvent.change(editInput, { target: { value: "edited content" } });
-    const saveBtn = screen.getByRole("button", { name: /Save/i });
-    fireEvent.click(saveBtn);
-
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnUpdateQueuedMessage",
-      "test-chat",
-      [["q-edit", "edited content"]]
-    );
-
-    // Delete item
-    const deleteBtns = screen.getAllByRole("button", { name: /Delete message/i });
-    fireEvent.click(deleteBtns[1]);
-
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnDeleteQueuedMessage",
-      "test-chat",
-      ["q-del"]
-    );
-
-    // Send item now
-    const sendNowBtns = screen.getAllByRole("button", { name: /Send now/i });
-    fireEvent.click(sendNowBtns[1]);
-
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnSendQueuedNow",
-      "test-chat",
-      ["q-send"]
-    );
-    expect(screen.getByText("to be sent now")).toBeInTheDocument();
-  });
-
-  it("preserves optimistically queued message when in-flight queuedMessages prop is empty", () => {
-    const handleEvent = vi.fn();
-    const { rerender } = render(
-      <ChatWidget
-        id="test-chat"
-        isStreaming={true}
-        activeSessionId="sess-1"
-        queuedMessages={[]}
-        events={["OnSendMessage"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
-
-    fireEvent.change(textarea, { target: { value: "optimistic prompt" } });
-    fireEvent.click(queueBtn);
-
-    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
-    expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
-
-    // Simulate in-flight SignalR update where server hasn't yet included the queued message
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        isStreaming={true}
-        activeSessionId="sess-1"
-        queuedMessages={[]}
-        events={["OnSendMessage"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    // Should still be visible optimistically!
-    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
-    expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
-
-    // When server confirms the queued message
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        isStreaming={true}
-        activeSessionId="sess-1"
-        queuedMessages={[{ id: "guid-server-123", prompt: "optimistic prompt" }]}
-        events={["OnSendMessage"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
-    expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
-  });
-
-  it("does not drop queued message when its content matches an existing historical message", () => {
-    const handleEvent = vi.fn();
-    const session = {
-      id: "sess-repeat",
-      title: "Repeat Test",
-      agentId: "claude",
-      modelId: "opus",
-      createdAt: "2026-08-15T12:00:00Z",
-      updatedAt: "2026-08-15T12:30:00Z",
-      messages: [{ id: "m-1", role: "user" as const, content: "what can you do?", timestamp: "10:00" }],
-      status: "generating" as const,
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        isStreaming={true}
-        activeSessionId="sess-repeat"
-        sessions={[session]}
-        queuedMessages={[]}
-        events={["OnSendMessage"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
-
-    fireEvent.change(textarea, { target: { value: "what can you do?" } });
-    fireEvent.click(queueBtn);
-
-    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
-    // Verify it is inside the queued panel
-    const queuedItem = document.querySelector(".chat-queued-item-text");
-    expect(queuedItem).toHaveTextContent("what can you do?");
-  });
-
-  it("offers Delete chat in the header options menu and emits OnDeleteSession upon click", () => {
-    const handleEvent = vi.fn();
-    const session = {
-      id: "sess-123",
-      title: "My Great Chat",
-      agentId: "antigravity",
-      modelId: "gemini-3.7-flash",
-      createdAt: "2026-08-15T12:00:00Z",
-      updatedAt: "2026-08-15T12:30:00Z",
-      messages: [],
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-123"
-        sessions={[session]}
-        events={["OnDeleteSession"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    expect(screen.queryByRole("menuitem", { name: /Delete chat/i })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Chat options/i }));
-
-    const deleteBtn = screen.getByRole("menuitem", { name: /Delete chat/i });
-    expect(deleteBtn).toBeInTheDocument();
-
-    fireEvent.click(deleteBtn);
-    expect(screen.queryByRole("menuitem", { name: /Delete chat/i })).not.toBeInTheDocument();
-
-    expect(handleEvent).toHaveBeenCalledTimes(1);
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnDeleteSession",
-      "test-chat",
-      ["sess-123"]
-    );
-  });
-
-  it("renders effort picker and emits OnEffortChanged when changed", () => {
-    const handleEvent = vi.fn();
-    const efforts = [
-      { id: "default", displayName: "Default" },
-      { id: "low", displayName: "Low" },
-      { id: "high", displayName: "High" },
-      { id: "max", displayName: "Max" },
-    ];
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        efforts={efforts}
-        selectedEffort="high"
-        supportsEffort={true}
-        events={["OnEffortChanged"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    // The effort select lives in the agent picker's side panel for the selected agent.
-    fireEvent.click(screen.getByRole("button", { name: /^Agent:/i }));
-    const effortTrigger = screen.getByTitle("Effort Level");
-    expect(effortTrigger).toBeInTheDocument();
-    expect(screen.getByText("High")).toBeInTheDocument();
-
-    fireEvent.click(effortTrigger.querySelector("button")!);
-    const maxOption = screen.getByRole("button", { name: /Max/i });
-    fireEvent.click(maxOption);
-
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnEffortChanged",
-      "test-chat",
-      ["max"]
-    );
-  });
-});
-
-describe("ChatWidget File Uploads and Attachments", () => {
-  beforeEach(() => {
-    window.ResizeObserver = class {
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    } as any;
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
-  });
-
-  it("attaches non-image files (e.g. PDF and text files) on paste and prevents default text insertion", async () => {
-    render(<ChatWidget id="test-chat" />);
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-
-    const pdfFile = new File(["dummy pdf content"], "sample.pdf", { type: "application/pdf" });
-    const textFile = new File(["line1\nline2\nline3"], "notes.txt", { type: "text/plain" });
-
-    const pasteEvent = {
-      clipboardData: {
-        files: [pdfFile, textFile],
-        items: [],
-      },
-    };
-
-    fireEvent.paste(textarea, pasteEvent);
-
-    await waitFor(() => {
-      expect(screen.getByTitle("sample.pdf")).toBeInTheDocument();
-      expect(screen.getByText("notes.txt")).toBeInTheDocument();
-      expect(screen.getByText("PDF")).toBeInTheDocument();
-      expect(screen.getByText("TXT")).toBeInTheDocument();
-    });
-  });
-
-  it("supports dragging and dropping files onto chat input container with drag styling", async () => {
-    const { container } = render(<ChatWidget id="test-chat" />);
-    const inputBox = container.querySelector(".chat-input-box")!;
-    expect(inputBox).toBeInTheDocument();
-
-    // Drag enter
-    fireEvent.dragEnter(inputBox, {
-      dataTransfer: { dropEffect: "none" },
-    });
-    expect(inputBox).toHaveClass("dragging");
-
-    // Drag leave
-    fireEvent.dragLeave(inputBox);
-    expect(inputBox).not.toHaveClass("dragging");
-
-    // Drag over
-    fireEvent.dragOver(inputBox, {
-      dataTransfer: { dropEffect: "none" },
-    });
-    expect(inputBox).toHaveClass("dragging");
-
-    // Drop file
-    const droppedFile = new File(["test data"], "report.docx", { type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" });
-    fireEvent.drop(inputBox, {
-      dataTransfer: { files: [droppedFile] },
-    });
-    expect(inputBox).not.toHaveClass("dragging");
-
-    await waitFor(() => {
-      expect(screen.getByText("report.docx")).toBeInTheDocument();
-      expect(screen.getByText("DOCX")).toBeInTheDocument();
-    });
-  });
-
-  it("activates dragging state and renders drop overlay when dragging over the root widget or message area", () => {
-    const { container } = render(<ChatWidget id="test-chat" />);
-    const root = container.querySelector(".chat-widget-root")!;
-    expect(root).toBeInTheDocument();
-
-    // Drag enter on root
-    fireEvent.dragEnter(root, {
-      dataTransfer: { dropEffect: "none" },
-    });
-    expect(root).toHaveClass("dragging");
-    expect(screen.getByText("Drop files here to attach to message")).toBeInTheDocument();
-
-    // Drag leave on root
-    fireEvent.dragLeave(root);
-    expect(root).not.toHaveClass("dragging");
-    expect(screen.queryByText("Drop files here to attach to message")).not.toBeInTheDocument();
-
-    // Drag over messages container activates overlay
-    const messagesArea = container.querySelector(".chat-thread") || root;
-    fireEvent.dragEnter(messagesArea, {
-      dataTransfer: { dropEffect: "none" },
-    });
-    expect(root).toHaveClass("dragging");
-    expect(screen.getByText("Drop files here to attach to message")).toBeInTheDocument();
-  });
-
-  it("supports dropping a file anywhere on the chat widget to add attachment", async () => {
-    const { container } = render(<ChatWidget id="test-chat" />);
-    const root = container.querySelector(".chat-widget-root")!;
-    const messagesArea = container.querySelector(".chat-thread") || root;
-
-    // Drag over chat area
-    fireEvent.dragEnter(messagesArea, {
-      dataTransfer: { dropEffect: "none" },
-    });
-    expect(root).toHaveClass("dragging");
-
-    // Drop file on messages area
-    const droppedFile = new File(["test docx content"], "specs.docx", { type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" });
-    fireEvent.drop(messagesArea, {
-      dataTransfer: { files: [droppedFile] },
-    });
-    expect(root).not.toHaveClass("dragging");
-    expect(screen.queryByText("Drop files here to attach to message")).not.toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(screen.getByText("specs.docx")).toBeInTheDocument();
-      expect(screen.getByText("DOCX")).toBeInTheDocument();
-    });
-  });
-
-  it("calls preventDefault on dragover and drop events to block browser file navigation", () => {
-    const { container } = render(<ChatWidget id="test-chat" />);
-    const root = container.querySelector(".chat-widget-root")!;
-
-    // Drag over root prevents default
-    const dragOverEvent = new Event("dragover", { bubbles: true, cancelable: true });
-    root.dispatchEvent(dragOverEvent);
-    expect(dragOverEvent.defaultPrevented).toBe(true);
-
-    // Drop on root prevents default
-    const dropEvent = new Event("drop", { bubbles: true, cancelable: true });
-    root.dispatchEvent(dropEvent);
-    expect(dropEvent.defaultPrevented).toBe(true);
-
-    // Window-level dragover prevents default
-    const windowDragOverEvent = new Event("dragover", { bubbles: true, cancelable: true });
-    window.dispatchEvent(windowDragOverEvent);
-    expect(windowDragOverEvent.defaultPrevented).toBe(true);
-
-    // Window-level drop prevents default
-    const windowDropEvent = new Event("drop", { bubbles: true, cancelable: true });
-    window.dispatchEvent(windowDropEvent);
-    expect(windowDropEvent.defaultPrevented).toBe(true);
-  });
-
-  it("supports removing an attached file via its thumbnail remove button", async () => {
-    render(<ChatWidget id="test-chat" />);
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-
-    const file = new File(["content"], "delete-me.txt", { type: "text/plain" });
-    fireEvent.paste(textarea, {
-      clipboardData: { files: [file], items: [] },
-      preventDefault: vi.fn(),
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("delete-me.txt")).toBeInTheDocument();
-    });
-
-    const removeBtn = screen.getByRole("button", { name: /Remove attachment/i });
-    fireEvent.click(removeBtn);
-
-    expect(screen.queryByText("delete-me.txt")).not.toBeInTheDocument();
-  });
-
-  it("includes attachments in OnSendMessage event payload", async () => {
-    const handleEvent = vi.fn();
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-1"
-        events={["OnSendMessage"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    const sendBtn = screen.getByRole("button", { name: /Send/i });
-
-    const file = new File(["hello world"], "hello.py", { type: "text/x-python" });
-    fireEvent.paste(textarea, {
-      clipboardData: { files: [file], items: [] },
-      preventDefault: vi.fn(),
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("hello.py")).toBeInTheDocument();
-    });
-
-    fireEvent.change(textarea, { target: { value: "Please review this code" } });
-    fireEvent.click(sendBtn);
-
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnSendMessage",
-      "test-chat",
-      expect.arrayContaining([
-        expect.objectContaining({
-          prompt: "Please review this code",
-          sessionId: "sess-1",
-          attachments: expect.arrayContaining([
-            expect.objectContaining({
-              name: "hello.py",
-              contentType: "text/x-python",
-            }),
-          ]),
-        }),
-      ])
-    );
-  });
-
-  it("renders user messages with attachments displaying clean badges instead of raw paths", () => {
-    const session = {
-      id: "sess-1",
-      title: "Chat with Files",
-      agentId: "antigravity",
-      modelId: "gemini-3.7-flash",
-      createdAt: "2026-08-15T12:00:00Z",
-      updatedAt: "2026-08-15T12:30:00Z",
-      messages: [
-        {
-          id: "m-1",
-          role: "user" as const,
-          content: "Here is the log file\n\n[Attached Files]:\n- /path/to/server-error.log\n- /path/to/data-export.csv",
-          timestamp: "12:00",
-        },
-      ],
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-1"
-        sessions={[session]}
-      />
-    );
-
-    expect(screen.getByText("Here is the log file")).toBeInTheDocument();
-    expect(screen.getByText("server-error.log")).toBeInTheDocument();
-    expect(screen.getByText("LOG")).toBeInTheDocument();
-    expect(screen.getByText("data-export.csv")).toBeInTheDocument();
-    expect(screen.getByText("CSV")).toBeInTheDocument();
-    expect(screen.queryByText("[Attached Files]:")).not.toBeInTheDocument();
-  });
-
-  it("renders image preview elements pointing to the /ivy/local-file endpoint for image attachments in chat history", () => {
-    const session: ChatSessionDto = {
-      id: "sess-img",
-      title: "Image Preview Test",
-      agentId: "antigravity",
-      modelId: "gemini-3.7-flash",
-      createdAt: "2026-08-15T12:00:00Z",
-      updatedAt: "2026-08-15T12:30:00Z",
-      messages: [
-        {
-          id: "m-img",
-          role: "user" as const,
-          content: "Here is a screenshot\n\n[Attached Files]:\n- /path/to/screenshot.png\n- /path/to/photo.jpg",
-          timestamp: "12:00",
-        },
-      ],
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-img"
-        sessions={[session]}
-      />
-    );
-
-    expect(screen.getByText("Here is a screenshot")).toBeInTheDocument();
-    expect(screen.getByText("screenshot.png")).toBeInTheDocument();
-    expect(screen.getByText("PNG")).toBeInTheDocument();
-    expect(screen.getByText("photo.jpg")).toBeInTheDocument();
-    expect(screen.getByText("JPG")).toBeInTheDocument();
-
-    const imgElements = screen.getAllByRole("img");
-    const previewImgs = imgElements.filter((img) =>
-      img.getAttribute("src")?.includes("/ivy/local-file?path=")
-    );
-    expect(previewImgs.length).toBe(2);
-    expect(previewImgs[0].getAttribute("src")).toContain("/ivy/local-file?path=%2Fpath%2Fto%2Fscreenshot.png");
-    expect(previewImgs[1].getAttribute("src")).toContain("/ivy/local-file?path=%2Fpath%2Fto%2Fphoto.jpg");
-  });
-
-  it("opens lightbox modal with full image view on click, and closes via Escape or close button", () => {
-    const session: ChatSessionDto = {
-      id: "sess-lightbox",
-      title: "Lightbox Test",
-      agentId: "antigravity",
-      modelId: "gemini-3.7-flash",
-      createdAt: "2026-08-15T12:00:00Z",
-      updatedAt: "2026-08-15T12:30:00Z",
-      messages: [
-        {
-          id: "m-lb",
-          role: "user" as const,
-          content: "Check this out\n\n[Attached Files]:\n- /path/to/preview.png",
-          timestamp: "12:00",
-        },
-      ],
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-lightbox"
-        sessions={[session]}
-      />
-    );
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-
-    const thumbnailCard = screen.getByText("preview.png").closest(".chat-user-attachment-card");
-    expect(thumbnailCard).toBeInTheDocument();
-    fireEvent.click(thumbnailCard!);
-
-    const modal = screen.getByRole("dialog");
-    expect(modal).toBeInTheDocument();
-    const closeBtn = screen.getByRole("button", { name: /Close preview/i });
-    expect(closeBtn).toBeInTheDocument();
-
-    // Close via close button
-    fireEvent.click(closeBtn);
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-
-    // Reopen and close via Escape
-    fireEvent.click(thumbnailCard!);
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
-    fireEvent.keyDown(window, { key: "Escape" });
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  });
-
-  it("renders PDF preview cards with PdfThumbnail for PDF attachments in chat history", () => {
-    const session: ChatSessionDto = {
-      id: "sess-pdf",
-      title: "PDF Preview Test",
-      agentId: "antigravity",
-      modelId: "gemini-3.7-flash",
-      createdAt: "2026-08-15T12:00:00Z",
-      updatedAt: "2026-08-15T12:30:00Z",
-      messages: [
-        {
-          id: "m-pdf",
-          role: "user" as const,
-          content: "Here is the report\n\n[Attached Files]:\n- /docs/specification.pdf",
-          timestamp: "12:00",
-        },
-      ],
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-pdf"
-        sessions={[session]}
-      />
-    );
-
-    expect(screen.getByText("Here is the report")).toBeInTheDocument();
-    expect(screen.getByText("specification.pdf")).toBeInTheDocument();
-    expect(screen.getByText("PDF")).toBeInTheDocument();
-
-    const pdfCard = screen.getByText("specification.pdf").closest(".chat-user-attachment-card-pdf");
-    expect(pdfCard).toBeInTheDocument();
-  });
-
-  it("submitting a message with an attached file and empty text prompt emits OnSendMessage with empty prompt", async () => {
-    const handleEvent = vi.fn();
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-1"
-        events={["OnSendMessage"]}
-        eventHandler={handleEvent}
-      />
-    );
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    const sendBtn = screen.getByRole("button", { name: /Send/i });
-
-    // Initially disabled when empty and no attachments
-    expect(sendBtn).toBeDisabled();
-
-    const imageFile = new File(["dummy-image-bytes"], "screenshot.png", { type: "image/png" });
-    fireEvent.paste(textarea, {
-      clipboardData: { files: [imageFile], items: [] },
-      preventDefault: vi.fn(),
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTitle("screenshot.png")).toBeInTheDocument();
-    });
-
-    // Send button should be enabled even without prompt text
-    expect(sendBtn).not.toBeDisabled();
-    fireEvent.click(sendBtn);
-
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnSendMessage",
-      "test-chat",
-      expect.arrayContaining([
-        expect.objectContaining({
-          prompt: "",
-          sessionId: "sess-1",
-          attachments: expect.arrayContaining([
-            expect.objectContaining({
-              name: "screenshot.png",
-              contentType: "image/png",
-            }),
-          ]),
-        }),
-      ])
-    );
-  });
-
-  it("displays payload size warning banner and disables Send button when attachments exceed 50 MB", async () => {
-    render(<ChatWidget id="test-chat" />);
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    const sendBtn = screen.getByRole("button", { name: /Send/i });
-
-    // Create a 51 MB dummy file
-    const largeFile = new File(["x"], "large-dataset.bin", { type: "application/octet-stream" });
-    Object.defineProperty(largeFile, "size", { value: 51 * 1024 * 1024 });
-
-    fireEvent.paste(textarea, {
-      clipboardData: { files: [largeFile], items: [] },
-      preventDefault: vi.fn(),
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("large-dataset.bin")).toBeInTheDocument();
-    });
-
-    // Warning banner is displayed
-    const warning = screen.getByRole("alert");
-    expect(warning).toBeInTheDocument();
-    expect(warning).toHaveTextContent(/Attachments exceed the 50 MB limit/i);
-
-    // Send button is disabled due to oversized payload
-    expect(sendBtn).toBeDisabled();
-    expect(sendBtn).toHaveAttribute("title", "Attachments exceed the 50 MB limit");
-  });
-
-  it("uploads files via HTTP multipart POST when uploadUrl is provided and sends metadata without base64", async () => {
-    const handleEvent = vi.fn();
-    let capturedXhr: any = null;
-
-    class MockXMLHttpRequest {
-      open = vi.fn();
-      send = vi.fn();
-      upload = { onprogress: null as any };
-      onload: any = null;
-      onerror: any = null;
-      status = 200;
-      constructor() {
-        capturedXhr = this;
-      }
-    }
-
-    const origXHR = window.XMLHttpRequest;
-    (window as any).XMLHttpRequest = MockXMLHttpRequest;
-
-    try {
-      render(
-        <ChatWidget
-          id="test-chat"
-          activeSessionId="sess-1"
-          uploadUrl="/ivy/upload/conn-1/up-1"
-          events={["OnSendMessage"]}
-          eventHandler={handleEvent}
-        />
-      );
-
-      const textarea = screen.getByPlaceholderText(/Ask/i);
-      const sendBtn = screen.getByRole("button", { name: /Send/i });
-
-      const file = new File(["test-image-content"], "photo.png", { type: "image/png" });
-      fireEvent.paste(textarea, {
-        clipboardData: { files: [file], items: [] },
-        preventDefault: vi.fn(),
-      });
-
-      await waitFor(() => {
-        expect(capturedXhr).not.toBeNull();
-        expect(capturedXhr.open).toHaveBeenCalledWith("POST", "/ivy/upload/conn-1/up-1", true);
-        expect(capturedXhr.send).toHaveBeenCalledWith(expect.any(FormData));
-      });
-
-      // While uploading, send button should be disabled
-      expect(sendBtn).toBeDisabled();
-
-      // Complete the upload
-      capturedXhr.status = 200;
-      capturedXhr.onload();
-
-      await waitFor(() => {
-        expect(sendBtn).not.toBeDisabled();
-      });
-
-      fireEvent.change(textarea, { target: { value: "Look at this photo" } });
-      fireEvent.click(sendBtn);
-
-      expect(handleEvent).toHaveBeenCalledWith(
-        "OnSendMessage",
-        "test-chat",
-        expect.arrayContaining([
-          expect.objectContaining({
-            prompt: "Look at this photo",
-            sessionId: "sess-1",
-            attachments: expect.arrayContaining([
-              expect.objectContaining({
-                name: "photo.png",
-                contentType: "image/png",
-                base64Data: undefined,
-              }),
-            ]),
-          }),
-        ])
-      );
-    } finally {
-      window.XMLHttpRequest = origXHR;
-    }
-  });
-
-  it("displays upload progress and failure state on HTTP upload error", async () => {
-    let capturedXhr: any = null;
-
-    class MockXMLHttpRequest {
-      open = vi.fn();
-      send = vi.fn();
-      upload = { onprogress: null as any };
-      onload: any = null;
-      onerror: any = null;
-      status = 500;
-      constructor() {
-        capturedXhr = this;
-      }
-    }
-
-    const origXHR = window.XMLHttpRequest;
-    (window as any).XMLHttpRequest = MockXMLHttpRequest;
-
-    try {
-      render(
-        <ChatWidget
-          id="test-chat"
-          activeSessionId="sess-1"
-          uploadUrl="/ivy/upload/conn-1/up-1"
-        />
-      );
-
-      const textarea = screen.getByPlaceholderText(/Ask/i);
-      const sendBtn = screen.getByRole("button", { name: /Send/i });
-
-      const file = new File(["sample data"], "data.csv", { type: "text/csv" });
-      fireEvent.paste(textarea, {
-        clipboardData: { files: [file], items: [] },
-        preventDefault: vi.fn(),
-      });
-
-      await waitFor(() => {
-        expect(capturedXhr).not.toBeNull();
-      });
-
-      // Trigger progress
-      capturedXhr.upload.onprogress?.({ lengthComputable: true, loaded: 50, total: 100 });
-
-      await waitFor(() => {
-        expect(screen.getByText("50%")).toBeInTheDocument();
-      });
-
-      // Trigger failure
-      capturedXhr.status = 500;
-      capturedXhr.onload();
-
-      await waitFor(() => {
-        expect(screen.getByText("Failed")).toBeInTheDocument();
-      });
-
-      // Send button remains disabled when there is no text or valid finished attachments
-      expect(sendBtn).toBeDisabled();
-    } finally {
-      window.XMLHttpRequest = origXHR;
-    }
-  });
-
-  it("handles 20MB large image upload without crashing and downscales before uploading", async () => {
-    let capturedXhr: any = null;
-
-    class MockXMLHttpRequest {
-      open = vi.fn();
-      send = vi.fn();
-      upload = { onprogress: null as any };
-      onload: any = null;
-      onerror: any = null;
-      status = 200;
-      constructor() {
-        capturedXhr = this;
-      }
-    }
-
-    const origXHR = window.XMLHttpRequest;
-    (window as any).XMLHttpRequest = MockXMLHttpRequest;
-
-    try {
-      render(
-        <ChatWidget
-          id="test-chat"
-          activeSessionId="sess-1"
-          uploadUrl="/ivy/upload/test"
-        />
-      );
-
-      const textarea = screen.getByPlaceholderText(/Ask/i);
-      const sendBtn = screen.getByRole("button", { name: /Send/i });
-
-      const largeImage = new File(["dummy-data"], "large-photo.jpg", { type: "image/jpeg" });
-      Object.defineProperty(largeImage, "size", { value: 20 * 1024 * 1024 });
-
-      fireEvent.paste(textarea, {
-        clipboardData: { files: [largeImage], items: [] },
-        preventDefault: vi.fn(),
-      });
-
-      await waitFor(() => {
-        expect(capturedXhr).not.toBeNull();
-        expect(capturedXhr.open).toHaveBeenCalledWith("POST", "/ivy/upload/test", true);
-      });
-
-      capturedXhr.status = 200;
-      capturedXhr.onload();
-
-      await waitFor(() => {
-        expect(sendBtn).not.toBeDisabled();
-      });
-    } finally {
-      window.XMLHttpRequest = origXHR;
-    }
-  });
-
-  it("optimistically displays user message immediately upon clicking Send", async () => {
-    const handleEvent = vi.fn();
-    const session = {
-      id: "sess-empty",
-      title: "New Chat",
-      agentId: "codex",
-      modelId: "gpt-5.6-sol",
-      createdAt: "2026-09-03T10:00:00Z",
-      updatedAt: "2026-09-03T10:00:00Z",
-      messages: [],
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-empty"
-        sessions={[session]}
-        eventHandler={handleEvent}
-        events={["OnSendMessage"]}
-      />
-    );
-
-    expect(screen.getByText("What Are We Producing Today?")).toBeInTheDocument();
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    fireEvent.change(textarea, { target: { value: "test. Alive?" } });
-
-    const sendBtn = screen.getByRole("button", { name: /Send/i });
-    fireEvent.click(sendBtn);
-
-    expect(handleEvent).toHaveBeenCalledWith("OnSendMessage", "test-chat", [
-      { prompt: "test. Alive?", attachments: [], sessionId: "sess-empty" },
-    ]);
-
-    // Optimistic message should appear immediately without waiting for props update!
-    expect(screen.getByText("test. Alive?")).toBeInTheDocument();
-    expect(screen.queryByText("What Are We Producing Today?")).not.toBeInTheDocument();
-  });
-
-  it("optimistically displays assistant Starting status and switches Send button to Stop/Queue immediately upon clicking Send", async () => {
-    const handleEvent = vi.fn();
-    const session = {
-      id: "sess-1",
-      title: "Active Chat",
-      agentId: "codex",
-      modelId: "gpt-5.6-sol",
-      createdAt: "2026-09-03T10:00:00Z",
-      updatedAt: "2026-09-03T10:00:00Z",
-      messages: [],
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-1"
-        selectedAgent="codex"
-        sessions={[session]}
-        eventHandler={handleEvent}
-        events={["OnSendMessage", "OnCancelStream"]}
-      />
-    );
-
-    const textarea = screen.getByPlaceholderText(/Ask/i);
-    fireEvent.change(textarea, { target: { value: "retry again" } });
-
-    const sendBtn = screen.getByRole("button", { name: /Send/i });
-    expect(sendBtn).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Stop/i })).not.toBeInTheDocument();
-
-    fireEvent.click(sendBtn);
-
-    // Immediately shows Stop and Queue buttons without waiting for server props
-    expect(screen.getByRole("button", { name: /Stop/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Queue/i })).toBeInTheDocument();
-
-    // Immediately shows the Thinking status indicator
-    expect(screen.getByText("Thinking")).toBeInTheDocument();
-
-    // Clicking Stop cancels optimistic stream
-    const stopBtn = screen.getByRole("button", { name: /Stop/i });
-    fireEvent.click(stopBtn);
-    expect(handleEvent).toHaveBeenCalledWith("OnCancelStream", "test-chat", []);
-    expect(screen.queryByRole("button", { name: /Stop/i })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Send/i })).toBeInTheDocument();
-  });
-
-  it("displays spawned jobs in header badge and emits OnSendMessage when reviewing outcomes from dropdown", () => {
-    const handleEvent = vi.fn();
-    const session: ChatSessionDto = {
-      id: "sess-jobs",
-      title: "Jobs Chat",
-      agentId: "claude",
-      modelId: "opus",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      messages: [],
-      spawnedJobs: [
-        {
-          id: "job-101",
-          type: "plan",
-          status: "Completed",
-          planTitle: "Add OAuth2 authentication",
-        },
-      ],
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-jobs"
-        sessions={[session]}
-        eventHandler={handleEvent}
-        events={["OnSendMessage"]}
-      />
-    );
-
-    // Banner directly above chat is removed
-    expect(screen.queryByText(/Spawned Jobs \(/i)).not.toBeInTheDocument();
-
-    // Header badge is displayed
-    const badgeBtn = screen.getByRole("button", { name: /View running jobs/i });
-    expect(badgeBtn).toBeInTheDocument();
-    expect(within(badgeBtn).getByText(/1 job/i)).toBeInTheDocument();
-
-    // Open dropdown by clicking badge
-    fireEvent.click(badgeBtn);
-
-    expect(screen.getByText(/Spawned Jobs/i)).toBeInTheDocument();
-    expect(screen.getByText(/1 completed/i)).toBeInTheDocument();
-    expect(screen.getByText("Add OAuth2 authentication")).toBeInTheDocument();
-
-    const reviewBtn = screen.getByRole("button", { name: /Ask agent to review outcomes/i });
-    expect(reviewBtn).toBeInTheDocument();
-
-    fireEvent.click(reviewBtn);
-
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnSendMessage",
-      "test-chat",
-      expect.arrayContaining([
-        expect.objectContaining({
-          prompt: expect.stringContaining("All spawned jobs have completed"),
-          sessionId: "sess-jobs",
-        }),
-      ])
-    );
-  });
-
-  it("renders interactive questions in chat message and emits OnAnswerQuestion when user submits response", async () => {
-    const handleEvent = vi.fn();
-    const session: ChatSessionDto = {
-      id: "sess-q",
-      title: "Questions Chat",
-      agentId: "claude",
-      modelId: "opus",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      messages: [
-        {
-          id: "msg-q1",
-          role: "assistant",
-          content: [
-            "Please confirm your choices below:",
-            "```questions",
-            "- id: deploy_target",
-            "  title: Which environment should we deploy to?",
-            "  options:",
-            "    - title: Staging Environment",
-            "      value: staging",
-            "    - title: Production Environment",
-            "      value: prod",
-            "```",
-          ].join("\n"),
-          timestamp: "12:00 PM",
-        },
-      ],
-    };
-
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-q"
-        sessions={[session]}
-        eventHandler={handleEvent}
-        events={["OnAnswerQuestion"]}
-      />
-    );
-
-    expect(screen.getByText("Which environment should we deploy to?")).toBeInTheDocument();
-    expect(screen.getByText("Staging Environment")).toBeInTheDocument();
-    expect(screen.getByText("Production Environment")).toBeInTheDocument();
-
-    const submitBtn = screen.getByRole("button", { name: /Submit Response/i });
-    expect(submitBtn).toBeDisabled();
-
-    // Select Staging Environment option
-    const stagingRadio = screen.getByRole("radio", { name: /Staging Environment/i });
-    fireEvent.click(stagingRadio);
-
-    // Submit button should now be enabled
-    expect(submitBtn).not.toBeDisabled();
-
-    fireEvent.click(submitBtn);
-
-    expect(handleEvent).toHaveBeenCalledWith(
-      "OnAnswerQuestion",
-      "test-chat",
-      expect.arrayContaining([
-        expect.objectContaining({
-          sessionId: "sess-q",
-          messageId: "msg-q1",
-          answers: { deploy_target: ["staging"] },
-          responseText: expect.stringContaining("Staging Environment"),
-        }),
-      ])
-    );
-  });
-
-  it("renders running jobs header badge and toggles dropdown on click", async () => {
-    const session: ChatSessionDto = {
-      id: "sess-running",
-      title: "Active Job Session",
-      agentId: "antigravity",
-      modelId: "gemini-3.8-flash",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      messages: [],
-      spawnedJobs: [
-        {
-          id: "00148",
-          type: "CreatePlan",
-          status: "Running",
-          planTitle: "Test job tracking",
-          statusMessage: "Researching architecture...",
-        },
-      ],
-    };
-
-    const { container } = render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-running"
-        sessions={[session]}
-      />
-    );
-
-    // Header badge displays running count
-    const badgeBtn = screen.getByRole("button", { name: /View running jobs/i });
-    expect(badgeBtn).toBeInTheDocument();
-    expect(within(badgeBtn).getByText(/1 running/i)).toBeInTheDocument();
-
-    // Click badge to open dropdown
-    fireEvent.click(badgeBtn);
-
-    // Dropdown is open and displays job item details
-    const dropdown = container.querySelector(".chat-jobs-dropdown-menu") as HTMLElement;
-    expect(dropdown).toBeInTheDocument();
-    expect(within(dropdown).getByText("00148")).toBeInTheDocument();
-    expect(within(dropdown).getByText("CreatePlan")).toBeInTheDocument();
-    expect(within(dropdown).getByText("Researching architecture...")).toBeInTheDocument();
-  });
-
-  it("renders system event messages in chat timeline", async () => {
-    const session: ChatSessionDto = {
-      id: "sess-sys",
-      title: "System Notification Session",
-      agentId: "antigravity",
-      modelId: "gemini-3.8-flash",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      messages: [
-        {
-          id: "msg-sys-1",
-          role: "system",
-          content: "Job 00148 (CreatePlan) has completed successfully.",
-          timestamp: "10:00 AM",
-        },
-        {
-          id: "msg-ast-1",
-          role: "assistant",
-          content: "I reviewed the plan and it looks great!",
-          timestamp: "10:01 AM",
-        },
-      ],
-    };
-
-    const { container } = render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-sys"
-        sessions={[session]}
-      />
-    );
-
-    const systemRow = container.querySelector(".chat-system-event-row");
-    expect(systemRow).toBeInTheDocument();
-    expect(screen.getByText("Job 00148 (CreatePlan) has completed successfully.")).toBeInTheDocument();
-    expect(screen.getByText("I reviewed the plan and it looks great!")).toBeInTheDocument();
-  });
-});
-
-describe("ChatWidget Interactive Question Draft Persistence", () => {
-  beforeEach(() => {
-    window.ResizeObserver = class {
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    } as any;
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
-  });
-
-  const questionsFence = (...lines: string[]) => ["```questions", ...lines, "```"].join("\n");
-
-  const deployQuestion = questionsFence(
-    "- id: deploy_target",
-    "  title: Which environment should we deploy to?",
-    "  options:",
-    "    - title: Staging Environment",
-    "      value: staging",
-    "    - title: Production Environment",
-    "      value: prod",
-  );
-
-  const deployQuestionWithOther = questionsFence(
-    "- id: deploy_target",
-    "  title: Which environment should we deploy to?",
-    "  other: true",
-    "  options:",
-    "    - title: Staging Environment",
-    "      value: staging",
-    "    - title: Production Environment",
-    "      value: prod",
-  );
-
-  const freeTextQuestion = questionsFence("- id: comment", "  title: Anything else?");
-
-  const twoBlockMessage = [
-    "First block:",
-    questionsFence(
-      "- id: color",
-      "  title: Favorite color?",
-      "  options:",
-      "    - title: Red",
-      "      value: red",
-      "    - title: Blue",
-      "      value: blue",
-    ),
-    "Second block:",
-    questionsFence(
-      "- id: size",
-      "  title: Favorite size?",
-      "  options:",
-      "    - title: Small",
-      "      value: small",
-      "    - title: Large",
-      "      value: large",
-    ),
-  ].join("\n\n");
-
-  const sessionWith = (id: string, content: string): ChatSessionDto => ({
-    id,
-    title: id,
-    agentId: "claude",
-    modelId: "opus",
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    messages: [
-      {
-        id: `${id}-msg`,
-        role: "assistant",
-        content,
-        timestamp: "12:00 PM",
-      },
-    ],
-  });
-
-  it("keeps a selection through a streamVersion re-render (streaming chunk arriving)", () => {
-    const session = sessionWith("sess-stream", deployQuestion);
-
-    const { rerender } = render(
-      <ChatWidget id="test-chat" activeSessionId="sess-stream" sessions={[session]} events={["OnAnswerQuestion"]} />
-    );
-
-    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
-    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
-
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-stream"
-        sessions={[session]}
-        events={["OnAnswerQuestion"]}
-        isStreaming
-        streamingText='{"kind":"text","text":"Working on it...","delta":false}'
-      />
-    );
-
-    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
-    expect(screen.getByRole("button", { name: /Submit Response/i })).not.toBeDisabled();
-  });
-
-  it("never remounts the callout's input across a streamVersion re-render", () => {
-    const session = sessionWith("sess-remount", freeTextQuestion);
-
-    const { rerender } = render(
-      <ChatWidget id="test-chat" activeSessionId="sess-remount" sessions={[session]} events={["OnAnswerQuestion"]} />
-    );
-
-    const inputBefore = screen.getByPlaceholderText("Type your answer");
-
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-remount"
-        sessions={[session]}
-        events={["OnAnswerQuestion"]}
-        isStreaming
-        streamingText='{"kind":"text","text":"Still working...","delta":false}'
-      />
-    );
-
-    expect(screen.getByPlaceholderText("Type your answer")).toBe(inputBefore);
-  });
-
-  it("keeps typed Other text and focus through a sessionVersion re-render (runningJobs change)", () => {
-    const session = sessionWith("sess-other", deployQuestionWithOther);
-
-    const { rerender } = render(
-      <ChatWidget id="test-chat" activeSessionId="sess-other" sessions={[session]} events={["OnAnswerQuestion"]} />
-    );
-
-    fireEvent.click(screen.getByRole("radio", { name: /^Other$/i }));
-    const otherInput = screen.getByPlaceholderText("Type your answer");
-    otherInput.focus();
-    fireEvent.change(otherInput, { target: { value: "A canary environment" } });
-    expect(otherInput).toHaveValue("A canary environment");
-
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-other"
-        sessions={[session]}
-        events={["OnAnswerQuestion"]}
-        runningJobs={[{ id: "job-1", type: "ExecutePlan", status: "Running" }]}
-      />
-    );
-
-    const otherInputAfter = screen.getByPlaceholderText("Type your answer");
-    expect(otherInputAfter).toBe(otherInput);
-    expect(otherInputAfter).toHaveValue("A canary environment");
-    expect(document.activeElement).toBe(otherInputAfter);
-  });
-
-  it("restores a selection from the draft store after a real remount (switching sessions and back)", () => {
-    const sessionA = sessionWith("sess-a", deployQuestion);
-    const sessionB = sessionWith("sess-b", "Just a plain message, no questions here.");
-
-    const { rerender } = render(
-      <ChatWidget id="test-chat" activeSessionId="sess-a" sessions={[sessionA, sessionB]} events={["OnAnswerQuestion"]} />
-    );
-
-    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
-    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
-
-    rerender(
-      <ChatWidget id="test-chat" activeSessionId="sess-b" sessions={[sessionA, sessionB]} events={["OnAnswerQuestion"]} />
-    );
-    expect(screen.queryByRole("radio", { name: /Staging Environment/i })).toBeNull();
-
-    rerender(
-      <ChatWidget id="test-chat" activeSessionId="sess-a" sessions={[sessionA, sessionB]} events={["OnAnswerQuestion"]} />
-    );
-
-    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
-  });
-
-  it("clears the draft on submit, so a later remount starts empty rather than re-offering the old selection", () => {
-    const sessionA = sessionWith("sess-a", deployQuestion);
-    const sessionB = sessionWith("sess-b", "Just a plain message, no questions here.");
-    const handleEvent = vi.fn();
-
-    const { rerender } = render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-a"
-        sessions={[sessionA, sessionB]}
-        eventHandler={handleEvent}
-        events={["OnAnswerQuestion"]}
-      />
-    );
-
-    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
-    fireEvent.click(screen.getByRole("button", { name: /Submit Response/i }));
-    expect(handleEvent).toHaveBeenCalled();
-
-    // Switch away and back to force a remount of the message row.
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-b"
-        sessions={[sessionA, sessionB]}
-        eventHandler={handleEvent}
-        events={["OnAnswerQuestion"]}
-      />
-    );
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-a"
-        sessions={[sessionA, sessionB]}
-        eventHandler={handleEvent}
-        events={["OnAnswerQuestion"]}
-      />
-    );
-
-    expect(screen.getByRole("radio", { name: /Staging Environment/i })).not.toBeChecked();
-    expect(screen.getByRole("button", { name: /Submit Response/i })).toBeDisabled();
-  });
-
-  it("keeps two question blocks in one message independent when only one is answered", () => {
-    const session = sessionWith("sess-two-blocks", twoBlockMessage);
-
-    const { rerender } = render(
-      <ChatWidget id="test-chat" activeSessionId="sess-two-blocks" sessions={[session]} events={["OnAnswerQuestion"]} />
-    );
-
-    fireEvent.click(screen.getByRole("radio", { name: /^Red$/i }));
-    expect(screen.getByRole("radio", { name: /^Red$/i })).toBeChecked();
-    expect(screen.getByRole("radio", { name: /^Small$/i })).not.toBeChecked();
-
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-two-blocks"
-        sessions={[session]}
-        events={["OnAnswerQuestion"]}
-        isStreaming
-        streamingText='{"kind":"text","text":"Working...","delta":false}'
-      />
-    );
-
-    expect(screen.getByRole("radio", { name: /^Red$/i })).toBeChecked();
-    expect(screen.getByRole("radio", { name: /^Small$/i })).not.toBeChecked();
-  });
-
-  it("keeps a selection made inside a rawStream-rendered questions block through a re-render", () => {
-    const rawStream = JSON.stringify({ kind: "text", text: deployQuestion, delta: false });
-    const session: ChatSessionDto = {
-      id: "sess-raw",
-      title: "Raw Stream Chat",
-      agentId: "claude",
-      modelId: "opus",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      messages: [
-        {
-          id: "msg-raw",
-          role: "assistant",
-          content: "",
-          rawStream,
-          timestamp: "12:00 PM",
-        },
-      ],
-    };
-
-    const { rerender } = render(
-      <ChatWidget id="test-chat" activeSessionId="sess-raw" sessions={[session]} events={["OnAnswerQuestion"]} />
-    );
-
-    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
-    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
-
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-raw"
-        sessions={[session]}
-        events={["OnAnswerQuestion"]}
-        runningJobs={[{ id: "job-2", type: "ExecutePlan", status: "Running" }]}
-      />
-    );
-
-    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
-  });
-});
-
-describe("ChatWidget Streaming Scroll Behavior", () => {
-  const session = {
-    id: "sess-scroll",
-    title: "Scroll Test Chat",
-    agentId: "codex",
-    modelId: "gpt-5",
-    createdAt: "2026-09-03T10:00:00Z",
-    updatedAt: "2026-09-03T10:00:00Z",
-    messages: [
-      {
-        id: "m-1",
-        role: "user" as const,
-        content: "Explain markdown streaming",
-        timestamp: "10:00 AM",
-      },
-    ],
-  };
-
-  it("scrolls to bottom without triggering continuous smooth scroll calls when container is at bottom", () => {
-    const scrollIntoViewMock = vi.fn();
-    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
-
-    const { rerender } = render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-scroll"
-        sessions={[session]}
-        isStreaming={true}
-        streamingText='{"type":"text_delta","content":"First chunk"}'
-      />
-    );
-
-    const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
-    expect(container).toBeInTheDocument();
-
-    let currentScrollTop = 600;
-    Object.defineProperty(container, "scrollHeight", { value: 1000, configurable: true, writable: true });
-    Object.defineProperty(container, "clientHeight", { value: 400, configurable: true, writable: true });
-    Object.defineProperty(container, "scrollTop", {
-      get: () => currentScrollTop,
-      set: (v: number) => { currentScrollTop = v; },
-      configurable: true,
-    });
-
-    // Reset any initial scrollIntoView calls from mount
-    scrollIntoViewMock.mockClear();
-
-    // Stream next chunk
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-scroll"
-        sessions={[session]}
-        isStreaming={true}
-        streamingText='{"type":"text_delta","content":"First chunk and second chunk"}'
-      />
-    );
-
-    // Should update scrollTop to bottom (1000 - 400 = 600) instantly without calling scrollIntoView smooth
-    expect(scrollIntoViewMock).not.toHaveBeenCalled();
-    expect(currentScrollTop).toBe(600);
-  });
-
-  it("does not force scroll down when user is scrolled up", () => {
-    const { rerender } = render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-scroll"
-        sessions={[session]}
-        isStreaming={true}
-        streamingText='{"type":"text_delta","content":"Initial streaming"}'
-      />
-    );
-
-    const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
-    let currentScrollTop = 600;
-    Object.defineProperty(container, "scrollHeight", { value: 1000, configurable: true, writable: true });
-    Object.defineProperty(container, "clientHeight", { value: 400, configurable: true, writable: true });
-    Object.defineProperty(container, "scrollTop", {
-      get: () => currentScrollTop,
-      set: (v: number) => { currentScrollTop = v; },
-      configurable: true,
-    });
-
-    // User scrolls up to 200px (distance to bottom is 1000 - 200 - 400 = 400px > 50px threshold)
-    currentScrollTop = 200;
-    fireEvent.scroll(container);
-
-    // New stream chunk arrives
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-scroll"
-        sessions={[session]}
-        isStreaming={true}
-        streamingText='{"type":"text_delta","content":"Initial streaming with more tokens"}'
-      />
-    );
-
-    // Container should remain at user scroll offset (200px) and not be forced down
-    expect(currentScrollTop).toBe(200);
-  });
-
-  it("re-enables auto-scroll when user scrolls back to bottom", () => {
-    const { rerender } = render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-scroll"
-        sessions={[session]}
-        isStreaming={true}
-        streamingText='{"type":"text_delta","content":"Starting stream"}'
-      />
-    );
-
-    const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
-    let currentScrollTop = 600;
-    let height = 1000;
-    Object.defineProperty(container, "scrollHeight", {
-      get: () => height,
-      set: (v: number) => { height = v; },
-      configurable: true,
-    });
-    Object.defineProperty(container, "clientHeight", { value: 400, configurable: true, writable: true });
-    Object.defineProperty(container, "scrollTop", {
-      get: () => currentScrollTop,
-      set: (v: number) => { currentScrollTop = v; },
-      configurable: true,
-    });
-
-    // User scrolls up
-    currentScrollTop = 150;
-    fireEvent.scroll(container);
-
-    // New chunk while scrolled up: stays at 150
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-scroll"
-        sessions={[session]}
-        isStreaming={true}
-        streamingText='{"type":"text_delta","content":"Starting stream..."}'
-      />
-    );
-    expect(currentScrollTop).toBe(150);
-
-    // User scrolls back near bottom: 580px (1000 - 580 - 400 = 20px <= 50px threshold)
-    currentScrollTop = 580;
-    fireEvent.scroll(container);
-
-    // Height increases with new tokens
-    height = 1200;
-    rerender(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-scroll"
-        sessions={[session]}
-        isStreaming={true}
-        streamingText='{"type":"text_delta","content":"Starting stream... more tokens generated"}'
-      />
-    );
-
-    // Auto-scroll is re-enabled and pins to bottom (1200 - 400 = 800)
-    expect(currentScrollTop).toBe(800);
-  });
-});
+import { setupChatWidgetTestEnvironment } from "./ChatWidget.testUtils";
 
 describe("ChatWidget Running Jobs Badge and Spinner", () => {
   beforeEach(() => {
-    window.ResizeObserver = class {
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    } as any;
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    setupChatWidgetTestEnvironment();
   });
 
   it("renders running jobs badge indicator, .spin loader, and .chat-jobs-pulse-dot when runningJobs has active jobs", () => {
@@ -1818,7 +30,7 @@ describe("ChatWidget Running Jobs Badge and Spinner", () => {
         activeSessionId="sess-0"
         sessions={[session]}
         runningJobs={runningJobs}
-      />
+      />,
     );
 
     const badge = screen.getByRole("button", { name: /View running jobs/i });
@@ -1847,13 +59,7 @@ describe("ChatWidget Running Jobs Badge and Spinner", () => {
       ],
     };
 
-    render(
-      <ChatWidget
-        id="test-chat"
-        activeSessionId="sess-1"
-        sessions={[session]}
-      />
-    );
+    render(<ChatWidget id="test-chat" activeSessionId="sess-1" sessions={[session]} />);
 
     const badge = screen.getByRole("button", { name: /View running jobs/i });
     expect(badge).toBeInTheDocument();
@@ -1887,7 +93,7 @@ describe("ChatWidget Running Jobs Badge and Spinner", () => {
         activeSessionId="sess-order"
         sessions={[session]}
         runningJobs={runningJobs}
-      />
+      />,
     );
 
     const badge = screen.getByRole("button", { name: /View running jobs/i });
@@ -1904,21 +110,18 @@ describe("ChatWidget Running Jobs Badge and Spinner", () => {
     expect(actionsContainer).toContainElement(newChatBtn);
     expect(actionsContainer).toContainElement(chatOptionsBtn);
 
-    expect(badge.compareDocumentPosition(newChatBtn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(newChatBtn.compareDocumentPosition(chatOptionsBtn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      badge.compareDocumentPosition(newChatBtn) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      newChatBtn.compareDocumentPosition(chatOptionsBtn) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });
 
-
-
 describe("ChatWidget redesign", () => {
   beforeEach(() => {
-    window.ResizeObserver = class {
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    } as any;
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    setupChatWidgetTestEnvironment();
   });
 
   const baseSession = (overrides: Partial<ChatSessionDto>): ChatSessionDto => ({
@@ -1943,7 +146,7 @@ describe("ChatWidget redesign", () => {
         sessions={[baseSession({})]}
         events={["OnRenameSession"]}
         eventHandler={handleEvent}
-      />
+      />,
     );
 
     expect(screen.getByRole("heading", { name: "Redesign Chat" })).toBeInTheDocument();
@@ -1954,7 +157,9 @@ describe("ChatWidget redesign", () => {
     fireEvent.change(input, { target: { value: "Dark mode toggle" } });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(handleEvent).toHaveBeenCalledWith("OnRenameSession", "test-chat", [["sess-redesign", "Dark mode toggle"]]);
+    expect(handleEvent).toHaveBeenCalledWith("OnRenameSession", "test-chat", [
+      ["sess-redesign", "Dark mode toggle"],
+    ]);
     expect(screen.getByRole("heading", { name: "Dark mode toggle" })).toBeInTheDocument();
   });
 
@@ -1966,13 +171,105 @@ describe("ChatWidget redesign", () => {
     expect(handleEvent).toHaveBeenCalledWith("OnCreateSession", "test-chat", []);
   });
 
+  it("offers Delete chat in the header options menu and emits OnDeleteSession upon click", () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-123",
+      title: "My Great Chat",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-123"
+        sessions={[session]}
+        events={["OnDeleteSession"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    expect(screen.queryByRole("menuitem", { name: /Delete chat/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Chat options/i }));
+
+    const deleteBtn = screen.getByRole("menuitem", { name: /Delete chat/i });
+    expect(deleteBtn).toBeInTheDocument();
+
+    fireEvent.click(deleteBtn);
+    expect(screen.queryByRole("menuitem", { name: /Delete chat/i })).not.toBeInTheDocument();
+
+    expect(handleEvent).toHaveBeenCalledTimes(1);
+    expect(handleEvent).toHaveBeenCalledWith("OnDeleteSession", "test-chat", ["sess-123"]);
+  });
+
+  it("renders effort picker and emits OnEffortChanged when changed", () => {
+    const handleEvent = vi.fn();
+    const efforts = [
+      { id: "default", displayName: "Default" },
+      { id: "low", displayName: "Low" },
+      { id: "high", displayName: "High" },
+      { id: "max", displayName: "Max" },
+    ];
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        efforts={efforts}
+        selectedEffort="high"
+        supportsEffort={true}
+        events={["OnEffortChanged"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    // The effort select lives in the agent picker's side panel for the selected agent.
+    fireEvent.click(screen.getByRole("button", { name: /^Agent:/i }));
+    const effortTrigger = screen.getByTitle("Effort Level");
+    expect(effortTrigger).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+
+    fireEvent.click(effortTrigger.querySelector("button")!);
+    const maxOption = screen.getByRole("button", { name: /Max/i });
+    fireEvent.click(maxOption);
+
+    expect(handleEvent).toHaveBeenCalledWith("OnEffortChanged", "test-chat", ["max"]);
+  });
+
   it("collapses a turn's tool calls behind one line and lists them with their in/out on demand", () => {
     const rawStream = wire([
       { kind: "session_init", timestamp: "t0", session_id: "s1", model: "opus" },
-      { kind: "tool_call", timestamp: "t1", tool_use_id: "tu1", tool_name: "Read", input: { file_path: "/src/theme.ts" } },
-      { kind: "tool_result", timestamp: "t2", tool_use_id: "tu1", output: "export const theme = 1;", is_error: false },
-      { kind: "tool_call", timestamp: "t3", tool_use_id: "tu2", tool_name: "Bash", input: { command: "pnpm test" } },
-      { kind: "tool_result", timestamp: "t4", tool_use_id: "tu2", output: "42 passed", is_error: false },
+      {
+        kind: "tool_call",
+        timestamp: "t1",
+        tool_use_id: "tu1",
+        tool_name: "Read",
+        input: { file_path: "/src/theme.ts" },
+      },
+      {
+        kind: "tool_result",
+        timestamp: "t2",
+        tool_use_id: "tu1",
+        output: "export const theme = 1;",
+        is_error: false,
+      },
+      {
+        kind: "tool_call",
+        timestamp: "t3",
+        tool_use_id: "tu2",
+        tool_name: "Bash",
+        input: { command: "pnpm test" },
+      },
+      {
+        kind: "tool_result",
+        timestamp: "t4",
+        tool_use_id: "tu2",
+        output: "42 passed",
+        is_error: false,
+      },
       { kind: "text", timestamp: "t5", text: "Plan 00059 started.", delta: false },
       {
         kind: "result",
@@ -1980,14 +277,30 @@ describe("ChatWidget redesign", () => {
         response: "Plan 00059 started.",
         is_success: true,
         duration_ms: 125200,
-        usage: { input_tokens: 140284, output_tokens: 23009, cache_read_tokens: 0, cache_write_tokens: 0, reasoning_tokens: 0 },
+        usage: {
+          input_tokens: 140284,
+          output_tokens: 23009,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+          reasoning_tokens: 0,
+        },
       },
     ]);
     const session = baseSession({
-      messages: [{ id: "m-turn", role: "assistant", content: "Plan 00059 started.", timestamp: "10:00", rawStream }],
+      messages: [
+        {
+          id: "m-turn",
+          role: "assistant",
+          content: "Plan 00059 started.",
+          timestamp: "10:00",
+          rawStream,
+        },
+      ],
     });
 
-    const { container } = render(<ChatWidget id="test-chat" activeSessionId="sess-redesign" sessions={[session]} />);
+    const { container } = render(
+      <ChatWidget id="test-chat" activeSessionId="sess-redesign" sessions={[session]} />,
+    );
 
     const toggle = screen.getByRole("button", { name: /2 tool calls/i });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
@@ -2028,15 +341,19 @@ describe("ChatWidget redesign", () => {
         sessions={[session]}
         events={["OnOpenPlan"]}
         eventHandler={handleEvent}
-      />
+      />,
     );
 
     const row = container.querySelector(".chat-system-event-row") as HTMLElement;
     expect(row).toHaveAttribute("data-kind", "completed");
-    expect(row).toHaveTextContent("Completed plan #59 Add dark mode toggle to vault theme settings.");
+    expect(row).toHaveTextContent(
+      "Completed plan #59 Add dark mode toggle to vault theme settings.",
+    );
     expect(screen.queryByText(/Please inspect/)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "#59 Add dark mode toggle to vault theme settings" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "#59 Add dark mode toggle to vault theme settings" }),
+    );
     expect(handleEvent).toHaveBeenCalledWith("OnOpenPlan", "test-chat", ["00059"]);
   });
 
@@ -2044,26 +361,37 @@ describe("ChatWidget redesign", () => {
     const handleEvent = vi.fn();
     const agents = [
       { id: "claude", label: "Claude Code", icon: "ClaudeCode", supportsEffort: true },
-      { id: "codex", label: "Codex", icon: "OpenAI", models: [{ id: "gpt-5", displayName: "GPT-5" }] },
+      {
+        id: "codex",
+        label: "Codex",
+        icon: "OpenAI",
+        models: [{ id: "gpt-5", displayName: "GPT-5" }],
+      },
     ];
     render(
       <ChatWidget
         id="test-chat"
         agents={agents}
         models={[{ id: "opus", displayName: "Opus" }]}
-        efforts={[{ id: "default", displayName: "Default" }, { id: "max", displayName: "Max" }]}
+        efforts={[
+          { id: "default", displayName: "Default" },
+          { id: "max", displayName: "Max" },
+        ]}
         selectedAgent="claude"
         selectedModel="opus"
         selectedEffort="max"
         events={["OnAgentChanged", "OnModelChanged", "OnEffortChanged"]}
         eventHandler={handleEvent}
-      />
+      />,
     );
 
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Agent: Claude Code" }));
 
-    expect(screen.getByRole("menuitem", { name: "Claude Code" })).toHaveAttribute("data-selected", "true");
+    expect(screen.getByRole("menuitem", { name: "Claude Code" })).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
     expect(screen.getByText("Opus")).toBeInTheDocument();
     expect(screen.getByText("Max")).toBeInTheDocument();
 
@@ -2093,7 +421,13 @@ describe("ChatWidget redesign", () => {
     try {
       const session = baseSession({});
       const { rerender } = render(
-        <ChatWidget id="test-chat" activeSessionId="sess-redesign" sessions={[session]} events={["OnSendMessage"]} eventHandler={vi.fn()} />
+        <ChatWidget
+          id="test-chat"
+          activeSessionId="sess-redesign"
+          sessions={[session]}
+          events={["OnSendMessage"]}
+          eventHandler={vi.fn()}
+        />,
       );
 
       const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
@@ -2128,10 +462,15 @@ describe("ChatWidget redesign", () => {
           activeSessionId="sess-redesign"
           sessions={[session]}
           isStreaming={true}
-          streamingText={JSON.stringify({ kind: "text", timestamp: "t", text: "working", delta: false })}
+          streamingText={JSON.stringify({
+            kind: "text",
+            timestamp: "t",
+            text: "working",
+            delta: false,
+          })}
           events={["OnSendMessage"]}
           eventHandler={vi.fn()}
-        />
+        />,
       );
       expect(spacer.style.height).toBe("190px");
       expect(scrollTop).toBe(290);
@@ -2141,256 +480,9 @@ describe("ChatWidget redesign", () => {
   });
 });
 
-describe("ChatWidget voice input", () => {
-  /** A Web Speech stub whose behaviour on start() the test decides. */
-  class FakeRecognition {
-    static instances: FakeRecognition[] = [];
-    static onStart: ((recognition: FakeRecognition) => void) | null = null;
-
-    continuous = false;
-    interimResults = false;
-    onstart: (() => void) | null = null;
-    onend: (() => void) | null = null;
-    onerror: ((event: { error?: string }) => void) | null = null;
-    onresult: ((event: { results: ArrayLike<{ 0: { transcript: string } }> }) => void) | null = null;
-    stopped = false;
-
-    constructor() {
-      FakeRecognition.instances.push(this);
-    }
-
-    start() {
-      FakeRecognition.onStart?.(this);
-    }
-
-    stop() {
-      this.stopped = true;
-      this.onend?.();
-    }
-
-    emitResult(transcript: string) {
-      this.onstart?.();
-      this.onresult?.({ results: [{ 0: { transcript } }] });
-    }
-
-    emitError(error: string) {
-      this.onerror?.({ error });
-      // Real browsers always follow onerror with onend.
-      this.onend?.();
-    }
-  }
-
-  /** A WebSocket stub that records construction and lets the test push server messages. */
-  class FakeWebSocket {
-    static instances: FakeWebSocket[] = [];
-    static readonly OPEN = 1;
-
-    readonly OPEN = 1;
-    readyState = 1;
-    onopen: (() => void) | null = null;
-    onmessage: ((event: { data: string }) => void) | null = null;
-    onerror: (() => void) | null = null;
-    onclose: ((event: { code: number; reason: string; wasClean: boolean }) => void) | null = null;
-    sent: unknown[] = [];
-
-    constructor(public url: string) {
-      FakeWebSocket.instances.push(this);
-    }
-
-    send(data: unknown) {
-      this.sent.push(data);
-    }
-
-    close() {
-      this.readyState = 3;
-    }
-
-    emitServerMessage(payload: unknown) {
-      this.onmessage?.({ data: JSON.stringify(payload) });
-    }
-  }
-
-  const stubMediaDevices = (value: unknown) => {
-    Object.defineProperty(global.navigator, "mediaDevices", { configurable: true, value });
-  };
-
-  const stubWorkingCaptureEnvironment = () => {
-    stubMediaDevices({ getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [] }) });
-    vi.stubGlobal("AudioWorkletNode", class {});
-    vi.stubGlobal(
-      "AudioContext",
-      class {
-        state = "running";
-        audioWorklet = { addModule: vi.fn().mockResolvedValue(undefined) };
-        close() {
-          return Promise.resolve();
-        }
-        resume() {
-          return Promise.resolve();
-        }
-        createMediaStreamSource() {
-          return { connect: vi.fn() };
-        }
-      },
-    );
-  };
-
-  const renderChat = () =>
-    render(<ChatWidget id="test-chat" transcriptionUrl="ws://transcribe-test" />);
-
-  const micButton = () => screen.getByRole("button", { name: /Voice input/i });
-  const errorBanner = () => document.querySelector(".chat-voice-error");
-
-  beforeEach(() => {
-    window.ResizeObserver = class {
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    } as any;
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
-
-    FakeRecognition.instances = [];
-    FakeRecognition.onStart = null;
-    FakeWebSocket.instances = [];
-
-    vi.stubGlobal("alert", vi.fn());
-    vi.stubGlobal("WebSocket", FakeWebSocket);
-    stubWorkingCaptureEnvironment();
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    stubMediaDevices(undefined);
-  });
-
-  it("uses the Web Speech API alone when it produces results", async () => {
-    FakeRecognition.onStart = (recognition) => recognition.emitResult("hello from web speech");
-    vi.stubGlobal("SpeechRecognition", FakeRecognition);
-
-    renderChat();
-    fireEvent.click(micButton());
-
-    const textarea = screen.getByPlaceholderText(/Ask/i) as HTMLTextAreaElement;
-    await waitFor(() => expect(textarea.value).toBe("hello from web speech"));
-
-    expect(FakeWebSocket.instances).toHaveLength(0);
-    expect(window.alert).not.toHaveBeenCalled();
-    expect(errorBanner()).toBeNull();
-  });
-
-  it("falls back to server transcription when Web Speech errors with 'network' before any result", async () => {
-    FakeRecognition.onStart = (recognition) => recognition.emitError("network");
-    vi.stubGlobal("SpeechRecognition", FakeRecognition);
-
-    renderChat();
-    fireEvent.click(micButton());
-
-    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
-    expect(FakeWebSocket.instances[0].url).toBe("ws://transcribe-test");
-    expect(window.alert).not.toHaveBeenCalled();
-    expect(errorBanner()).toBeNull();
-  });
-
-  it("falls back to server transcription when Web Speech errors with 'service-not-allowed'", async () => {
-    FakeRecognition.onStart = (recognition) => recognition.emitError("service-not-allowed");
-    vi.stubGlobal("webkitSpeechRecognition", FakeRecognition);
-
-    renderChat();
-    fireEvent.click(micButton());
-
-    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
-    expect(errorBanner()).toBeNull();
-  });
-
-  it("opens a WebSocket directly when no SpeechRecognition constructor exists", async () => {
-    expect((window as any).SpeechRecognition).toBeUndefined();
-    expect((window as any).webkitSpeechRecognition).toBeUndefined();
-
-    renderChat();
-    fireEvent.click(micButton());
-
-    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
-    expect(FakeWebSocket.instances[0].url).toBe("ws://transcribe-test");
-    expect(window.alert).not.toHaveBeenCalled();
-  });
-
-  it("shows the error banner and returns to idle when the fallback finds no mediaDevices", async () => {
-    FakeRecognition.onStart = (recognition) => recognition.emitError("network");
-    vi.stubGlobal("SpeechRecognition", FakeRecognition);
-    stubMediaDevices(undefined);
-
-    renderChat();
-    const button = micButton();
-    fireEvent.click(button);
-
-    await waitFor(() => expect(errorBanner()?.textContent).toContain("not available in this window"));
-    expect(FakeWebSocket.instances).toHaveLength(0);
-    expect(button).toHaveClass("chat-voice-idle");
-  });
-
-  it("blames the connection when the page is not a secure context", async () => {
-    FakeRecognition.onStart = (recognition) => recognition.emitError("network");
-    vi.stubGlobal("SpeechRecognition", FakeRecognition);
-    vi.stubGlobal("isSecureContext", false);
-    vi.stubGlobal("location", { hostname: "192.168.1.42", href: "http://192.168.1.42:5000/" });
-
-    renderChat();
-    fireEvent.click(micButton());
-
-    await waitFor(() => expect(errorBanner()?.textContent).toContain("secure connection"));
-    expect(errorBanner()?.textContent).toContain("HTTPS");
-    expect(FakeWebSocket.instances).toHaveLength(0);
-  });
-
-  it("reports a denied microphone without attempting the server fallback", async () => {
-    FakeRecognition.onStart = (recognition) => recognition.emitError("not-allowed");
-    vi.stubGlobal("SpeechRecognition", FakeRecognition);
-
-    renderChat();
-    const button = micButton();
-    fireEvent.click(button);
-
-    await waitFor(() => expect(errorBanner()?.textContent).toContain("Microphone access was denied"));
-    expect(FakeWebSocket.instances).toHaveLength(0);
-    expect(button).toHaveClass("chat-voice-idle");
-  });
-
-  it("appends a server transcript to text already in the composer", async () => {
-    renderChat();
-
-    const textarea = screen.getByPlaceholderText(/Ask/i) as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "look into" } });
-
-    fireEvent.click(micButton());
-    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
-
-    const socket = FakeWebSocket.instances[0];
-    socket.emitServerMessage({ type: "result", text: "the flaky test" });
-
-    await waitFor(() => expect(textarea.value).toBe("look into the flaky test"));
-  });
-
-  it("dismisses the error banner when the close button is clicked", async () => {
-    FakeRecognition.onStart = (recognition) => recognition.emitError("not-allowed");
-    vi.stubGlobal("SpeechRecognition", FakeRecognition);
-
-    renderChat();
-    fireEvent.click(micButton());
-
-    await waitFor(() => expect(errorBanner()).not.toBeNull());
-    fireEvent.click(screen.getByRole("button", { name: /Dismiss voice input error/i }));
-    expect(errorBanner()).toBeNull();
-  });
-});
-
 describe("ChatWidget embedded mode", () => {
   beforeEach(() => {
-    window.ResizeObserver = class {
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    } as any;
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    setupChatWidgetTestEnvironment();
   });
 
   it("drops the title bar and shows the plan greeting above the headline", () => {
@@ -2422,7 +514,9 @@ describe("ChatWidget embedded mode", () => {
       messages: [{ id: "m1", role: "user", content: "hi", timestamp: "" }],
       spawnedJobs: [{ id: "00148", type: "ExecutePlan", status: "Running" }],
     };
-    const { container } = render(<ChatWidget id="embedded" embedded activeSessionId="s1" sessions={[session]} />);
+    const { container } = render(
+      <ChatWidget id="embedded" embedded activeSessionId="s1" sessions={[session]} />,
+    );
 
     expect(container.querySelector(".chat-header--embedded")).not.toBeNull();
     expect(screen.getByRole("button", { name: "View running jobs" })).toBeInTheDocument();
@@ -2432,12 +526,7 @@ describe("ChatWidget embedded mode", () => {
 
 describe("ChatWidget Markdown Code Blocks", () => {
   beforeEach(() => {
-    window.ResizeObserver = class {
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    } as any;
-    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    setupChatWidgetTestEnvironment();
   });
 
   it("renders assistant markdown code blocks inside pmv-code-block with copy button", () => {
@@ -2458,13 +547,16 @@ describe("ChatWidget Markdown Code Blocks", () => {
         {
           id: "m-assistant",
           role: "assistant",
-          content: "Here is a TypeScript snippet:\n\n```typescript\nconst greeting = 'hello world';\nconsole.log(greeting);\n```\n\nAnd here is an untagged block:\n\n```\necho 'plain text block'\n```\n\nAnd an inline `const foo = 42;` value.",
+          content:
+            "Here is a TypeScript snippet:\n\n```typescript\nconst greeting = 'hello world';\nconsole.log(greeting);\n```\n\nAnd here is an untagged block:\n\n```\necho 'plain text block'\n```\n\nAnd an inline `const foo = 42;` value.",
           timestamp: "",
         },
       ],
     };
 
-    const { container } = render(<ChatWidget id="test-chat" activeSessionId="s-code" sessions={[session]} />);
+    const { container } = render(
+      <ChatWidget id="test-chat" activeSessionId="s-code" sessions={[session]} />,
+    );
 
     const assistantRow = container.querySelector(".chat-message-row.assistant");
     expect(assistantRow).toBeInTheDocument();
@@ -2492,7 +584,9 @@ describe("ChatWidget Markdown Code Blocks", () => {
 
     // Verify inline code is rendered as standalone code tag outside pmv-code-block
     const allCodeTags = assistantRow?.querySelectorAll("code");
-    const inlineCode = Array.from(allCodeTags || []).find((el) => el.textContent === "const foo = 42;");
+    const inlineCode = Array.from(allCodeTags || []).find(
+      (el) => el.textContent === "const foo = 42;",
+    );
     expect(inlineCode).toBeInTheDocument();
     expect(inlineCode?.closest(".pmv-code-block")).toBeNull();
   });
@@ -2522,7 +616,9 @@ describe("ChatWidget Markdown Code Blocks", () => {
       ],
     };
 
-    const { container } = render(<ChatWidget id="test-chat" activeSessionId="s-stream" sessions={[session]} />);
+    const { container } = render(
+      <ChatWidget id="test-chat" activeSessionId="s-stream" sessions={[session]} />,
+    );
 
     const assistantRow = container.querySelector(".chat-message-row.assistant");
     expect(assistantRow).toBeInTheDocument();
@@ -2536,4 +632,3 @@ describe("ChatWidget Markdown Code Blocks", () => {
     expect(codeBlock?.textContent).toContain("def add(a, b):");
   });
 });
-

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.testUtils.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.testUtils.ts
@@ -1,0 +1,31 @@
+import { vi } from "vitest";
+import type { ChatSessionDto } from "./ChatWidget";
+
+vi.mock("pdfjs-dist", () => ({ GlobalWorkerOptions: {}, getDocument: vi.fn() }));
+vi.mock("pdfjs-dist/build/pdf.worker.mjs?url", () => ({ default: "" }));
+
+export function setupChatWidgetTestEnvironment() {
+  window.ResizeObserver = class {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+  } as any;
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+}
+
+export function createMockSession(overrides: Partial<ChatSessionDto> = {}): ChatSessionDto {
+  return {
+    id: "sess-1",
+    title: "Session 1",
+    agentId: "claude",
+    modelId: "opus",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    messages: [],
+    ...overrides,
+  };
+}
+
+export function questionsFence(...lines: string[]): string {
+  return ["```questions", ...lines, "```"].join("\n");
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.voice.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.voice.test.tsx
@@ -1,0 +1,248 @@
+import "./ChatWidget.testUtils";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom";
+import { ChatWidget } from "./ChatWidget";
+import { setupChatWidgetTestEnvironment } from "./ChatWidget.testUtils";
+
+describe("ChatWidget voice input", () => {
+  /** A Web Speech stub whose behaviour on start() the test decides. */
+  class FakeRecognition {
+    static instances: FakeRecognition[] = [];
+    static onStart: ((recognition: FakeRecognition) => void) | null = null;
+
+    continuous = false;
+    interimResults = false;
+    onstart: (() => void) | null = null;
+    onend: (() => void) | null = null;
+    onerror: ((event: { error?: string }) => void) | null = null;
+    onresult: ((event: { results: ArrayLike<{ 0: { transcript: string } }> }) => void) | null =
+      null;
+    stopped = false;
+
+    constructor() {
+      FakeRecognition.instances.push(this);
+    }
+
+    start() {
+      FakeRecognition.onStart?.(this);
+    }
+
+    stop() {
+      this.stopped = true;
+      this.onend?.();
+    }
+
+    emitResult(transcript: string) {
+      this.onstart?.();
+      this.onresult?.({ results: [{ 0: { transcript } }] });
+    }
+
+    emitError(error: string) {
+      this.onerror?.({ error });
+      // Real browsers always follow onerror with onend.
+      this.onend?.();
+    }
+  }
+
+  /** A WebSocket stub that records construction and lets the test push server messages. */
+  class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+    static readonly OPEN = 1;
+
+    readonly OPEN = 1;
+    readyState = 1;
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onerror: (() => void) | null = null;
+    onclose: ((event: { code: number; reason: string; wasClean: boolean }) => void) | null = null;
+    sent: unknown[] = [];
+
+    constructor(public url: string) {
+      FakeWebSocket.instances.push(this);
+    }
+
+    send(data: unknown) {
+      this.sent.push(data);
+    }
+
+    close() {
+      this.readyState = 3;
+    }
+
+    emitServerMessage(payload: unknown) {
+      this.onmessage?.({ data: JSON.stringify(payload) });
+    }
+  }
+
+  const stubMediaDevices = (value: unknown) => {
+    Object.defineProperty(global.navigator, "mediaDevices", { configurable: true, value });
+  };
+
+  const stubWorkingCaptureEnvironment = () => {
+    stubMediaDevices({ getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [] }) });
+    vi.stubGlobal("AudioWorkletNode", class {});
+    vi.stubGlobal(
+      "AudioContext",
+      class {
+        state = "running";
+        audioWorklet = { addModule: vi.fn().mockResolvedValue(undefined) };
+        close() {
+          return Promise.resolve();
+        }
+        resume() {
+          return Promise.resolve();
+        }
+        createMediaStreamSource() {
+          return { connect: vi.fn() };
+        }
+      },
+    );
+  };
+
+  const renderChat = () =>
+    render(<ChatWidget id="test-chat" transcriptionUrl="ws://transcribe-test" />);
+
+  const micButton = () => screen.getByRole("button", { name: /Voice input/i });
+  const errorBanner = () => document.querySelector(".chat-voice-error");
+
+  beforeEach(() => {
+    setupChatWidgetTestEnvironment();
+
+    FakeRecognition.instances = [];
+    FakeRecognition.onStart = null;
+    FakeWebSocket.instances = [];
+
+    vi.stubGlobal("alert", vi.fn());
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    stubWorkingCaptureEnvironment();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    stubMediaDevices(undefined);
+  });
+
+  it("uses the Web Speech API alone when it produces results", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitResult("hello from web speech");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    const textarea = screen.getByPlaceholderText(/Ask/i) as HTMLTextAreaElement;
+    await waitFor(() => expect(textarea.value).toBe("hello from web speech"));
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(window.alert).not.toHaveBeenCalled();
+    expect(errorBanner()).toBeNull();
+  });
+
+  it("falls back to server transcription when Web Speech errors with 'network' before any result", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("network");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    expect(FakeWebSocket.instances[0].url).toBe("ws://transcribe-test");
+    expect(window.alert).not.toHaveBeenCalled();
+    expect(errorBanner()).toBeNull();
+  });
+
+  it("falls back to server transcription when Web Speech errors with 'service-not-allowed'", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("service-not-allowed");
+    vi.stubGlobal("webkitSpeechRecognition", FakeRecognition);
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    expect(errorBanner()).toBeNull();
+  });
+
+  it("opens a WebSocket directly when no SpeechRecognition constructor exists", async () => {
+    expect((window as any).SpeechRecognition).toBeUndefined();
+    expect((window as any).webkitSpeechRecognition).toBeUndefined();
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    expect(FakeWebSocket.instances[0].url).toBe("ws://transcribe-test");
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  it("shows the error banner and returns to idle when the fallback finds no mediaDevices", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("network");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+    stubMediaDevices(undefined);
+
+    renderChat();
+    const button = micButton();
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(errorBanner()?.textContent).toContain("not available in this window"),
+    );
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(button).toHaveClass("chat-voice-idle");
+  });
+
+  it("blames the connection when the page is not a secure context", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("network");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+    vi.stubGlobal("isSecureContext", false);
+    vi.stubGlobal("location", { hostname: "192.168.1.42", href: "http://192.168.1.42:5000/" });
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(errorBanner()?.textContent).toContain("secure connection"));
+    expect(errorBanner()?.textContent).toContain("HTTPS");
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it("reports a denied microphone without attempting the server fallback", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("not-allowed");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+
+    renderChat();
+    const button = micButton();
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(errorBanner()?.textContent).toContain("Microphone access was denied"),
+    );
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(button).toHaveClass("chat-voice-idle");
+  });
+
+  it("appends a server transcript to text already in the composer", async () => {
+    renderChat();
+
+    const textarea = screen.getByPlaceholderText(/Ask/i) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "look into" } });
+
+    fireEvent.click(micButton());
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    const socket = FakeWebSocket.instances[0];
+    socket.emitServerMessage({ type: "result", text: "the flaky test" });
+
+    await waitFor(() => expect(textarea.value).toBe("look into the flaky test"));
+  });
+
+  it("dismisses the error banner when the close button is clicked", async () => {
+    FakeRecognition.onStart = (recognition) => recognition.emitError("not-allowed");
+    vi.stubGlobal("SpeechRecognition", FakeRecognition);
+
+    renderChat();
+    fireEvent.click(micButton());
+
+    await waitFor(() => expect(errorBanner()).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Dismiss voice input error/i }));
+    expect(errorBanner()).toBeNull();
+  });
+});


### PR DESCRIPTION
# Summary

## Changes

Split the monolithic `ChatWidget.test.tsx` file (over 2,500 lines) into focused, domain-specific test files aligned with codebase conventions. Extracted shared test utilities, mock environment setup, and mock factories into `ChatWidget.testUtils.ts` without regressions across any of the 64 test cases.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.testUtils.ts`: Created shared helper module providing `setupChatWidgetTestEnvironment()`, PDF.js worker mocks, `createMockSession()`, and `questionsFence()`.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.queuing.test.tsx`: Extracted queued messages UI test suite.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.attachments.test.tsx`: Extracted file uploads, attachments, drag-and-drop, and preview test suites.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx`: Extracted interactive questions draft persistence test suite.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.streaming.test.tsx`: Extracted streaming scroll behavior test suite.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.voice.test.tsx`: Extracted voice input and Web Speech API mock test suite.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Streamlined to focus on core UI integration suites (Running Jobs, Redesign/Session Switching, Embedded Mode, Markdown Code Blocks).

## Manual Testing

N/A - internal test refactoring with no user-facing behavior changes. Verified all tests pass via `vp test --run src/ChatWidget` and full solution build completes via `dotnet build src/Ivy.Tendril/Ivy.Tendril.slnx`.

---
- 8850dc8f Split ChatWidget tests into dedicated test files (Plan 00260)

---
Created using [Ivy Tendril](https://ivy.app).