### PR TITLE
fix(shell): let a review action's terminal be escaped via a page tab

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/StripTabsTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/StripTabsTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Immutable;
+using Ivy.Tendril.AppShell;
+using Ivy.Tendril.Widgets;
+using static Ivy.Tendril.AppShell.TendrilAppShell;
+
+namespace Ivy.Tendril.Test.AppShell;
+
+/// <summary>
+///     The bottom strip must always offer a way back to the page behind the session panes;
+///     without it, running a review action strands the reviewer on its terminal (issue #2245).
+/// </summary>
+public class StripTabsTests
+{
+    private static TabState Tab(string id, string appId) => new(id, appId, id, null!, null, "key");
+
+    [Fact]
+    public void BuildStripTabs_LeadsWithNonClosablePageTab()
+    {
+        var strip = BuildStripTabs("Review", "ThumbsUp", []);
+
+        var pageTab = Assert.Single(strip);
+        Assert.Equal(PageTabId, pageTab.Id);
+        Assert.Equal("Review", pageTab.Title);
+        Assert.Equal("ThumbsUp", pageTab.Icon);
+        Assert.False(pageTab.Closable);
+    }
+
+    [Fact]
+    public void BuildStripTabs_KeepsSessionTabsAfterThePageTab()
+    {
+        var strip = BuildStripTabs("Review", "ThumbsUp", [("tab1", "#74 Run"), ("tab2", "#74 Build")]);
+
+        Assert.Equal([PageTabId, "tab1", "tab2"], strip.Select(t => t.Id));
+        Assert.All(strip.Skip(1), t => Assert.True(t.Closable));
+    }
+
+    [Fact]
+    public void BuildStripTabs_WallpaperPage_CarriesNoIcon()
+    {
+        // No page open: the tab is "Home" with no app icon, and the frontend picks its own glyph.
+        var pageTab = BuildStripTabs("Home", null, [("tab1", "#74 Run")])[0];
+
+        Assert.Equal("Home", pageTab.Title);
+        Assert.Null(pageTab.Icon);
+        Assert.False(pageTab.Closable);
+    }
+
+    private static ShellSidebarListState List(string appId, string? selectedId, params (string Id, string Title)[] rows)
+        => new(appId, "Plans", rows.Select(r => new ShellSectionItemDto(r.Id, r.Title)).ToList(),
+            selectedId, _ => null);
+
+    [Fact]
+    public void PageTabTitle_SelectedRow_NamesTheRowNotTheApp()
+    {
+        // "#74 Draft | #74 Run Tests" reads better than "Plans | #74 Run Tests".
+        var list = List("plans", "p74", ("p73", "#73 Older"), ("p74", "#74 Draft"));
+
+        Assert.Equal("#74 Draft", PageTabTitle("Plans", list));
+    }
+
+    [Fact]
+    public void PageTabTitle_NoSidebarList_UsesTheAppTitle()
+    {
+        Assert.Equal("Configuration", PageTabTitle("Configuration", null));
+    }
+
+    [Fact]
+    public void PageTabTitle_NoRowSelected_UsesTheAppTitle()
+    {
+        var list = List("plans", null, ("p74", "#74 Draft"));
+
+        Assert.Equal("Plans", PageTabTitle("Plans", list));
+    }
+
+    [Fact]
+    public void PageTabTitle_SelectionMissingFromRows_UsesTheAppTitle()
+    {
+        // The published list can lag its selection for a render; never show an empty tab.
+        var list = List("plans", "p99", ("p74", "#74 Draft"));
+
+        Assert.Equal("Plans", PageTabTitle("Plans", list));
+    }
+
+    [Fact]
+    public void PageTabTitle_BlankRowTitle_UsesTheAppTitle()
+    {
+        var list = List("plans", "p74", ("p74", ""));
+
+        Assert.Equal("Plans", PageTabTitle("Plans", list));
+    }
+
+    [Fact]
+    public void SelectedStripTabId_NoSessionSelected_SelectsThePageTab()
+    {
+        var tabs = ImmutableArray.Create(Tab("tab1", "review-action"));
+
+        Assert.Equal(PageTabId, SelectedStripTabId(tabs, null));
+    }
+
+    [Fact]
+    public void SelectedStripTabId_ReviewActionSelected_SelectsThatTab()
+    {
+        var tabs = ImmutableArray.Create(Tab("tab1", "review-action"), Tab("tab2", "review-action"));
+
+        Assert.Equal("tab2", SelectedStripTabId(tabs, 1));
+    }
+
+    [Fact]
+    public void SelectedStripTabId_TerminalPaneActive_SelectsNothing()
+    {
+        // Terminal panes live in the Chats list, not the strip, so the page tab must not
+        // look current while one is showing.
+        var tabs = ImmutableArray.Create(Tab("tab1", "review-action"), Tab("session1", "agent"));
+
+        Assert.Null(SelectedStripTabId(tabs, 1));
+    }
+
+    [Fact]
+    public void SelectedStripTabId_IndexOutOfRange_FallsBackToThePageTab()
+    {
+        var tabs = ImmutableArray.Create(Tab("tab1", "review-action"));
+
+        Assert.Equal(PageTabId, SelectedStripTabId(tabs, 5));
+    }
+}

