### PR TITLE
[00303] Publish VS Code Extension in Release Workflow

### DIFF
--- a/.claude/skills/tendril-release/SKILL.md
+++ b/.claude/skills/tendril-release/SKILL.md
@@ -23,7 +23,7 @@ This skill automates the release preparation and deployment process for Ivy Tend
 6. **Creates a Pull Request** from `development` into `main`.
 7. **Merges the PR** into `main` (if mergeable).
 8. **Synchronizes the branches** by merging `main` back into `development`.
-9. **Triggers the GitHub release workflow** (`publish-tendril.yml`) on `main` (or on a test branch like `development` with `test-mode` enabled), publishing NuGet packages, desktop installers, and the VS Code extension.
+9. **Triggers the GitHub release workflow** (`publish-tendril.yml`) on `main` (or on a test branch like `development` with `test-mode` enabled), publishing NuGet packages and desktop installers.
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ This skill automates the release preparation and deployment process for Ivy Tend
 
 ## Step-by-Step Workflow
 
-### Phase 1 — Create Release Prep Branch
+### Phase 1: Create Release Prep Branch
 Ensure the workspace is clean and up to date, then check out a temporary package update branch from `development`:
 ```bash
 git checkout development
@@ -44,13 +44,13 @@ git pull origin development
 git checkout -b release/update-packages
 ```
 
-### Phase 2 — Update Ivy packages
+### Phase 2: Update Ivy packages
 Run the PowerShell update script. This script temporarily disables local `IvySource` references to allow NuGet resolution, finds all package references starting with `Ivy` or `Ivy.*` in all project files, runs `dotnet add` to update them to their latest versions, and restores the original settings when finished:
 ```bash
 pwsh src/.releases/UpdateIvyPackages.ps1
 ```
 
-### Phase 3 — Verify Build
+### Phase 3: Verify Build
 Verify that the package updates do not break compilation. Run builds with `IvySource` set to `false` to verify NuGet package resolution:
 ```bash
 dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj /p:IvySource=false
@@ -58,7 +58,7 @@ dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj /p:IvySource=false
 
 If the build fails, abort the process and notify the developer. Do not proceed to commit.
 
-### Phase 4 — Merge to Development and Increment Version
+### Phase 4: Merge to Development and Increment Version
 If the build succeeds, commit the changes and merge the branch back into `development`:
 ```bash
 git add .
@@ -81,13 +81,13 @@ git commit -m "chore: bump patch version for release"
 git push origin development
 ```
 
-### Phase 5 — Create and Merge PR into Main
+### Phase 5: Create and Merge PR into Main
 Generate a Pull Request to merge the updated `development` branch into `main`:
 ```bash
 gh pr create --base main --head development --title "Release: Merge development into main" --body "Automated release PR created by Tendril Release Skill."
 ```
 
-Once the PR is created, wait for/trigger the merge:
+Once the PR is created, wait for or trigger the merge:
 - **If checks are required or you want to queue it**:
   ```bash
   gh pr merge --merge --auto
@@ -97,8 +97,8 @@ Once the PR is created, wait for/trigger the merge:
   gh pr merge --merge
   ```
 
-### Phase 6 — Sync Main Back into Development
-Keep the branches perfectly in sync by merging `main` back into `development` after the PR is merged:
+### Phase 6: Sync Main Back into Development
+Keep the branches in sync by merging `main` back into `development` after the PR is merged:
 ```bash
 git checkout main
 git pull origin main
@@ -117,25 +117,61 @@ The release workflow executes the following pipeline jobs:
 - `version`: Resolves the release version from git tags or `src/Directory.Build.props`.
 - `publish-nuget`: Packs, signs, and pushes NuGet packages to nuget.org.
 - `publish-desktop`: Builds and packages native desktop installers (Windows, macOS, Linux).
