### PR TITLE
[00261] Upgrade Ivy Packages to 1.4.0 and Remove Retired Package References

### DIFF
--- a/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
+++ b/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
     <ItemGroup Condition="'$(IvySource)' != 'true'">
         <PackageReference Include="Ivy" Version="$(IvyPackageVersion)" Condition="'$(IvyPackageVersion)' != ''" />
-        <PackageReference Include="Ivy" Version="1.3.21" Condition="'$(IvyPackageVersion)' == ''" />
+        <PackageReference Include="Ivy" Version="1.4.0" Condition="'$(IvyPackageVersion)' == ''" />
         <PackageReference Include="Ivy.Docs.Helpers" Version="$(IvyPackageVersion)" Condition="'$(IvyPackageVersion)' != ''" />
     </ItemGroup>
 
@@ -59,15 +59,6 @@
             <OutputItemType>Analyzer</OutputItemType>
         </ProjectReference>
     </ItemGroup>
-    <ItemGroup Condition="'$(IvySource)' != 'true'">
-        <PackageReference Include="Ivy.Analyser" Version="$(IvyPackageVersion)" Condition="'$(IvyPackageVersion)' != ''">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Ivy.Analyser" Version="1.3.21" Condition="'$(IvyPackageVersion)' == ''">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+
 
 </Project>

--- a/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
+++ b/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
@@ -38,7 +38,7 @@
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Desktop/Ivy.Desktop.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.3.21" />
-    <PackageReference Include="Ivy.Desktop" Version="1.3.21" />
+    <PackageReference Include="Ivy" Version="1.4.0" />
+    <PackageReference Include="Ivy.Desktop" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
+++ b/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.3.21" />
+    <PackageReference Include="Ivy" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- QuestionAnswers.cs merges an answer back into a `questions` fence. Same version as Ivy.Tendril. -->

--- a/src/Ivy.Tendril/Apps/Settings/AboutSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AboutSetupView.cs
@@ -60,7 +60,7 @@ public class AboutSetupView : ViewBase
         var isCheckingUpdates = UseState(false);
 
         var tendrilVersion = typeof(Program).Assembly.GetName().Version?.ToString(3) ?? "1.0.0";
-        var ivyVersion = typeof(ViewBase).Assembly.GetName().Version?.ToString(3) ?? "1.3.21";
+        var ivyVersion = typeof(ViewBase).Assembly.GetName().Version?.ToString(3) ?? "1.4.0";
         var osDescription = RuntimeInformation.OSDescription;
         var osArch = RuntimeInformation.OSArchitecture.ToString();
         var processArch = RuntimeInformation.ProcessArchitecture.ToString();

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -57,14 +57,8 @@
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Desktop/Ivy.Desktop.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.3.21" />
-    <PackageReference Include="Ivy.Desktop" Version="1.3.21" />
-    <PackageReference Include="Ivy.Hooks.Pty" Version="1.3.21" />
-    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.3.21" />
-    <PackageReference Include="Ivy.Widgets.AnimatedStatusLabel" Version="1.3.21" />
-    <PackageReference Include="Ivy.Widgets.DiffView" Version="1.3.21" />
-    <PackageReference Include="Ivy.Widgets.QRCode" Version="1.3.21" />
-    <PackageReference Include="Ivy.Widgets.Xterm" Version="1.3.21" />
+    <PackageReference Include="Ivy" Version="1.4.0" />
+    <PackageReference Include="Ivy.Desktop" Version="1.4.0" />
   </ItemGroup>
   <!-- Ivy Analyser -->
   <ItemGroup Condition="'$(IvySource)' == 'true'">
@@ -74,12 +68,6 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Analyzer</OutputItemType>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy.Analyser" Version="1.3.21">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
   <!-- Tendril ProjectReferences -->
   <ItemGroup>


### PR DESCRIPTION
# Summary

## Changes

Upgraded Ivy package dependencies from 1.3.21 to 1.4.0 across Ivy.Tendril, Ivy.Tendril.Widgets, Ivy.Tendril.Docs, and Ivy.Tendril.Test projects. Removed retired standalone NuGet package references (`Ivy.Hooks.Pty`, `Ivy.Widgets.*`, and `Ivy.Analyser`) now consolidated into the core Ivy package. Updated the fallback Ivy version string in `AboutSetupView` to 1.4.0.

## API Changes

None.

## Files Modified

- Project files:
  - `src/Ivy.Tendril/Ivy.Tendril.csproj`: Upgraded Ivy and Ivy.Desktop to 1.4.0; removed retired Ivy.Hooks.Pty, Ivy.Widgets.*, and Ivy.Analyser references.
  - `src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj`: Upgraded Ivy to 1.4.0.
  - `src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj`: Upgraded fallback Ivy to 1.4.0; removed retired Ivy.Analyser references.
  - `src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj`: Upgraded Ivy and Ivy.Desktop to 1.4.0.
- Settings UI:
  - `src/Ivy.Tendril/Apps/Settings/AboutSetupView.cs`: Updated fallback Ivy version string to 1.4.0.

## Manual Testing

1. Launch Tendril or run `AboutSetupViewTests`:
   - Run `dotnet test src/Ivy.Tendril/Ivy.Tendril.slnx --configuration Release --filter "FullyQualifiedName~AboutSetupViewTests"`
   - Observe that all 4 tests pass.
2. In the Tendril application, navigate to Settings -> About & Setup.
3. Observe that the reported Ivy Framework version displays `1.4.0` (or the runtime assembly version).

---
- 2e8f0fc6 [00261] Upgrade Ivy packages to 1.4.0 and remove retired package references

---
Created using [Ivy Tendril](https://ivy.app).
