### PR TITLE
[00267] Fix Cut Off Create Project Button in Add Project Dialog

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Onboarding/ProjectInputStepViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Onboarding/ProjectInputStepViewTests.cs
@@ -1,0 +1,31 @@
+using Ivy.Tendril.Apps.Onboarding;
+
+namespace Ivy.Tendril.Test.Apps.Onboarding;
+
+public class ProjectInputStepViewTests
+{
+    [Fact]
+    public void BackgroundButton_RendersWithBackgroundLabel()
+    {
+        var button = ProjectInputStepView.BuildBackgroundButton(canContinue: true, onClick: () => { });
+
+        Assert.Equal("Background", button.Title);
+        Assert.Equal(ProjectInputStepView.BackgroundButtonLabel, button.Title);
+    }
+
+    [Fact]
+    public void BackgroundButton_WhenCanContinueIsTrue_IsNotDisabled()
+    {
+        var button = ProjectInputStepView.BuildBackgroundButton(canContinue: true, onClick: () => { });
+
+        Assert.False(button.Disabled);
+    }
+
+    [Fact]
+    public void BackgroundButton_WhenCanContinueIsFalse_IsDisabled()
+    {
+        var button = ProjectInputStepView.BuildBackgroundButton(canContinue: false, onClick: () => { });
+
+        Assert.True(button.Disabled);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -21,6 +21,17 @@ public class ProjectInputStepView(
     bool disableSkipWhenCannotContinue = false,
     bool showHeader = true) : ViewBase
 {
+    public const string BackgroundButtonLabel = "Background";
+
+    public static Button BuildBackgroundButton(bool canContinue, Action onClick)
+    {
+        return new Button(BackgroundButtonLabel)
+            .Outline()
+            .Large()
+            .Disabled(!canContinue)
+            .OnClick(onClick);
+    }
+
     public override object Build()
     {
         var config = UseService<IConfigService>();
@@ -79,7 +90,7 @@ public class ProjectInputStepView(
             | new Spacer()
             | (onBack != null ? (object)new Button("Back").Outline().Large().Icon(Icons.ArrowLeft).OnClick(onBack) : null!)
             | (isBeta
-                ? (object)new Button("Background (beta)").Outline().Large().Disabled(!canContinue).OnClick(handleBgJob)
+                ? (object)BuildBackgroundButton(canContinue, handleBgJob)
                 : null!)
             | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .Disabled(!canContinue)


### PR DESCRIPTION
Fixes #2506

# Summary

## Changes

Removed the "(beta)" suffix from the "Background (beta)" button in the Add Project dialog, changing its label to "Background". This reduces the button width and prevents the adjacent "Create Project" action button from being cut off at the right edge of the dialog.

## API Changes

None.

## Files Modified

- **UI Views**: `src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs` (Updated background button label and added `BuildBackgroundButton` helper)
- **Unit Tests**: `src/Ivy.Tendril.Test/Apps/Onboarding/ProjectInputStepViewTests.cs` (New unit tests for `ProjectInputStepView` background button label and state)

## Manual Testing

1. Launch Tendril.
2. Navigate to Settings -> Projects and click "Add Project" to open the Add New Project dialog.
3. Observe the bottom action bar in Step 0 of the dialog.
4. Verify that the button label displays as "Background" instead of "Background (beta)".
5. Verify that the "Create Project" button is fully visible and not cut off at the right edge.

---
- 4bd94d07 [00267] Remove (beta) label from Background button in Add Project dialog

---
Created using [Ivy Tendril](https://ivy.app).