-- `publish-vscode-extension`: Runs typechecking, builds, tests, packages into `.vsix`, uploads to release assets, and publishes to Visual Studio Code Marketplace and Open VSX.
-- `upload-release-assets`: Downloads desktop installers and VS Code extension artifacts and publishes them to the GitHub release.
+- `upload-release-assets`: Downloads desktop installers and publishes them to the GitHub release.
 
 #### Test Mode Deployment
-To run a test deployment dry run (which compiles, packages, and uploads unsigned NuGet, desktop installer, and VS Code extension artifacts to the workflow run, while skipping all signing, notarization, publishing, and docs deployment), trigger the workflow with `test-mode` set to `true` (this can be run on `development` or `main`):
+To run a test deployment dry run (which compiles, packages, and uploads unsigned NuGet and desktop installer artifacts to the workflow run, while skipping all signing, notarization, NuGet push, GitHub release creation, Docker image push, and Azure production docs deployment), trigger the workflow with `test-mode` set to `true` (this can be run on `development` or `main`):
 ```bash
 gh workflow run publish-tendril.yml --ref development -f test-mode=true
 ```
 
 In test mode (`test-mode=true`):
 - It performs a side-effect-free release dry run.
-- It compiles, packages, and uploads unsigned NuGet, desktop installer, and VS Code extension (.vsix) artifacts to the workflow run.
-- It runs typecheck, unit tests, version synchronization, and packaging for the VS Code extension.
-- It completely skips all signing (SSL.com NuGet and Windows signing, Apple codesign and productsign), Apple notarization, NuGet push, VS Code Marketplace publishing, Open VSX publishing, GitHub release creation and asset uploads, Docker image push, and Azure production docs deployment.
+- It compiles, packages, and uploads unsigned NuGet and desktop installer artifacts to the workflow run.
+- It completely skips all signing (SSL.com NuGet and Windows signing, Apple codesign and productsign), Apple notarization, NuGet push, GitHub release creation, Docker image push, and Azure production docs deployment.
 
-Confirm that the workflow has been dispatched by showing the URL/logs:
+Confirm that the workflow has been dispatched by showing the URL or logs:
 ```bash
 gh run list --workflow=publish-tendril.yml --limit 1
 ```
+
+---
+
+### Phase 8: Publish VS Code Extension (Standalone Workflow)
+The VS Code extension has a decoupled release cadence and is published independently via `.github/workflows/publish-vscode-extension.yml`.
+
+#### Production Release
+Trigger via git tag:
+```bash
+git tag vscode-v0.1.1
+git push origin vscode-v0.1.1
+```
+
+Or trigger via GitHub CLI:
+```bash
+gh workflow run publish-vscode-extension.yml --ref development -f version=0.1.1
+```
+
+The workflow executes:
+1. Installs dependencies and runs typecheck (`npm run typecheck`).
+2. Builds the extension and runs tests (`npm test`).
+3. Resolves and synchronizes the version in `package.json`.
+4. Packages the extension into `.vsix` using `@vscode/vsce`.
+5. Uploads the `.vsix` artifact to the workflow run.
+6. Creates or updates GitHub release `vscode-v<version>` with the `.vsix` asset.
+7. Publishes to the Visual Studio Code Marketplace using `VSCE_PAT`.
+8. Publishes to the Open VSX Registry using `OVSX_PAT` if provided.
+
+#### Test Mode (Dry Run)
+To verify extension typechecking, testing, and `.vsix` packaging without publishing to marketplaces or creating release assets:
+```bash
+gh workflow run publish-vscode-extension.yml --ref development -f test-mode=true
+```
+
+In test mode (`test-mode=true`):
+- Runs typecheck, build, unit tests, and `.vsix` packaging.
+- Uploads the generated `.vsix` as a workflow artifact.
+- Skips GitHub release creation, asset upload, Visual Studio Code Marketplace publishing, and Open VSX publishing.
 
 ---
 

--- a/.claude/skills/tendril-release/SKILL.md
+++ b/.claude/skills/tendril-release/SKILL.md
@@ -23,12 +23,14 @@ This skill automates the release preparation and deployment process for Ivy Tend
 6. **Creates a Pull Request** from `development` into `main`.
 7. **Merges the PR** into `main` (if mergeable).
 8. **Synchronizes the branches** by merging `main` back into `development`.
