### PR TITLE
[00269] Default Codex Deep Profile to 5.6 Sol

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -683,15 +683,15 @@ codingAgents:
   environmentVariables: {}
   profiles:
   - name: deep
-    model: default
+    model: gpt-5.6-sol
     effort: high
     arguments: ''
   - name: balanced
-    model: default
+    model: gpt-5.6-terra
     effort: medium
     arguments: ''
   - name: quick
-    model: default
+    model: gpt-5.6-luna
     effort: low
     arguments: ''
 - name: opencode

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -232,6 +232,95 @@ public class AgentProviderFactoryTests
     }
 
     [Fact]
+    public void Resolve_CodexWithDefaultModel_ResolvesToCliDefaultProfile()
+    {
+        var runner = CreateRunner();
+        var settings = CreateSettings(
+            "codex",
+            codingAgents: new List<AgentConfig>
+            {
+                new()
+                {
+                    Name = "codex",
+                    Profiles = new List<AgentProfileConfig>
+                    {
+                        new() { Name = "deep", Model = "default", Effort = "high" }
+                    }
+                }
+            },
+            promptwares: new Dictionary<string, PromptwareConfig>
+            {
+                ["_default"] = new() { Profile = "deep" }
+            });
+
+        var resolution = AgentProviderFactory.Resolve(runner, settings, "Test");
+
+        Assert.Equal("codex", resolution.AgentId);
+        Assert.Equal("gpt-5.6-sol", resolution.Model);
+        Assert.Equal("high", resolution.Effort);
+    }
+
+    [Theory]
+    [InlineData("balanced", "gpt-5.6-terra", "medium")]
+    [InlineData("quick", "gpt-5.6-luna", "low")]
+    public void Resolve_CodexWithDefaultModel_ResolvesBalancedAndQuick(string profile, string expectedModel, string expectedEffort)
+    {
+        var runner = CreateRunner();
+        var settings = CreateSettings(
+            "codex",
+            codingAgents: new List<AgentConfig>
+            {
+                new()
+                {
+                    Name = "codex",
+                    Profiles = new List<AgentProfileConfig>
+                    {
+                        new() { Name = profile, Model = "default", Effort = "default" }
+                    }
+                }
+            },
+            promptwares: new Dictionary<string, PromptwareConfig>
+            {
+                ["_default"] = new() { Profile = profile }
+            });
+
+        var resolution = AgentProviderFactory.Resolve(runner, settings, "Test");
+
+        Assert.Equal("codex", resolution.AgentId);
+        Assert.Equal(expectedModel, resolution.Model);
+        Assert.Equal(expectedEffort, resolution.Effort);
+    }
+
+    [Fact]
+    public void Resolve_CodexWithExplicitModel_PreservesExplicitModel()
+    {
+        var runner = CreateRunner();
+        var settings = CreateSettings(
+            "codex",
+            codingAgents: new List<AgentConfig>
+            {
+                new()
+                {
+                    Name = "codex",
+                    Profiles = new List<AgentProfileConfig>
+                    {
+                        new() { Name = "deep", Model = "o3", Effort = "high" }
+                    }
+                }
+            },
+            promptwares: new Dictionary<string, PromptwareConfig>
+            {
+                ["_default"] = new() { Profile = "deep" }
+            });
+
+        var resolution = AgentProviderFactory.Resolve(runner, settings, "Test");
+
+        Assert.Equal("codex", resolution.AgentId);
+        Assert.Equal("o3", resolution.Model);
+        Assert.Equal("high", resolution.Effort);
+    }
+
+    [Fact]
     public void Resolve_MatchesCapitalizedAgentName_ClaudeCode()
     {
         var runner = CreateRunner();

--- a/src/Ivy.Tendril/Services/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/AgentProviderFactory.cs
@@ -154,10 +154,34 @@ public static class AgentProviderFactory
                 cli.Capabilities.HasFlag(AgentCapabilities.ModelSelection))
                 model = profile.Model;
             if (!string.IsNullOrEmpty(profile.Effort) &&
+                !profile.Effort.Equals("default", StringComparison.OrdinalIgnoreCase) &&
                 cli.Capabilities.HasFlag(AgentCapabilities.EffortControl))
                 effort = profile.Effort;
             if (!string.IsNullOrWhiteSpace(profile.Arguments))
                 extraArgs.AddRange(SplitArgs(profile.Arguments));
