### PR TITLE
fix(chat): restyle the composer's stop button and show queue only with input

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.attachments.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.attachments.test.tsx
@@ -686,8 +686,10 @@ describe("ChatWidget File Uploads and Attachments", () => {
 
     fireEvent.click(sendBtn);
 
-    // Immediately shows Stop and Queue buttons without waiting for server props
+    // Immediately swaps Send for Stop without waiting for server props; Queue waits for new input
     expect(screen.getByRole("button", { name: /Stop/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Queue/i })).not.toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText(/Ask/i), { target: { value: "next" } });
     expect(screen.getByRole("button", { name: /Queue/i })).toBeInTheDocument();
 
     // Immediately shows the agent status line

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.queuing.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.queuing.test.tsx
@@ -22,15 +22,14 @@ describe("ChatWidget Queued Messages UI", () => {
     );
 
     const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
 
     // Queue first message
     fireEvent.change(textarea, { target: { value: "test message 1" } });
-    fireEvent.click(queueBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Queue message" }));
 
     // Queue second message
     fireEvent.change(textarea, { target: { value: "test message 2" } });
-    fireEvent.click(queueBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Queue message" }));
 
     expect(screen.getByText("Queued Messages")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
@@ -40,14 +39,44 @@ describe("ChatWidget Queued Messages UI", () => {
     expect(screen.getByText("test message 2")).toBeInTheDocument();
   });
 
+  it("only shows the queue button while the composer has content, left of the stop button", () => {
+    render(<ChatWidget id="test-chat" isStreaming={true} />);
+
+    expect(screen.getByRole("button", { name: /Stop agent/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Queue message" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Send message/i })).not.toBeInTheDocument();
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    fireEvent.change(textarea, { target: { value: "hello" } });
+
+    const queueBtn = screen.getByRole("button", { name: "Queue message" });
+    const stopBtn = screen.getByRole("button", { name: /Stop agent/i });
+    expect(queueBtn.compareDocumentPosition(stopBtn) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(stopBtn).toHaveClass("chat-stop-btn");
+
+    fireEvent.change(textarea, { target: { value: "   " } });
+    expect(screen.queryByRole("button", { name: "Queue message" })).not.toBeInTheDocument();
+  });
+
+  it("hides the queue button again once the message is queued", () => {
+    render(<ChatWidget id="test-chat" isStreaming={true} />);
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    fireEvent.change(textarea, { target: { value: "queued task" } });
+    fireEvent.click(screen.getByRole("button", { name: "Queue message" }));
+
+    expect(screen.getByText("queued task")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Queue message" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Stop agent/i })).toBeInTheDocument();
+  });
+
   it("allows collapsing and expanding the queued messages list", () => {
     render(<ChatWidget id="test-chat" isStreaming={true} />);
 
     const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
 
     fireEvent.change(textarea, { target: { value: "queued task" } });
-    fireEvent.click(queueBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Queue message" }));
 
     const toggleBtn = screen.getByRole("button", { name: /Collapse queued messages/i });
     fireEvent.click(toggleBtn);
@@ -64,10 +93,9 @@ describe("ChatWidget Queued Messages UI", () => {
     render(<ChatWidget id="test-chat" isStreaming={true} />);
 
     const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
 
     fireEvent.change(textarea, { target: { value: "original prompt" } });
-    fireEvent.click(queueBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Queue message" }));
 
     const editBtn = screen.getByRole("button", { name: /Edit message/i });
     fireEvent.click(editBtn);
@@ -94,13 +122,12 @@ describe("ChatWidget Queued Messages UI", () => {
     );
 
     const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
 
     fireEvent.change(textarea, { target: { value: "message to send now" } });
-    fireEvent.click(queueBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Queue message" }));
 
     fireEvent.change(textarea, { target: { value: "message to delete" } });
-    fireEvent.click(queueBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Queue message" }));
 
     expect(screen.getByText("2")).toBeInTheDocument();
 
@@ -227,10 +254,9 @@ describe("ChatWidget Queued Messages UI", () => {
     );
 
     const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
 
     fireEvent.change(textarea, { target: { value: "optimistic prompt" } });
-    fireEvent.click(queueBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Queue message" }));
 
     expect(screen.getByText("Queued Messages")).toBeInTheDocument();
     expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
@@ -295,10 +321,9 @@ describe("ChatWidget Queued Messages UI", () => {
     );
 
     const textarea = screen.getByPlaceholderText(/Ask/i);
-    const queueBtn = screen.getByRole("button", { name: /Queue/i });
 
     fireEvent.change(textarea, { target: { value: "what can you do?" } });
-    fireEvent.click(queueBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Queue message" }));
 
     expect(screen.getByText("Queued Messages")).toBeInTheDocument();
     // Verify it is inside the queued panel

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -259,6 +259,7 @@ export function ChatWidget({
   const headerJobs = [...sessionSpawnedJobs, ...otherRunningJobs];
   const currentOptimistic = (activeSessionId && optimisticMessages[activeSessionId]) || [];
   const displayMessages = [...(activeSession?.messages || []), ...currentOptimistic];
+  const hasComposerContent = promptText.trim().length > 0 || attachments.length > 0;
   const isSendDisabled =
     isPayloadOversized || isUploading || isAnyFailed || (!promptText.trim() && !hasValidAttachments);
   const effectiveIsStreaming =
@@ -962,26 +963,26 @@ export function ChatWidget({
 
                 {effectiveIsStreaming ? (
                   <>
-                    <IconButton
-                      className="chat-stop-btn"
-                      label="Stop agent"
-                      onClick={handleCancelStream}
-                    >
+                    {hasComposerContent && (
+                      <IconButton
+                        variant="solid"
+                        className="chat-send-btn"
+                        label="Queue message"
+                        tooltip={sendTitle}
+                        disabled={isSendDisabled}
+                        onClick={handleSendMessage}
+                      >
+                        <ListPlus size={16} />
+                      </IconButton>
+                    )}
+                    <IconButton className="chat-stop-btn" label="Stop agent" onClick={handleCancelStream}>
                       <Square size={12} fill="currentColor" />
-                    </IconButton>
-                    <IconButton
-                      variant="solid"
-                      label="Queue message"
-                      tooltip={sendTitle}
-                      disabled={isSendDisabled}
-                      onClick={handleSendMessage}
-                    >
-                      <ListPlus size={16} />
                     </IconButton>
                   </>
                 ) : (
                   <IconButton
                     variant="solid"
+                    className="chat-send-btn"
                     label="Send message"
                     tooltip={sendTitle}
                     disabled={isSendDisabled}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -14,6 +14,7 @@
   --tch-border: var(--border, #e0e0e0);
   --tch-surface: color-mix(in srgb, var(--foreground, #000000) 4%, var(--background, #ffffff));
   --tch-surface-hover: color-mix(in srgb, var(--foreground, #000000) 8%, var(--background, #ffffff));
+  --tch-input-border: color-mix(in srgb, var(--foreground, #000000) 15%, transparent);
   --tch-popover: var(--popover, #ffffff);
   --tch-bubble-bg: var(--primary, #000000);
   --tch-bubble-fg: var(--primary-foreground, #ffffff);
@@ -983,7 +984,7 @@ button.chat-system-event-plan {
 }
 
 .chat-input-box:focus-within {
-  border-color: color-mix(in srgb, var(--tch-fg) 15%, transparent);
+  border-color: var(--tch-input-border);
 }
 
 .chat-input-box.dragging {
@@ -1197,16 +1198,15 @@ button.chat-system-event-plan {
   color: currentColor;
 }
 
-/* The shared icon button, in the composer's stop colors. */
 .chat-stop-btn {
-  border: 1px solid var(--tch-danger);
-  background: color-mix(in srgb, var(--tch-danger) 10%, transparent);
-  color: var(--tch-danger);
+  border: 1px solid var(--tch-input-border);
+  background: var(--tch-surface);
+  color: var(--tch-fg);
   opacity: 1;
 }
 
 .chat-stop-btn:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--tch-danger) 20%, transparent);
+  background: var(--tch-surface-hover);
 }
 
 /* ---------- Agent picker (portalled) ---------- */


### PR DESCRIPTION
## Summary
- While the agent is running, the send button becomes a **stop** button in the same slot and size, styled with the chat input's background (`--tch-surface`) and border color (new `--tch-input-border`, shared with the input's focus ring) instead of the danger red.
- The **queue** button now appears only while the composer has text or attachments, to the left of the stop button, and disappears once the message is queued.
- Send/queue buttons regain the `chat-send-btn` class so the embedded plan chat sizes them at 28px like the stop button.

Fixes #2462

## Verification
- `pnpm test` in `src/Ivy.Tendril.Widgets/frontend`: 54 files, 578 tests pass (queuing + attachments tests updated, 2 new tests for the queue button's visibility and ordering).
- `pnpm build` (tsc + vite) passes.
- Rendered the composer in a local Vite harness: idle, running-empty, running-typing, embedded plan chat, light and dark.

Generated with [Claude Code](https://claude.com/claude-code)