-9. **Triggers the GitHub release workflow** (`publish-tendril.yml`) on `main` (or on a test branch like `development` with `test-mode` enabled).
+9. **Triggers the GitHub release workflow** (`publish-tendril.yml`) on `main` (or on a test branch like `development` with `test-mode` enabled), publishing NuGet packages, desktop installers, and the VS Code extension.
 
 ## Prerequisites
 
 - **GitHub CLI** (`gh`) must be installed and authenticated with PR and workflow write access.
 - **PowerShell 7** (`pwsh`) must be installed on the system.
+- **VSCE_PAT Secret**: Repository secret containing a Personal Access Token with Marketplace (Manage) permissions to publish the VS Code extension to the Visual Studio Code Marketplace.
+- **OVSX_PAT Secret** (optional): Repository secret containing an access token to publish the VS Code extension to the Eclipse Open VSX Registry.
 
 ---
 
@@ -105,22 +107,30 @@ git merge main --no-ff -m "Merge branch 'main' into development to sync"
 git push origin development
 ```
 
-### Phase 7 — Trigger Release Workflow
+### Phase 7: Trigger Release Workflow
 Trigger the release Action workflow (`publish-tendril.yml`) on `main`:
 ```bash
 gh workflow run publish-tendril.yml --ref main
 ```
 
+The release workflow executes the following pipeline jobs:
+- `version`: Resolves the release version from git tags or `src/Directory.Build.props`.
+- `publish-nuget`: Packs, signs, and pushes NuGet packages to nuget.org.
+- `publish-desktop`: Builds and packages native desktop installers (Windows, macOS, Linux).
+- `publish-vscode-extension`: Runs typechecking, builds, tests, packages into `.vsix`, uploads to release assets, and publishes to Visual Studio Code Marketplace and Open VSX.
+- `upload-release-assets`: Downloads desktop installers and VS Code extension artifacts and publishes them to the GitHub release.
+
 #### Test Mode Deployment
-To run a test deployment dry run (which compiles, packages, and uploads unsigned NuGet and desktop installer artifacts to the workflow run, while skipping all signing, notarization, NuGet push, GitHub release creation, Docker image push, and Azure production docs deployment), trigger the workflow with `test-mode` set to `true` (this can be run on `development` or `main`):
+To run a test deployment dry run (which compiles, packages, and uploads unsigned NuGet, desktop installer, and VS Code extension artifacts to the workflow run, while skipping all signing, notarization, publishing, and docs deployment), trigger the workflow with `test-mode` set to `true` (this can be run on `development` or `main`):
 ```bash
 gh workflow run publish-tendril.yml --ref development -f test-mode=true
 ```
 
 In test mode (`test-mode=true`):
 - It performs a side-effect-free release dry run.
-- It compiles, packages, and uploads unsigned NuGet and desktop installer artifacts to the workflow run.
-- It completely skips all signing (SSL.com NuGet and Windows signing, Apple codesign and productsign), Apple notarization, NuGet push, GitHub release creation, Docker image push, and Azure production docs deployment.
+- It compiles, packages, and uploads unsigned NuGet, desktop installer, and VS Code extension (.vsix) artifacts to the workflow run.
+- It runs typecheck, unit tests, version synchronization, and packaging for the VS Code extension.
+- It completely skips all signing (SSL.com NuGet and Windows signing, Apple codesign and productsign), Apple notarization, NuGet push, VS Code Marketplace publishing, Open VSX publishing, GitHub release creation and asset uploads, Docker image push, and Azure production docs deployment.
 
 Confirm that the workflow has been dispatched by showing the URL/logs:
 ```bash

--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -727,8 +727,96 @@ jobs:
             releases/RELEASES
             releases/releases.*.json
 
