### PR TITLE
[00265] Show Context-Aware Sample Prompts When Displaying Chat

### DIFF
--- a/src/Ivy.Tendril.Test/ChatSamplePromptProviderTests.cs
+++ b/src/Ivy.Tendril.Test/ChatSamplePromptProviderTests.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Ivy.Tendril.Apps.Chat;
+using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Chat;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class ChatSamplePromptProviderTests
+{
+    private static PlanFile CreatePlan(
+        int id,
+        string title,
+        PlanStatus status = PlanStatus.Draft,
+        string latestRevision = "",
+        List<string>? dependsOn = null,
+        List<PlanVerificationEntry>? verifications = null)
+    {
+        var folderName = $"{id:D5}-{title.Replace(' ', '-')}";
+        var metadata = new PlanMetadata(
+            Id: id,
+            Project: "Acme",
+            Level: "Feature",
+            Title: title,
+            State: status,
+            Repos: [],
+            Commits: [],
+            Prs: [],
+            Verifications: verifications ?? [],
+            RelatedPlans: [],
+            DependsOn: dependsOn ?? [],
+            Created: DateTime.UtcNow,
+            Updated: DateTime.UtcNow,
+            InitialPrompt: null,
+            SourceUrl: null,
+            ChatSessionId: null);
+
+        return new PlanFile(metadata, latestRevision, $"/tmp/Plans/{folderName}", "");
+    }
+
+    [Fact]
+    public void GetPromptsForPlan_DraftPlan_IncludesSolutionApproachAndTestCoverage()
+    {
+        var plan = CreatePlan(1, "Draft feature", PlanStatus.Draft);
+
+        var prompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
+        Assert.Contains("Explain the solution approach for this plan", prompts);
+        Assert.Contains("Add unit tests to the plan's test section", prompts);
+        Assert.Contains("What are the risks and dependencies of this approach?", prompts);
+        Assert.Contains("Make this plan more concise", prompts);
+        Assert.DoesNotContain("Help me answer the open questions", prompts);
+        Assert.DoesNotContain("What dependencies block this plan?", prompts);
+    }
+
+    [Fact]
+    public void GetPromptsForPlan_DraftPlan_WithOpenQuestions_IncludesAnswerOpenQuestions()
+    {
+        var revisionMarkdown = @"# Sample Plan
+
+```questions
+questions:
+  - id: choice-1
+    title: Which strategy to choose?
+    options:
+      - title: Option A
+        value: option-a
+      - title: Option B
+        value: option-b
+```
+";
+        var plan = CreatePlan(2, "Plan with questions", PlanStatus.Draft, latestRevision: revisionMarkdown);
+
+        var prompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
+        Assert.Contains("Help me answer the open questions", prompts);
+    }
+
+    [Fact]
+    public void GetPromptsForPlan_DraftPlan_WithAnsweredQuestions_DoesNotIncludeAnswerOpenQuestions()
+    {
+        var revisionMarkdown = @"# Sample Plan
+
+```questions
+questions:
+  - id: choice-1
+    title: Which strategy to choose?
+    options:
+      - title: Option A
+        value: option-a
+      - title: Option B
+        value: option-b
+    answer: option-a
+```
+";
+        var plan = CreatePlan(3, "Plan with answered questions", PlanStatus.Draft, latestRevision: revisionMarkdown);
+
+        var prompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
+        Assert.DoesNotContain("Help me answer the open questions", prompts);
+    }
+
+    [Fact]
+    public void GetPromptsForPlan_DraftPlan_WithDependsOn_IncludesDependencyQuestion()
+    {
+        var plan = CreatePlan(4, "Plan with dependencies", PlanStatus.Draft, dependsOn: ["00100-BasePlan"]);
+
+        var prompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
+        Assert.Contains("What dependencies block this plan?", prompts);
+    }
+
+    [Fact]
+    public void GetPromptsForPlan_ReviewPlan_IncludesDiffReviewVerificationCheckAndPrPrompts()
+    {
+        var plan = CreatePlan(5, "Review feature", PlanStatus.Review);
+
+        var prompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
+        Assert.Contains("Explain the implementation changes made", prompts);
+        Assert.Contains("Review the git diff for potential issues", prompts);
+        Assert.Contains("Create the pull request", prompts);
+        Assert.Contains("Retry the plan with adjustments", prompts);
+        Assert.DoesNotContain("Why did verification fail?", prompts);
+    }
+
+    [Fact]
+    public void GetPromptsForPlan_ReviewPlan_WithFailedVerification_IncludesWhyVerificationFailed()
+    {
+        var verifications = new List<PlanVerificationEntry>
+        {
+            new() { Name = "DotnetBuild", Status = VerificationStatus.Pass },
+            new() { Name = "DotnetTest", Status = VerificationStatus.Fail }
+        };
+        var plan = CreatePlan(6, "Review feature failing", PlanStatus.Review, verifications: verifications);
+
+        var prompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
+        Assert.Contains("Why did verification fail?", prompts);
+        Assert.Contains("Retry the plan with adjustments", prompts);
+    }
+
+    [Fact]
+    public void GetPromptsForPlan_FailedPlan_IncludesFailureDiagnosis()
+    {
+        var plan = CreatePlan(7, "Failed feature", PlanStatus.Failed);
+
+        var prompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
+        Assert.Contains("Why did the plan execution fail?", prompts);
+        Assert.Contains("Retry the plan with fixes for the errors", prompts);
+    }
+
+    [Fact]
+    public void GetPromptsForPlan_CompletedPlan_IncludesCompletionSummaryAndPrDetails()
+    {
+        var plan = CreatePlan(8, "Completed feature", PlanStatus.Completed);
+
+        var prompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
+        Assert.Contains("Summarize what was delivered in this plan", prompts);
+        Assert.Contains("Review the pull request details", prompts);
+    }
+
+    [Fact]
+    public void GetPromptsForPlan_DefaultOrOtherState_ReturnsFallbackPrompts()
+    {
+        var plan = CreatePlan(9, "Executing feature", PlanStatus.Executing);
+
+        var prompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
+        Assert.Contains("Explain the solution approach", prompts);
+        Assert.Contains("What is the status of this plan?", prompts);
+    }
+
+    [Fact]
+    public void GetPromptsForGeneralChat_WithRegisteredProject_IncludesProjectAwarePrompts()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilSamplePromptsTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var settings = new TendrilSettings();
+            var config = new ConfigService(settings, tempDir);
+            config.Projects.Add(new ProjectConfig { Name = "awesome-app" });
+
+            var prompts = ChatSamplePromptProvider.GetPromptsForGeneralChat(config);
+
+            Assert.Contains("Create a plan to add <feature> to awesome-app", prompts);
+            Assert.Contains("What plans are in Draft or Review?", prompts);
+            Assert.Contains("Review recent job failures", prompts);
+            Assert.Contains("Explain the architecture and tech stack of awesome-app", prompts);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void GetPromptsForGeneralChat_WithoutProject_FallsBackToGenericPrompts()
+    {
+        var prompts = ChatSamplePromptProvider.GetPromptsForGeneralChat(null);
+
+        Assert.Contains("Create a new plan", prompts);
+        Assert.Contains("What plans are in Draft or Review?", prompts);
+        Assert.Contains("Review recent job failures", prompts);
+        Assert.Contains("Explain the architecture and tech stack", prompts);
+    }
+
+    [Fact]
+    public void ContentView_ExposesSamplePromptsWhenSupplied()
+    {
+        var samplePrompts = new List<string> { "Prompt A", "Prompt B" };
+
+        var contentView = new ContentView(
+            activeSession: null,
+            activeSessionId: new FakeState<string?>(null),
+            sessionVersion: new FakeState<int>(0),
+            selectedAgent: new FakeState<string>("claude"),
+            selectedModel: new FakeState<string>("opus"),
+            selectedEffort: new FakeState<string>("default"),
+            sessionDtos: [],
+            agentDtos: [],
+            modelDtos: [],
+            effortDtos: [],
+            supportsEffort: false,
+            isStreaming: false,
+            streamingText: "",
+            greeting: "Hello",
+            headline: "Headline",
+            chatService: null!,
+            executionService: null!,
+            agentRunner: null!,
+            sendMessage: _ => { },
+            selectSession: _ => { },
+            startNewChat: () => { },
+            embedded: false,
+            samplePrompts: samplePrompts
+        );
+
+        Assert.NotNull(contentView.SamplePrompts);
+        Assert.Equal(2, contentView.SamplePrompts.Count);
+        Assert.Equal("Prompt A", contentView.SamplePrompts[0]);
+    }
+
+    private sealed class FakeState<T> : Ivy.IState<T>
+    {
+        private readonly T _initial;
+
+        public FakeState(T initial)
+        {
+            _initial = initial;
+            Value = initial;
+        }
+
+        public T Value { get; set; }
+        public IDisposable Subscribe(IObserver<T> observer) => throw new NotImplementedException();
+        public void Dispose() { }
+        public T Set(T value) => Value = value;
+        public T Set(Func<T, T> setter) => Value = setter(Value);
+        public T Reset() => Value = _initial;
+        public IDisposable SubscribeAny(Action action) => throw new NotImplementedException();
+        public IDisposable SubscribeAny(Action<object?> action) => throw new NotImplementedException();
+        public Type GetStateType() => typeof(T);
+        public object? GetValueAsObject() => Value;
+        public Ivy.IEffectTrigger ToTrigger() => throw new NotImplementedException();
+    }
+}

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -112,6 +112,7 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Prop] public List<ChatJobDto>? RunningJobs { get; init; }
     [Prop] public string? Greeting { get; init; }
     [Prop] public string? Headline { get; init; }
