### PR TITLE
fix(build): disable IvyEnableExternalWidgets to resolve duplicate embedded resources

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,5 +5,7 @@
     <IvySource Condition="'$(IvySource)' == '' And Exists('$(MSBuildThisFileDirectory)../../Ivy-Framework/src/Ivy/Ivy.csproj')">true</IvySource>
     <IvySource Condition="'$(IvySource)' == ''">false</IvySource>
     <IvySource Condition="'$(GITHUB_ACTIONS)' == 'true' or '$(Publishing)' == 'true'">false</IvySource>
+    <!-- Ivy.Tendril.Widgets manages its own frontend build and embedding -->
+    <IvyEnableExternalWidgets>false</IvyEnableExternalWidgets>
   </PropertyGroup>
 </Project>

--- a/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
+++ b/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <IvyEnableExternalWidgets>false</IvyEnableExternalWidgets>
   </PropertyGroup>
   <ItemGroup>
     <!-- WebViewerProxy hosts endpoints on the consuming app's origin. -->


### PR DESCRIPTION
## Summary
When building/packaging \Ivy.Tendril.Widgets\ against the NuGet package of \Ivy\ (\IvySource=false\), the NuGet build targets in \Ivy\ automatically import \Ivy.ExternalWidget.targets\. That target attempts to build and embed any files in \rontend/dist/**/*\.

Since \Ivy.Tendril.Widgets\ already manages its own custom frontend build and resource embedding, this caused duplicate \EmbeddedResource\ items for \ivy-tendril-widgets.js\ and \ivy-tendril-widgets.css\, leading to compiler error \CS1508\.

Setting \<IvyEnableExternalWidgets>false</IvyEnableExternalWidgets>\ disables the imported external widget target so \Ivy.Tendril.Widgets\'s own target embeds the frontend bundle cleanly.