+  publish-vscode-extension:
+    needs: version
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: extensions/vscode
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+      - name: Build extension and tests
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Sync version
+        run: |
+          npm version ${{ needs.version.outputs.version }} --no-git-tag-version --allow-same-version
+
+      - name: Package extension (.vsix)
+        run: |
+          npx --yes @vscode/vsce package --no-git-tag-version --allow-missing-repository --skip-license -o ivy-tendril-${{ needs.version.outputs.version }}.vsix
+
+      - name: Upload VS Code Extension Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tendril-vscode-extension-${{ needs.version.outputs.version }}
+          path: extensions/vscode/*.vsix
+
+      - name: Upload VSIX to Release Assets
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.version.outputs.version }}"
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $TAG does not exist yet; creating release..."
+            gh release create "$TAG" --repo "${{ github.repository }}" --generate-notes
+          fi
+          gh release upload "$TAG" *.vsix --repo "${{ github.repository }}" --clobber
+
+      - name: Publish to Visual Studio Code Marketplace
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [ -n "$VSCE_PAT" ]; then
+            npx --yes @vscode/vsce publish --packagePath *.vsix --skip-duplicate
+          else
+            echo "VSCE_PAT secret is not set; skipping Visual Studio Code Marketplace publishing."
+          fi
+
+      - name: Publish to Open VSX Registry (Optional)
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          if [ -n "$OVSX_PAT" ]; then
+            npx --yes ovsx publish *.vsix --skip-duplicate
+          else
+            echo "OVSX_PAT secret is not set; skipping Open VSX publishing."
+          fi
+
+      - name: Extension publish summary
+        if: always()
+        run: |
+          echo "## Ivy Tendril VS Code Extension" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Version: ${{ needs.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Marketplace**: [Ivy Tendril](https://marketplace.visualstudio.com/items?itemName=ivy-interactive.ivy-tendril)" >> $GITHUB_STEP_SUMMARY
+
   upload-release-assets:
-    needs: [version, publish-nuget, publish-desktop]
+    needs: [version, publish-nuget, publish-desktop, publish-vscode-extension]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
     steps:
@@ -736,6 +824,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: tendril-installer-*
+          merge-multiple: true
+
+      - name: Download VS Code extension artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: tendril-vscode-extension-*
           merge-multiple: true
 
       - name: Create or Upload to Release

--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -727,96 +727,8 @@ jobs:
             releases/RELEASES
             releases/releases.*.json
 
-  publish-vscode-extension:
-    needs: version
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: extensions/vscode
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run typecheck
-        run: npm run typecheck
-
-      - name: Build extension and tests
-        run: npm run build
-
-      - name: Run tests
-        run: npm test
-
-      - name: Sync version
-        run: |
-          npm version ${{ needs.version.outputs.version }} --no-git-tag-version --allow-same-version
-
-      - name: Package extension (.vsix)
-        run: |
-          npx --yes @vscode/vsce package --no-git-tag-version --allow-missing-repository --skip-license -o ivy-tendril-${{ needs.version.outputs.version }}.vsix
-
-      - name: Upload VS Code Extension Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: tendril-vscode-extension-${{ needs.version.outputs.version }}
-          path: extensions/vscode/*.vsix
-
-      - name: Upload VSIX to Release Assets
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="v${{ needs.version.outputs.version }}"
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            TAG="${{ github.event.release.tag_name }}"
-          fi
-          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "Release $TAG does not exist yet; creating release..."
-            gh release create "$TAG" --repo "${{ github.repository }}" --generate-notes
-          fi
-          gh release upload "$TAG" *.vsix --repo "${{ github.repository }}" --clobber
-
-      - name: Publish to Visual Studio Code Marketplace
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: |
-          if [ -n "$VSCE_PAT" ]; then
-            npx --yes @vscode/vsce publish --packagePath *.vsix --skip-duplicate
-          else
-            echo "VSCE_PAT secret is not set; skipping Visual Studio Code Marketplace publishing."
-          fi
-
-      - name: Publish to Open VSX Registry (Optional)
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
-        env:
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
-        run: |
-          if [ -n "$OVSX_PAT" ]; then
-            npx --yes ovsx publish *.vsix --skip-duplicate
-          else
-            echo "OVSX_PAT secret is not set; skipping Open VSX publishing."
-          fi
-
-      - name: Extension publish summary
-        if: always()
-        run: |
-          echo "## Ivy Tendril VS Code Extension" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Version: ${{ needs.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Marketplace**: [Ivy Tendril](https://marketplace.visualstudio.com/items?itemName=ivy-interactive.ivy-tendril)" >> $GITHUB_STEP_SUMMARY
-
   upload-release-assets:
-    needs: [version, publish-nuget, publish-desktop, publish-vscode-extension]
+    needs: [version, publish-nuget, publish-desktop]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
     steps:
@@ -824,12 +736,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: tendril-installer-*
-          merge-multiple: true
-
-      - name: Download VS Code extension artifact
-        uses: actions/download-artifact@v4
-        with:
-          pattern: tendril-vscode-extension-*
           merge-multiple: true
 
       - name: Create or Upload to Release

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -1,0 +1,128 @@
+name: Publish VS Code Extension
+
+permissions:
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version override (e.g. 0.1.1). Defaults to version in package.json if empty.'
+        required: false
+        type: string
+        default: ''
+      test-mode:
+        description: 'Run in test mode (build, test, package, and upload artifacts without publishing)'
+        required: false
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'vscode-v*'
+
+jobs:
+  publish-vscode-extension:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: extensions/vscode
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: extensions/vscode/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+      - name: Build extension and tests
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            VERSION="${TAG#vscode-v}"
+            VERSION="${VERSION#v}"
+          elif [ -n "${{ inputs.version }}" ]; then
+            INPUT_VER="${{ inputs.version }}"
+            VERSION="${INPUT_VER#v}"
+          else
+            VERSION=$(node -p "require('./package.json').version")
+          fi
+          echo "Resolved version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Package extension (.vsix)
+        run: |
+          npx --yes @vscode/vsce package --no-git-tag-version --allow-missing-repository --skip-license -o ivy-tendril-${{ steps.version.outputs.version }}.vsix
+
+      - name: Upload VS Code Extension Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tendril-vscode-extension-${{ steps.version.outputs.version }}
+          path: extensions/vscode/*.vsix
+
+      - name: Upload VSIX to Release Assets
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="vscode-v${{ steps.version.outputs.version }}"
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $TAG does not exist yet; creating release..."
+            gh release create "$TAG" --repo "${{ github.repository }}" --title "VS Code Extension v${{ steps.version.outputs.version }}" --generate-notes
+          fi
+          gh release upload "$TAG" *.vsix --repo "${{ github.repository }}" --clobber
+
+      - name: Publish to Visual Studio Code Marketplace
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [ -n "$VSCE_PAT" ]; then
+            npx --yes @vscode/vsce publish --packagePath *.vsix --skip-duplicate
+          else
+            echo "VSCE_PAT secret is not set; skipping Visual Studio Code Marketplace publishing."
+          fi
+
+      - name: Publish to Open VSX Registry (Optional)
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          if [ -n "$OVSX_PAT" ]; then
+            npx --yes ovsx publish *.vsix --skip-duplicate
+          else
+            echo "OVSX_PAT secret is not set; skipping Open VSX publishing."
+          fi
+
+      - name: Extension publish summary
+        if: always()
+        run: |
+          echo "## Ivy Tendril VS Code Extension" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Version: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.test-mode }}" = "true" ]; then
+            echo "> **Test Mode**: Dry run only. Extension packaged and uploaded as artifact, but publishing and release asset upload were skipped." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Marketplace**: [Ivy Tendril](https://marketplace.visualstudio.com/items?itemName=ivy-interactive.ivy-tendril)" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
# Summary

## Changes

Added automated VS Code extension build, test, packaging, and publishing steps to the CI/CD release workflow in `.github/workflows/publish-tendril.yml`. The new `publish-vscode-extension` job packages the extension into a `.vsix`, uploads the package to GitHub release assets and workflow run artifacts, and publishes to the Visual Studio Code Marketplace and Open VSX while honoring the `test-mode` dry-run flag. Updated the release skill documentation in `.claude/skills/tendril-release/SKILL.md` to document the secrets and workflow behavior.

## API Changes

None.

## Files Modified

- **CI/CD Workflows**:
  - `.github/workflows/publish-tendril.yml`: Added `publish-vscode-extension` job and updated `upload-release-assets` job to include the VS Code extension artifact.
- **Documentation**:
  - `.claude/skills/tendril-release/SKILL.md`: Added documentation for `VSCE_PAT` and `OVSX_PAT` secrets, extension publishing steps, and test-mode dry-run behavior.

## Manual Testing

1. Inspect the workflow file syntax using Ruby's YAML parser:
   ```bash
   ruby -ryaml -e "YAML.load_file('.github/workflows/publish-tendril.yml'); puts 'yaml ok'"
   ```
   Observe: The command outputs `yaml ok` with no syntax errors.
2. Verify the extension builds, typechecks, and passes tests:
   ```bash
   cd extensions/vscode && npm ci && npm run typecheck && npm run build && npm test
   ```
   Observe: Typecheck completes with no errors, esbuild outputs `out/extension.js` and test bundles, and all 23 unit tests pass.
3. Test packaging the extension with vsce:
   ```bash
   npx --yes @vscode/vsce package --no-git-tag-version --allow-missing-repository --skip-license -o test.vsix
   ```
   Observe: vsce generates `test.vsix` successfully.
4. Verify dry run in CI when triggering a release with `test-mode`:
   ```bash
   gh workflow run publish-tendril.yml --ref development -f test-mode=true
   ```
   Observe: The `publish-vscode-extension` job runs typecheck, test, build, packaging, and artifact upload, but skips release asset creation and marketplace publishing.

## Fix: Decouple VS Code Extension Release into Standalone Workflow

In response to the change request, removed VS Code extension packaging and publishing from `.github/workflows/publish-tendril.yml` and established a standalone workflow in `.github/workflows/publish-vscode-extension.yml`. The standalone workflow supports independent release triggers via `vscode-v*` git tags and `workflow_dispatch` (with version override and test-mode dry-run support), builds, tests, packages the extension, uploads workflow artifacts, and publishes to Visual Studio Code Marketplace and Open VSX Registry. Updated `.claude/skills/tendril-release/SKILL.md` to document the standalone workflow and invocation commands.

### Files Modified

- `.github/workflows/publish-tendril.yml`: Reverted changes so the main release workflow focuses strictly on core NuGet packages and desktop installers.
- `.github/workflows/publish-vscode-extension.yml`: Created dedicated standalone workflow for the VS Code extension.
- `.claude/skills/tendril-release/SKILL.md`: Documented Phase 8 for the standalone VS Code extension release workflow.

### Manual Testing

1. Validate workflow YAML files:
   ```bash
   ruby -ryaml -e "YAML.load_file('.github/workflows/publish-vscode-extension.yml'); YAML.load_file('.github/workflows/publish-tendril.yml'); puts 'yaml ok'"
   ```
   Observe: Both workflows parse successfully with output `yaml ok`.
2. Verify test-mode dispatch for the standalone extension workflow:
   ```bash
   gh workflow run publish-vscode-extension.yml --ref development -f test-mode=true
   ```
   Observe: The workflow builds, typechecks, tests, and packages `.vsix`, uploading it as a workflow artifact while skipping marketplace publishing.
3. Verify production tag trigger:
   ```bash
   git tag vscode-v0.1.1 && git push origin vscode-v0.1.1
   ```
   Observe: The workflow runs and publishes to the Visual Studio Code Marketplace and Open VSX Registry.

---

### Commits

- `206c10f3` [00303] Decouple VS Code extension publishing into standalone workflow
- `c501e8b5` [00303] Publish VS Code extension in release workflow and update release skill

---
Created using [Ivy Tendril](https://ivy.app).