+    [Prop] public List<string> SamplePrompts { get; init; } = new();
 
     /// <summary>Hosted inside another page (the plan chat panel): no title bar, a tighter composer.</summary>
     [Prop] public bool Embedded { get; init; }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -640,3 +640,119 @@ describe("ChatWidget Markdown Code Blocks", () => {
     expect(codeBlock?.textContent).toContain("def add(a, b):");
   });
 });
+
+describe("ChatWidget Sample Prompts", () => {
+  beforeEach(() => {
+    setupChatWidgetTestEnvironment();
+  });
+
+  it("renders sample prompt cards in empty state when samplePrompts prop is provided", () => {
+    const samplePrompts = [
+      "Explain the solution approach for this plan",
+      "Add unit tests to the plan's test section",
+    ];
+
+    const { container } = render(
+      <ChatWidget
+        id="test-chat"
+        samplePrompts={samplePrompts}
+      />,
+    );
+
+    const cardsContainer = container.querySelector(".chat-sample-prompts");
+    expect(cardsContainer).toBeInTheDocument();
+
+    const cards = container.querySelectorAll(".chat-sample-prompt-card");
+    expect(cards.length).toBe(2);
+    expect(cards[0].textContent).toContain("Explain the solution approach for this plan");
+    expect(cards[1].textContent).toContain("Add unit tests to the plan's test section");
+  });
+
+  it("renders sample prompt chips above composer when messages exist", () => {
+    const samplePrompts = [
+      "Explain the implementation changes made",
+      "Review the git diff for potential issues",
+    ];
+    const session: ChatSessionDto = {
+      id: "s-active",
+      title: "Active session",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: "",
+      updatedAt: "",
+      messages: [
+        {
+          id: "m-1",
+          role: "user",
+          content: "Hello",
+          timestamp: "",
+        },
+      ],
+    };
+
+    const { container } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="s-active"
+        sessions={[session]}
+        samplePrompts={samplePrompts}
+      />,
+    );
+
+    const emptyContainer = container.querySelector(".chat-empty-state");
+    expect(emptyContainer).toBeNull();
+
+    const chipsBar = container.querySelector(".chat-sample-prompts-bar");
+    expect(chipsBar).toBeInTheDocument();
+
+    const chips = container.querySelectorAll(".chat-sample-prompt-chip");
+    expect(chips.length).toBe(2);
+    expect(chips[0].textContent).toContain("Explain the implementation changes made");
+    expect(chips[1].textContent).toContain("Review the git diff for potential issues");
+  });
+
+  it("clicking a sample prompt populates the textarea and focuses the input", () => {
+    const samplePrompts = [
+      "Explain the solution approach for this plan",
+    ];
+
+    const { container } = render(
+      <ChatWidget
+        id="test-chat"
+        samplePrompts={samplePrompts}
+      />,
+    );
+
+    const textarea = container.querySelector(".chat-textarea") as HTMLTextAreaElement;
+    expect(textarea).toBeInTheDocument();
+    expect(textarea.value).toBe("");
+
+    const card = container.querySelector(".chat-sample-prompt-card") as HTMLButtonElement;
+    expect(card).toBeInTheDocument();
+
+    fireEvent.click(card);
+
+    expect(textarea.value).toBe("Explain the solution approach for this plan");
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("embedded chat mode renders sample prompts correctly", () => {
+    const samplePrompts = [
+      "Explain the solution approach for this plan",
+    ];
+
+    const { container } = render(
+      <ChatWidget
+        id="test-chat"
+        embedded={true}
+        samplePrompts={samplePrompts}
+      />,
+    );
+
+    const root = container.querySelector(".chat-widget-root");
+    expect(root).toHaveAttribute("data-embedded", "true");
+
+    const cardsContainer = container.querySelector(".chat-sample-prompts");
+    expect(cardsContainer).toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -150,6 +150,7 @@ export function ChatWidget({
   runningJobs = [],
   greeting,
   headline = "What Are We Producing Today?",
+  samplePrompts = [],
   embedded = false,
   events = [],
   eventHandler,
@@ -642,6 +643,12 @@ export function ChatWidget({
     }
   };
 
+  const handleSelectSamplePrompt = (prompt: string) => {
+    setPromptText(prompt);
+    adjustTextareaHeight();
+    textareaRef.current?.focus();
+  };
+
   const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setPromptText(e.target.value);
     adjustTextareaHeight();
@@ -779,6 +786,21 @@ export function ChatWidget({
             <div className="chat-empty-state">
               {greeting && <div className="chat-empty-greeting">{greeting}</div>}
               <div className="chat-empty-headline">{headline}</div>
+              {samplePrompts && samplePrompts.length > 0 && (
+                <div className="chat-sample-prompts">
+                  {samplePrompts.map((prompt, idx) => (
+                    <button
+                      key={idx}
+                      type="button"
+                      className="chat-sample-prompt-card"
+                      onClick={() => handleSelectSamplePrompt(prompt)}
+                    >
+                      <Sparkles className="chat-sample-prompt-icon" size={16} />
+                      <span className="chat-sample-prompt-text">{prompt}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
           )}
           <div ref={spacerRef} className="chat-scroll-spacer" aria-hidden="true" />
@@ -871,6 +893,22 @@ export function ChatWidget({
                   ))}
                 </div>
               )}
+            </div>
+          )}
+
+          {hasThreadContent && samplePrompts && samplePrompts.length > 0 && (
+            <div className="chat-sample-prompts-bar">
+              {samplePrompts.map((prompt, idx) => (
+                <button
+                  key={idx}
+                  type="button"
+                  className="chat-sample-prompt-chip"
+                  onClick={() => handleSelectSamplePrompt(prompt)}
+                >
+                  <Sparkles className="chat-sample-prompt-chip-icon" size={13} />
+                  <span className="chat-sample-prompt-chip-text">{prompt}</span>
+                </button>
+              ))}
             </div>
           )}
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -482,6 +482,93 @@ button.chat-jobs-dropdown-item:hover {
   color: var(--tch-fg);
 }
 
+.chat-sample-prompts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 10px;
+  width: 100%;
+  max-width: 680px;
+  margin-top: 24px;
+}
+
+.chat-sample-prompt-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--tch-border);
+  border-radius: 10px;
+  background: var(--tch-surface);
+  color: var(--tch-fg);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.chat-sample-prompt-card:hover {
+  background: var(--tch-surface-hover);
+  border-color: color-mix(in srgb, var(--tch-border) 60%, var(--tch-fg));
+}
+
+.chat-sample-prompt-card .chat-sample-prompt-icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--tch-muted);
+}
+
+.chat-sample-prompt-card:hover .chat-sample-prompt-icon {
+  color: var(--tch-fg);
+}
+
+.chat-sample-prompt-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-sample-prompts-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  overflow-x: auto;
+  padding: 0 0 8px;
+  scrollbar-width: thin;
+}
+
+.chat-sample-prompt-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--tch-border);
+  border-radius: 9999px;
+  background: var(--tch-surface);
+  color: var(--tch-muted);
+  font: inherit;
+  font-size: 12px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.chat-sample-prompt-chip:hover {
+  background: var(--tch-surface-hover);
+  color: var(--tch-fg);
+  border-color: color-mix(in srgb, var(--tch-border) 60%, var(--tch-fg));
+}
+
+.chat-sample-prompt-chip-icon {
+  flex-shrink: 0;
+}
+
+.chat-sample-prompt-chip-text {
+  white-space: nowrap;
+}
+
 .chat-message-row {
   display: flex;
   width: 100%;
@@ -1776,6 +1863,19 @@ button.chat-system-event-plan {
   font-size: 20px;
   font-weight: 500;
   line-height: 26px;
+}
+
+.chat-widget-root[data-embedded="true"] .chat-sample-prompts {
+  grid-template-columns: 1fr;
+  max-width: 100%;
+  margin-top: 16px;
+  gap: 8px;
+}
+
+.chat-widget-root[data-embedded="true"] .chat-sample-prompt-card {
+  padding: 8px 10px;
+  font-size: 12px;
+  border-radius: 8px;
 }
 
 .chat-widget-root[data-embedded="true"] .chat-footer {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
@@ -104,6 +104,7 @@ export interface ChatWidgetProps {
   /** Shown above the headline while the conversation is empty, e.g. "Good Morning, Joel!". */
   greeting?: string;
   headline?: string;
+  samplePrompts?: string[];
   /** Hosted inside another page (the plan chat panel): no title bar, a tighter composer. */
   embedded?: boolean;
   events?: string[];

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -14,7 +14,9 @@ using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Chat;
 using Ivy.Tendril.Services.Jobs;
+using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Widgets;
 
 namespace Ivy.Tendril.Apps.Chat;
@@ -88,6 +90,7 @@ public class ChatApp : ViewBase
         var executionService = UseService<IChatExecutionService>();
         var agentRunner = UseService<IAgentRunner>();
         Context.TryUseService<IJobService>(out var jobService);
+        Context.TryUseService<IPlanReaderService>(out var planService);
         Context.TryUseService<IChatAgentPreferences>(out var preferences);
         var navigator = UseNavigation();
         var sidebarListSignal = Context.UseSignal<ShellSidebarListSignal, ShellSidebarListState, Unit>();
@@ -305,6 +308,16 @@ public class ChatApp : ViewBase
             showSearchDialog,
             StartNewChat));
 
+        PlanFile? attachedPlan = null;
+        if (activeSession != null && !string.IsNullOrEmpty(activeSession.PlanFolderName) && planService != null)
+        {
+            attachedPlan = ContentView.FindPlan(planService, activeSession.PlanFolderName);
+        }
+
+        var samplePrompts = attachedPlan != null
+            ? ChatSamplePromptProvider.GetPromptsForPlan(attachedPlan)
+            : ChatSamplePromptProvider.GetPromptsForGeneralChat(configService, planService, jobService);
+
         var content = new ContentView(
             activeSession,
             activeSessionId,
@@ -326,7 +339,9 @@ public class ChatApp : ViewBase
             agentRunner,
             SendMessage,
             SelectSession,
-            StartNewChat
+            StartNewChat,
+            embedded: false,
+            samplePrompts: samplePrompts
         );
 
         return new Fragment(content, searchDialog);

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -10,6 +10,7 @@ using Ivy.Tendril.Apps.Chat.Dialogs;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Chat;
 using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Widgets;
 
@@ -37,11 +38,13 @@ public class ContentView(
     Action<ChatSendMessageDto> sendMessage,
     Action<string> selectSession,
     Action startNewChat,
-    bool embedded = false) : ViewBase
+    bool embedded = false,
+    List<string>? samplePrompts = null) : ViewBase
 {
     internal IState<string> SelectedAgentState => selectedAgent;
     internal IState<string> SelectedModelState => selectedModel;
     internal IState<string> SelectedEffortState => selectedEffort;
+    internal List<string>? SamplePrompts => samplePrompts;
 
     /// <summary>The plan a job event names, by folder, numeric id or zero-padded id.</summary>
     internal static PlanFile? FindPlan(IPlanReaderService planService, string planId)
@@ -102,6 +105,20 @@ public class ContentView(
                 .Select(ChatApp.ToJobDto).ToList()
             : new List<ChatJobDto>();
 
+        var resolvedPrompts = samplePrompts;
+        if (resolvedPrompts == null)
+        {
+            PlanFile? attachedPlan = null;
+            if (activeSession != null && !string.IsNullOrEmpty(activeSession.PlanFolderName) && planService != null)
+            {
+                attachedPlan = FindPlan(planService, activeSession.PlanFolderName);
+            }
+
+            resolvedPrompts = attachedPlan != null
+                ? ChatSamplePromptProvider.GetPromptsForPlan(attachedPlan)
+                : ChatSamplePromptProvider.GetPromptsForGeneralChat(configService, planService, jobService);
+        }
+
         var chatWidget = new ChatWidget
         {
             ActiveSessionId = activeSessionId.Value,
@@ -121,6 +138,7 @@ public class ContentView(
             Greeting = greeting,
             Headline = headline,
             Embedded = embedded,
+            SamplePrompts = resolvedPrompts,
 
             OnSelectSession = e =>
             {

--- a/src/Ivy.Tendril/Apps/Views/PlanChatView.cs
+++ b/src/Ivy.Tendril/Apps/Views/PlanChatView.cs
@@ -3,6 +3,7 @@ using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Apps.Chat;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Chat;
 using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Widgets;
 
@@ -130,6 +131,8 @@ public class PlanChatView(PlanFile plan) : ViewBase
             streamVersion.Set(v => v + 1);
         }
 
+        var samplePrompts = ChatSamplePromptProvider.GetPromptsForPlan(plan);
+
         return new Chat.ContentView(
             session,
             activeSessionId,
@@ -152,7 +155,8 @@ public class PlanChatView(PlanFile plan) : ViewBase
             SendMessage,
             id => activeSessionId.Set(id),
             startNewChat: () => { },
-            embedded: true);
+            embedded: true,
+            samplePrompts: samplePrompts);
 
         string DefaultAgent(ChatSessionModel? sess) =>
             sess?.AgentId ?? configService.Settings.CodingAgent ?? "claude";

--- a/src/Ivy.Tendril/Services/Chat/ChatSamplePromptProvider.cs
+++ b/src/Ivy.Tendril/Services/Chat/ChatSamplePromptProvider.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Widgets;
+
+namespace Ivy.Tendril.Services.Chat;
+
+public static class ChatSamplePromptProvider
+{
+    public static List<string> GetPromptsForPlan(PlanFile plan)
+    {
+        if (plan == null) return [];
+
+        var prompts = new List<string>();
+
+        switch (plan.Status)
+        {
+            case PlanStatus.Draft:
+                prompts.Add("Explain the solution approach for this plan");
+                prompts.Add("Add unit tests to the plan's test section");
+                prompts.Add("What are the risks and dependencies of this approach?");
+                prompts.Add("Make this plan more concise");
+
+                if (!string.IsNullOrWhiteSpace(plan.LatestRevisionContent))
+                {
+                    var questions = QuestionAnswers.Read(plan.LatestRevisionContent);
+                    if (questions.Any(q => !q.HasAnswer))
+                    {
+                        prompts.Add("Help me answer the open questions");
+                    }
+                }
+
+                if (plan.DependsOn != null && plan.DependsOn.Count > 0)
+                {
+                    prompts.Add("What dependencies block this plan?");
+                }
+                break;
+
+            case PlanStatus.Review:
+                prompts.Add("Explain the implementation changes made");
+                prompts.Add("Review the git diff for potential issues");
+                prompts.Add("Create the pull request");
+
+                var hasFailedVerification = plan.Verifications != null &&
+                    plan.Verifications.Any(v => v.Status == VerificationStatus.Fail);
+                if (hasFailedVerification)
+                {
+                    prompts.Add("Why did verification fail?");
+                }
+
+                prompts.Add("Retry the plan with adjustments");
+                break;
+
+            case PlanStatus.Failed:
+                prompts.Add("Why did the plan execution fail?");
+                prompts.Add("Retry the plan with fixes for the errors");
+                break;
+
+            case PlanStatus.Completed:
+                prompts.Add("Summarize what was delivered in this plan");
+                prompts.Add("Review the pull request details");
+                break;
+
+            default:
+                prompts.Add("Explain the solution approach");
+                prompts.Add("What is the status of this plan?");
+                break;
+        }
+
+        return prompts;
+    }
+
+    public static List<string> GetPromptsForGeneralChat(
+        IConfigService? configService = null,
+        IPlanReaderService? planService = null,
+        IJobService? jobService = null)
+    {
+        var prompts = new List<string>();
+        var primaryProject = configService?.Projects?.FirstOrDefault()?.Name;
+
+        if (!string.IsNullOrWhiteSpace(primaryProject))
+        {
+            prompts.Add($"Create a plan to add <feature> to {primaryProject}");
+        }
+        else
+        {
+            prompts.Add("Create a new plan");
+        }
+
+        prompts.Add("What plans are in Draft or Review?");
+        prompts.Add("Review recent job failures");
+
+        if (!string.IsNullOrWhiteSpace(primaryProject))
+        {
+            prompts.Add($"Explain the architecture and tech stack of {primaryProject}");
+        }
+        else
+        {
+            prompts.Add("Explain the architecture and tech stack");
+        }
+
+        return prompts;
+    }
+}


### PR DESCRIPTION
Fixes #2510

# Summary

## Changes

Added context-aware sample prompts to Tendril chat interfaces. Users opening chat in a plan context (Draft, Review, Failed, Completed) or general chat are now presented with actionable suggestion cards and chips that populate the composer upon click.

## API Changes

- Added `ChatSamplePromptProvider` class in `Ivy.Tendril.Services.Chat` with `GetPromptsForPlan` and `GetPromptsForGeneralChat` static methods.
- Added `[Prop] public List<string> SamplePrompts { get; init; }` property to `ChatWidget`.
- Added optional `List<string>? samplePrompts = null` parameter to `ContentView` constructor.
- Added `samplePrompts?: string[]` to `ChatWidgetProps` in frontend `types.ts`.

## Files Modified

- `Ivy.Tendril/Services/Chat/ChatSamplePromptProvider.cs`: Provider for context-aware sample prompts based on plan status, open questions, dependencies, and project configuration.
- `Ivy.Tendril.Widgets/ChatWidget.cs`: Added `SamplePrompts` property.
- `Ivy.Tendril/Apps/Chat/ContentView.cs`: Wired `samplePrompts` through to `ChatWidget`.
- `Ivy.Tendril/Apps/Views/PlanChatView.cs`: Provided plan-specific sample prompts to `ContentView`.
- `Ivy.Tendril/Apps/Chat/ChatApp.cs`: Resolved attached plan prompts or general chat prompts and supplied them to `ContentView`.
- `Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx`: Rendered sample prompt cards in empty state and chip bar in active conversations.
- `Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css`: Added styles for prompt cards, prompt chips, and embedded view.
- `Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts`: Added `samplePrompts` to widget props.
- `Ivy.Tendril.Test/ChatSamplePromptProviderTests.cs`: Unit tests for sample prompt provider and content view.
- `Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Unit tests for frontend cards, chips, clicking, and embedded layout.

## Manual Testing

1. Run the application: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Open the Chat app from the sidebar with no active chat: observe the empty state displays context-aware cards for general chat (e.g. plan creation, status, and architecture queries).
3. Click any sample prompt card: observe the composer textarea is populated with the prompt text and focused.
4. Send a message to start a conversation: observe the sample prompt chips appear in a horizontal bar above the composer.
5. Open a Draft plan and expand the chat panel: observe Draft-specific prompts (such as explaining solution approach, adding unit tests).
6. Open a Review plan: observe Review-specific prompts (such as reviewing git diff, explaining changes, creating pull request).

---
- e3f24e0f Add frontend sample prompt cards, active conversation chip bar, and tests (#00265)
- 88a4d23a Add context-aware chat sample prompts provider and backend wiring (#00265)

---
Created using [Ivy Tendril](https://ivy.app).