--- a/src/Ivy.Tendril.Widgets/ShellDtos.cs
+++ b/src/Ivy.Tendril.Widgets/ShellDtos.cs
@@ -12,4 +12,8 @@ public record ShellBadgeDto(string Label, string Kind = "neutral", string? Color
 
 public record ShellSectionItemDto(string Id, string Title, string? Tag = null, List<ShellBadgeDto>? Badges = null, string? Icon = null, string? State = null);
 
-public record ShellTabDto(string Id, string Title);
+/// <summary>
+///     One entry in the shell's bottom tab strip. <c>Closable</c> is false for the
+///     page tab, which represents the page behind the session panes and is always present.
+/// </summary>
+public record ShellTabDto(string Id, string Title, bool Closable = true, string? Icon = null);

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellTabs.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellTabs.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { ShellTabs } from "./ShellTabs";
+import { ShellTabDto } from "./types";
+
+const pageTab: ShellTabDto = { id: "$page", title: "Review", closable: false, icon: "ThumbsUp" };
+const sessionTab: ShellTabDto = { id: "tab-1", title: "#74 Run" };
+
+const renderTabs = (tabs: ShellTabDto[], selectedId?: string) => {
+  const eventHandler = vi.fn();
+  const utils = render(
+    <ShellTabs
+      id="tabs-1"
+      tabs={tabs}
+      selectedId={selectedId}
+      events={["OnSelect", "OnClose", "OnNew"]}
+      eventHandler={eventHandler}
+    />,
+  );
+  return { ...utils, eventHandler };
+};
+
+describe("ShellTabs", () => {
+  it("renders nothing when only the page tab exists", () => {
+    const { container } = renderTabs([pageTab]);
+    expect(container.querySelector(".tsh-tabs")).toBeNull();
+  });
+
+  it("shows the page tab beside a session tab", () => {
+    renderTabs([pageTab, sessionTab], "tab-1");
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((t) => t.textContent)).toEqual(["Review", "#74 Run"]);
+    expect(tabs[0]).toHaveAttribute("aria-selected", "false");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("renders the page app's own icon, and the terminal glyph for sessions", () => {
+    const { container } = renderTabs([pageTab, sessionTab], "$page");
+
+    const icons = container.querySelectorAll(".tsh-tab-icon");
+    expect(icons[0]).toHaveClass("lucide-thumbs-up");
+    expect(icons[1]).toHaveClass("lucide-square-terminal");
+  });
+
+  it("falls back to a neutral page glyph, not the terminal one, for an unmapped page icon", () => {
+    const { container } = renderTabs([{ ...pageTab, icon: "NotARealIcon" }, sessionTab], "$page");
+
+    const icon = container.querySelector(".tsh-tab-icon");
+    expect(icon).toHaveClass("lucide-file");
+    expect(icon).not.toHaveClass("lucide-square-terminal");
+  });
+
+  it("renders with nothing selected while a terminal pane is active", () => {
+    // Terminal panes are reached from the Chats list and are filtered out of the strip, so
+    // the server sends no selected id: the page tab must not claim to be current.
+    const { container } = renderTabs([pageTab, sessionTab], undefined);
+
+    expect(container.querySelector(".tsh-tabs")).not.toBeNull();
+    expect(screen.getAllByRole("tab").every((t) => t.getAttribute("aria-selected") === "false")).toBe(
+      true,
+    );
+  });
+
+  it("selects the page tab on click, so a session no longer traps the user", () => {
+    const { eventHandler } = renderTabs([pageTab, sessionTab], "tab-1");
+
+    fireEvent.click(screen.getByText("Review"));
+
+    expect(eventHandler).toHaveBeenCalledWith("OnSelect", "tabs-1", ["$page"]);
+  });
+
+  it("marks the page tab active when no session is selected", () => {
+    renderTabs([pageTab, sessionTab], "$page");
+
+    expect(screen.getAllByRole("tab")[0]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("gives the page tab no close button and ignores middle-click on it", () => {
+    const { eventHandler } = renderTabs([pageTab, sessionTab], "$page");
+
+    expect(screen.queryByLabelText("Close Review")).toBeNull();
+    expect(screen.getByLabelText("Close #74 Run")).toBeInTheDocument();
+
+    fireEvent(
+      screen.getAllByRole("tab")[0],
+      new MouseEvent("auxclick", { bubbles: true, button: 1 }),
+    );
+    expect(eventHandler).not.toHaveBeenCalledWith("OnClose", "tabs-1", ["$page"]);
+  });
+
+  it("closes a session tab from its close button without selecting it", () => {
+    const { eventHandler } = renderTabs([pageTab, sessionTab], "$page");
+
+    fireEvent.click(screen.getByLabelText("Close #74 Run"));
+
+    expect(eventHandler).toHaveBeenCalledWith("OnClose", "tabs-1", ["tab-1"]);
+    expect(eventHandler).not.toHaveBeenCalledWith("OnSelect", "tabs-1", ["tab-1"]);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellTabs.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellTabs.tsx
@@ -1,5 +1,24 @@
 import React from "react";
-import { Plus, SquareTerminal, X } from "lucide-react";
+import {
+  Activity,
+  ChartBar,
+  Feather,
+  File,
+  FileText,
+  GitPullRequest,
+  Inbox,
+  Info,
+  Lightbulb,
+  LucideIcon,
+  MessageSquare,
+  Plus,
+  Rocket,
+  Settings as SettingsIcon,
+  Snowflake,
+  SquareTerminal,
+  ThumbsUp,
+  X,
+} from "lucide-react";
 import { ShellTabDto, ShellWidgetProps } from "./types";
 import "./shell.css";
 
@@ -8,7 +27,27 @@ interface ShellTabsProps extends ShellWidgetProps {
   selectedId?: string;
 }
 
-/** The agent-session tab strip at the bottom of the content area. */
+/* Only the page tab carries an icon name - the icon of the app it reveals - so this
+   covers the [App] icons that can appear as a page. An unmapped name falls back to the
+   neutral page glyph rather than the terminal one, which would misread the tab as a
+   session; session tabs pass no name at all and always get the terminal glyph. */
+const tabIcons: Record<string, LucideIcon> = {
+  Activity,
+  ChartBar,
+  Feather,
+  FileText,
+  GitPullRequest,
+  Inbox,
+  Info,
+  Lightbulb,
+  MessageSquare,
+  Rocket,
+  Settings: SettingsIcon,
+  Snowflake,
+  ThumbsUp,
+};
+
+/** The session tab strip at the bottom of the content area, led by the page tab. */
 export const ShellTabs: React.FC<ShellTabsProps> = ({
   id,
   events = [],
@@ -20,45 +59,54 @@ export const ShellTabs: React.FC<ShellTabsProps> = ({
     if (events.includes(eventName)) eventHandler(eventName, id, args);
   };
 
-  // With no sessions open the strip would be an empty band with a lone "+",
-  // so it stays hidden until the first tab exists (new sessions start from the
-  // sidebar agent row instead).
-  if (tabs.length === 0) return null;
+  // With no sessions open the strip would be the page tab alone beside a "+", so it
+  // stays hidden until a session exists (new sessions start from the sidebar agent row).
+  // TendrilShell's `hasTabs` gates the surrounding row on the same condition, counting the
+  // session tabs before the page tab is prepended - keep the two in step.
+  if (tabs.every((tab) => tab.closable === false)) return null;
 
   return (
     <div className="tsh-tabs">
-      {tabs.map((tab) => (
-        <div
-          key={tab.id}
-          className="tsh-tab"
-          data-active={tab.id === selectedId}
-          role="tab"
-          aria-selected={tab.id === selectedId}
-          tabIndex={0}
-          onClick={() => fire("OnSelect", [tab.id])}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") fire("OnSelect", [tab.id]);
-          }}
-          onAuxClick={(e) => {
-            if (e.button === 1) fire("OnClose", [tab.id]);
-          }}
-        >
-          <span className="tsh-tab-main">
-            <SquareTerminal size={16} className="tsh-tab-icon" />
-            <span className="tsh-tab-label">{tab.title}</span>
-          </span>
-          <button
-            className="tsh-tab-close"
-            aria-label={`Close ${tab.title}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              fire("OnClose", [tab.id]);
+      {tabs.map((tab) => {
+        const closable = tab.closable !== false;
+        const TabIcon =
+          (tab.icon ? tabIcons[tab.icon] : undefined) ?? (closable ? SquareTerminal : File);
+        return (
+          <div
+            key={tab.id}
+            className="tsh-tab"
+            data-active={tab.id === selectedId}
+            data-closable={closable}
+            role="tab"
+            aria-selected={tab.id === selectedId}
+            tabIndex={0}
+            onClick={() => fire("OnSelect", [tab.id])}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") fire("OnSelect", [tab.id]);
+            }}
+            onAuxClick={(e) => {
+              if (e.button === 1 && closable) fire("OnClose", [tab.id]);
             }}
           >
-            <X size={16} />
-          </button>
-        </div>
-      ))}
+            <span className="tsh-tab-main">
+              <TabIcon size={16} className="tsh-tab-icon" />
+              <span className="tsh-tab-label">{tab.title}</span>
+            </span>
+            {closable && (
+              <button
+                className="tsh-tab-close"
+                aria-label={`Close ${tab.title}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  fire("OnClose", [tab.id]);
+                }}
+              >
+                <X size={16} />
+              </button>
+            )}
+          </div>
+        );
+      })}
       <button className="tsh-tab-new" aria-label="New agent session" onClick={() => fire("OnNew")}>
         <Plus size={16} />
       </button>

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -1106,6 +1106,12 @@
   opacity: 0.6;
 }
 
+/* The page tab has no close button, so it needn't reserve a 200px column for one. */
+.tsh-tab[data-closable="false"] {
+  width: auto;
+  max-width: 200px;
+}
+
 .tsh-tab-icon {
   width: 16px;
   height: 16px;

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/types.ts
@@ -38,6 +38,10 @@ export interface ShellSectionItemDto {
 export interface ShellTabDto {
   id: string;
   title: string;
+  /** The page tab cannot be closed: it is how the user gets back to the page behind the sessions. */
+  closable?: boolean;
+  /** Lucide icon name; defaults to the terminal glyph used by session tabs. */
+  icon?: string;
 }
 
 export const isMac = (): boolean =>

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -82,6 +82,44 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
            && index >= 0
            && index < tabCount;
 
+    /// <summary>
+    ///     The bottom strip's entries: a non-closable page tab first, then the session tabs.
+    ///     The page tab is what makes a session escapable - without it, opening a review action
+    ///     hides the page with no way back but closing every session (issue #2245).
+    /// </summary>
+    internal static List<ShellTabDto> BuildStripTabs(
+        string pageTitle, string? pageIcon, IEnumerable<(string Id, string Title)> sessionTabs)
+    {
+        var strip = new List<ShellTabDto> { new(PageTabId, pageTitle, Closable: false, Icon: pageIcon) };
+        strip.AddRange(sessionTabs.Select(t => new ShellTabDto(t.Id, t.Title)));
+        return strip;
+    }
+
+    /// <summary>
+    ///     The strip's selected id: the active session's, or the page tab when no session is
+    ///     showing. A terminal pane is not in the strip (it is reached from the Chats list), so
+    ///     it selects nothing rather than falsely marking the page tab as current.
+    /// </summary>
+    /// <summary>
+    ///     The page tab's title: the selected sidebar row when the page has one (so the strip
+    ///     reads "#74 Draft | #74 Run Tests" rather than the generic "Plans"), else the app's
+    ///     own title. A row whose title is blank falls back too.
+    /// </summary>
+    internal static string PageTabTitle(string appTitle, ShellSidebarListState? sidebarList)
+    {
+        if (sidebarList?.SelectedId is not { Length: > 0 } selectedId) return appTitle;
+
+        var selectedRow = sidebarList.Items.FirstOrDefault(i => i.Id == selectedId);
+        return selectedRow?.Title is { Length: > 0 } rowTitle ? rowTitle : appTitle;
+    }
+
+    internal static string? SelectedStripTabId(ImmutableArray<TabState> tabs, int? selectedIndex)
+    {
+        if (selectedIndex is not { } index || index < 0 || index >= tabs.Length) return PageTabId;
+        var tab = tabs[index];
+        return string.Equals(tab.AppId, AgentAppId, StringComparison.OrdinalIgnoreCase) ? null : tab.Id;
+    }
+
     internal static MenuItem[] BuildHelpMenuItems(bool isBeta, IClientProvider? client, INavigator? navigator)
     {
         var items = new List<MenuItem>
@@ -123,6 +161,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
     private const string AgentAppId = "agent";
     private const string ChatAppId = "chat";
     private const string InboxAppId = "inbox";
+
+    // Identifies the strip's leading tab, which reveals the page behind the session panes.
+    // Session tab ids are Guids or chat session ids, so the "$" prefix cannot collide.
+    internal const string PageTabId = "$page";
 
     private static readonly HashSet<string> SidebarSectionAppIds = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -677,6 +719,49 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             RedirectToAppIfNotError(new NavigateArgs(tab.AppId), tabId: tab.Id);
         }
 
+        // The page tab is named after the page it reveals - preferring the selected sidebar row,
+        // so it names the plan and not just "Plans" - falling back to "Home" when the shell is
+        // showing the wallpaper (no page opened yet this session). GetAppOrDefault matches how
+        // SetAppTitle and HandleCreateNewTab resolve a descriptor; currentApp always holds a
+        // real app id, so the "or default" arm is unreachable here.
+        (string Title, string? Icon) PageTabDisplay()
+        {
+            if (currentApp.Value?.AppId is not { } pageAppId) return ("Home", null);
+
+            var (title, icon) = BrandedAppDisplay(appRepository.GetAppOrDefault(pageAppId));
+            var pageList = sidebarList.Value is { } published
+                           && string.Equals(published.AppId, pageAppId, StringComparison.OrdinalIgnoreCase)
+                ? published
+                : null;
+            return (PageTabTitle(title, pageList), icon?.ToString());
+        }
+
+        // Reveals whatever sits behind the session panes: the open page, or the wallpaper
+        // (with the sidebar reopened, since there is nothing else left to navigate from).
+        // Shared by the page tab and by closing the last session so the two cannot drift.
+        void RevealPageBehindSessions()
+        {
+            if (currentApp.Value is { } page)
+            {
+                SetAppTitle(page.AppId);
+                RedirectToAppIfNotError(new NavigateArgs(page.AppId, page.AppArgs));
+                return;
+            }
+
+            client.SetTitle(serverArgs.Metadata.Title);
+            client.Redirect("/");
+            sidebarOpen.Set(true);
+        }
+
+        // Leaves every session pane mounted, so a review action's terminal keeps running
+        // while the reviewer goes back to the plan.
+        void ShowPage()
+        {
+            if (selectedIndex.Value == null) return;
+            selectedIndex.Set((int?)null);
+            RevealPageBehindSessions();
+        }
+
         void OnTabClose(int closedIndex)
         {
             if (!CheckTabExists(closedIndex)) return;
@@ -713,17 +798,9 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 SetTabTitle(tab);
                 RedirectToAppIfNotError(new NavigateArgs(tab.AppId), tabId: tab.Id);
             }
-            else if (currentApp.Value is { } page)
-            {
-                // The page is still open behind the sessions; reveal it again.
-                SetAppTitle(page.AppId);
-                RedirectToAppIfNotError(new NavigateArgs(page.AppId, page.AppArgs));
-            }
             else
             {
-                client.SetTitle(serverArgs.Metadata.Title);
-                client.Redirect("/");
-                sidebarOpen.Set(true);
+                RevealPageBehindSessions();
             }
         }
 
@@ -938,12 +1015,20 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             .ToArray();
 
         // Terminal panes are reached from the Chats list, so the strip only shows the other
-        // session tabs (review actions).
+        // session tabs (review actions). It is led by a non-closable tab for the page hidden
+        // behind them, so opening a review action no longer strands the reviewer on its
+        // terminal until every session is closed (issue #2245).
         var stripTabs = tabs.Value.Where(t => !IsAgentTab(t)).ToList();
+        var (pageTabTitle, pageTabIcon) = PageTabDisplay();
+
         var tabsWidget = new ShellTabs()
-            .Tabs(stripTabs.Select(t => new ShellTabDto(t.Id, t.Title)).ToList())
-            .SelectedId(selectedIndex.Value is { } si && CheckTabExists(si) ? tabs.Value[si].Id : null)
-            .OnSelect(tabId => SelectSession(FindTabIndexById(tabId)))
+            .Tabs(BuildStripTabs(pageTabTitle, pageTabIcon, stripTabs.Select(t => (t.Id, t.Title))))
+            .SelectedId(SelectedStripTabId(tabs.Value, selectedIndex.Value))
+            .OnSelect(tabId =>
+            {
+                if (tabId == PageTabId) ShowPage();
+                else SelectSession(FindTabIndexById(tabId));
+            })
             .OnClose(tabId => OnTabClose(FindTabIndexById(tabId)))
             .OnNew(StartNewChat);
 
@@ -1015,6 +1100,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 tabs: tabsWidget,
                 hidden: [selectInputWarmup, closeTabShortcut])
             .Collapsed(!sidebarOpen.Value)
+            // Counts session tabs only: the page tab never keeps the strip alive on its own.
+            // ShellTabs applies the same rule to its own markup - keep the two in step.
             .HasTabs(stripTabs.Count > 0)
             .ActiveSessionIndex(selectedIndex.Value)
             .OnCollapsedChanged(collapsed =>


### PR DESCRIPTION
## Problem

Clicking a review action navigates to `ReviewActionApp`, which the shell routes to `CreateNewTab` (the app is declared `allowDuplicateTabs: true`). `HandleCreateNewTab` then selects the new tab, hiding the page behind the session pane.

The dead end was that the bottom tab strip listed **only session tabs** — nothing on screen represented the page. `selectedIndex` was cleared in just two places: opening a page, and closing the *last* tab. So the reviewer was stranded on the terminal until every session was closed, exactly as reported.

## Fix

The strip now leads with a non-closable **page tab** for whatever sits behind the session panes. Selecting it reveals the page while leaving every session pane mounted, so the action's terminal keeps running.

- The page tab is named after the selected sidebar row where the page has one — `Harden release pipeline | #382 Run App` rather than a generic `Review` — and carries the page app's own icon.
- Closing the last session and the page tab now share one `RevealPageBehindSessions` helper, so the wallpaper fallback (which reopens the sidebar) cannot drift between the two paths.
- The strip still stays hidden until a session exists, so nothing changes for users who never run a review action.

## Verification

Ran the app against a scratch `TENDRIL_HOME` with seeded plans and reproduced the original flow from the Review page:

- Clicking the page tab returns to the exact plan, terminal still running; clicking back returns to the live terminal.
- Navigating the sidebar while a terminal is open retitles the page tab with the right icon.
- Closing the last session still hides the strip and restores the page — unchanged behaviour.

Tests: 3438 C# (+12 new), 585 frontend (+9 new), `tsc --noEmit` and `dotnet format --verify-no-changes` clean, build clean with no warnings.

## Note on approach

This is fixed at the shell level rather than by making `ReviewActionApp` open without stealing focus: Ivy's `INavigator` exposes no background/in-place option, so suppressing the focus steal would mean bypassing the public navigation API. The page tab also fixes the same trap for any future session app.

Fixes #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)