+        }
+
+        var targetProfile = profile?.Name ?? profileName;
+        var tier = !string.IsNullOrEmpty(targetProfile) ? MapProfileTier(targetProfile) : null;
+        if (tier.HasValue && cli.DefaultProfiles != null)
+        {
+            var defaultProfile = cli.DefaultProfiles.FirstOrDefault(p => p.Tier == tier.Value);
+            if (defaultProfile != null)
+            {
+                if (string.IsNullOrEmpty(model) &&
+                    cli.Capabilities.HasFlag(AgentCapabilities.ModelSelection) &&
+                    !string.IsNullOrEmpty(defaultProfile.Model))
+                {
+                    model = defaultProfile.Model;
+                }
+
+                if (string.IsNullOrEmpty(effort) &&
+                    cli.Capabilities.HasFlag(AgentCapabilities.EffortControl) &&
+                    !string.IsNullOrEmpty(defaultProfile.Effort))
+                {
+                    effort = defaultProfile.Effort;
+                }
+            }
         }
 
         // The applied profile is the one that was found, not the one that was asked for: an override
@@ -165,6 +189,14 @@ public static class AgentProviderFactory
         // recording the request rather than the fallback would misreport what the job ran under.
         return (model, effort, profile?.Name ?? "");
     }
+
+    private static ProfileTier? MapProfileTier(string profileName) => profileName.ToLowerInvariant() switch
+    {
+        "deep" => ProfileTier.Deep,
+        "balanced" => ProfileTier.Balanced,
+        "quick" => ProfileTier.Quick,
+        _ => null
+    };
 
     internal static string NormalizeAgentName(string name) => name.ToLowerInvariant() switch
     {

--- a/src/Ivy.Tendril/Services/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/AgentProviderFactory.cs
@@ -170,14 +170,16 @@ public static class AgentProviderFactory
             {
                 if (string.IsNullOrEmpty(model) &&
                     cli.Capabilities.HasFlag(AgentCapabilities.ModelSelection) &&
-                    !string.IsNullOrEmpty(defaultProfile.Model))
+                    !string.IsNullOrEmpty(defaultProfile.Model) &&
+                    !defaultProfile.Model.Equals("default", StringComparison.OrdinalIgnoreCase))
                 {
                     model = defaultProfile.Model;
                 }
 
                 if (string.IsNullOrEmpty(effort) &&
                     cli.Capabilities.HasFlag(AgentCapabilities.EffortControl) &&
-                    !string.IsNullOrEmpty(defaultProfile.Effort))
+                    !string.IsNullOrEmpty(defaultProfile.Effort) &&
+                    !defaultProfile.Effort.Equals("default", StringComparison.OrdinalIgnoreCase))
                 {
                     effort = defaultProfile.Effort;
                 }


### PR DESCRIPTION
Fixes #2514

# Summary

## Changes

Enhanced `AgentProviderFactory` to resolve models and effort levels from agent CLI `DefaultProfiles` when configured profiles specify empty or "default" values. Updated Team Ivy configuration to explicitly define OpenAI's `gpt-5.6-sol` model for Codex's deep profile (alongside `gpt-5.6-terra` for balanced and `gpt-5.6-luna` for quick).

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Services/AgentProviderFactory.cs`: Added tier mapping and fallback to `cli.DefaultProfiles` for model and effort resolution.
- `src/Ivy.Tendril.TeamIvyConfig/config.yaml`: Explicitly configured `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` for Codex profiles.
- `src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs`: Added unit tests for default Codex profile resolution and explicit model overrides.

## Manual Testing

1. Run the test suite:
   `dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~AgentProviderFactoryTests"`
2. Verify all tests pass, confirming that `codex` configured with `model: default` resolves to `gpt-5.6-sol` for the deep tier.

---
- 7e0267fe Ignore 'default' sentinel values when resolving from DefaultProfiles (Plan 00269)
- 0d540611 Default Codex deep profile to 5.6 sol (Plan 00269)

---
Created using [Ivy Tendril](https://ivy.app).
