### PR TITLE
[00263] Fix Agent Chat Keyboard Shortcut in Collapsed Sidebar Tooltip

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ShellAgentButton } from "./ShellAgentButton";
 
@@ -91,5 +91,31 @@ describe("ShellAgentButton", () => {
     expect(spans[0].textContent).toBe("Ctrl");
     expect(spans[1].textContent).toBe("Alt");
     expect(spans[2].textContent).toBe("A");
+  });
+
+  it("renders tooltip with three-key shortcut on hover", () => {
+    vi.useFakeTimers();
+    render(
+      <ShellAgentButton
+        id="agent"
+        events={["OnNewChat"]}
+        eventHandler={vi.fn()}
+        label="Claude Code"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Claude Code" });
+    fireEvent.pointerMove(button);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent("Claude Code");
+    const kbd = tooltip.querySelector(".tui-kbd");
+    expect(kbd).toBeInTheDocument();
+    expect(kbd?.textContent).toBe("Ctrl+Alt+A");
+    vi.useRealTimers();
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.tsx
@@ -54,11 +54,10 @@ export const ShellAgentButton: React.FC<ShellAgentButtonProps> = ({
   }, [fireNewChat, shortcutKey]);
 
   const hintKeys = isMac() ? ["⌘", "⌥", shortcutKey] : ["Ctrl", "Alt", shortcutKey];
-  const shortcutBadge = isMac() ? `⌘+${shortcutKey}` : `Ctrl+${shortcutKey}`;
 
   return (
     <div className="tsh-agent-wrap">
-      <ShellTooltip content={label} shortcut={shortcutBadge} side="right">
+      <ShellTooltip content={label} shortcut={hintKeys} side="right">
         <button className="tsh-agent" data-active={isActive} onClick={fireOpen} aria-label={label}>
           <span className="tsh-row">
             <span className="tsh-agent-brand">


### PR DESCRIPTION
Fixes #2500

# Summary

## Changes

Fixed the keyboard shortcut displayed in the collapsed sidebar tooltip for the Agent Chat button. Passing `hintKeys` directly to `ShellTooltip` ensures that the Option/Alt modifier key is properly included on both macOS and Windows/Linux instead of omitting the modifier.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.tsx`: Removed `shortcutBadge` and passed `hintKeys` directly to `ShellTooltip`.
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx`: Added unit test verifying tooltip shortcut keys.

## Manual Testing

1. Launch Tendril desktop or web server (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj`).
2. Collapse the left sidebar rail if it is expanded.
3. Hover your mouse over the Agent Chat button in the collapsed sidebar.
4. Observe the tooltip: on macOS it should display "⌘ ⌥ A" (with thin spaces between modifiers), and on Windows/Linux it should display "Ctrl+Alt+A".

---
- 9161cf36 Fix agent chat keyboard shortcut in collapsed sidebar tooltip (00263)

---
Created using [Ivy Tendril](https://ivy.app).
