### PR TITLE
Fix tool-call status flicker, retire progressed plan chats, unclip side-chat scrollbar

### DIFF
--- a/src/Ivy.Tendril.Test/JobServicePlanChatCleanupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServicePlanChatCleanupTests.cs
@@ -1,0 +1,139 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+///     Progressing a plan — executing the draft or opening its PR — retires the side chat that
+///     belongs to that plan (#2530).
+/// </summary>
+public class JobServicePlanChatCleanupTests : IDisposable
+{
+    private readonly string _tempDir = Path.Combine(
+        Path.GetTempPath(), "PlanChatCleanupTest_" + Guid.NewGuid().ToString("N"));
+
+    public JobServicePlanChatCleanupTests() => Directory.CreateDirectory(_tempDir);
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        if (Directory.Exists(_tempDir))
+        {
+            try { Directory.Delete(_tempDir, true); } catch { }
+        }
+    }
+
+    private sealed record Harness(
+        JobService JobService,
+        ChatHistoryService ChatService,
+        string PlanFolder,
+        string FolderName);
+
+    private Harness CreateHarness()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        const string folderName = "00099-TestPlan";
+        var planFolder = Path.Combine(_tempDir, folderName);
+        Directory.CreateDirectory(planFolder);
+
+        var configService = new ConfigService(new TendrilSettings(), _tempDir);
+        var chatService = new ChatHistoryService(configService);
+
+        var planReader = new FakePlanReaderService
+        {
+            PlanToReturn = new PlanFile(
+                new PlanMetadata(
+                    Id: 99,
+                    Project: "TestProject",
+                    Level: "NiceToHave",
+                    Title: "Test",
+                    State: PlanStatus.Draft,
+                    Repos: [],
+                    Commits: [],
+                    Prs: [],
+                    Verifications: [],
+                    RelatedPlans: [],
+                    DependsOn: [],
+                    Created: DateTime.UtcNow,
+                    Updated: DateTime.UtcNow,
+                    InitialPrompt: null,
+                    SourceUrl: null),
+                LatestRevisionContent: string.Empty,
+                FolderPath: planFolder,
+                PlanYamlRaw: string.Empty)
+        };
+
+        var jobService = new JobService(
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(10),
+            inboxPath: null,
+            maxConcurrentJobs: 0,
+            planReaderService: planReader,
+            agentRunner: TestAgentRunner.Create(),
+            chatHistoryService: chatService);
+
+        return new Harness(jobService, chatService, planFolder, folderName);
+    }
+
+    private static ChatSessionModel AttachSession(ChatHistoryService chat, string folderName) =>
+        chat.CreateSession("claude", "opus", title: "Plan chat", planFolderName: folderName);
+
+    [Fact]
+    public void StartJob_ExecutePlan_DeletesThePlansChatSession()
+    {
+        var h = CreateHarness();
+        var session = AttachSession(h.ChatService, h.FolderName);
+
+        h.JobService.StartJob(new ExecutePlanArgs(h.PlanFolder));
+
+        Assert.Null(h.ChatService.GetSession(session.Id));
+    }
+
+    [Fact]
+    public void StartJob_CreatePr_DeletesThePlansChatSession()
+    {
+        var h = CreateHarness();
+        var session = AttachSession(h.ChatService, h.FolderName);
+
+        h.JobService.StartJob(new CreatePrArgs(h.PlanFolder));
+
+        Assert.Null(h.ChatService.GetSession(session.Id));
+    }
+
+    [Fact]
+    public void StartJob_ExecutePlan_LeavesChatsOfOtherPlansAlone()
+    {
+        var h = CreateHarness();
+        var other = AttachSession(h.ChatService, "00100-OtherPlan");
+
+        h.JobService.StartJob(new ExecutePlanArgs(h.PlanFolder));
+
+        Assert.NotNull(h.ChatService.GetSession(other.Id));
+    }
+
+    [Fact]
+    public void StartJob_ExecutePlan_LeavesTheGeneralChatAlone()
+    {
+        var h = CreateHarness();
+        /* The plan's chatSessionId may still point at the general chat that created it; that
+           conversation is not about this plan and must survive. */
+        var general = h.ChatService.CreateSession("claude", "opus", title: "General");
+
+        h.JobService.StartJob(new ExecutePlanArgs(h.PlanFolder));
+
+        Assert.NotNull(h.ChatService.GetSession(general.Id));
+    }
+
+    [Fact]
+    public void StartJob_UpdatePlan_KeepsThePlansChatSession()
+    {
+        var h = CreateHarness();
+        var session = AttachSession(h.ChatService, h.FolderName);
+
+        /* Updating is not a progression: the conversation continues against the revised plan. */
+        h.JobService.StartJob(new UpdatePlanArgs(h.PlanFolder, "tweak it"));
+
+        Assert.NotNull(h.ChatService.GetSession(session.Id));
+    }
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -6,6 +6,7 @@ import { BlockMarkdown } from "../BlockMarkdown";
 import { useAutoScroll } from "./use-auto-scroll";
 import { parseEventWires, presentEventWires } from "./parse-events";
 import { deriveStatus } from "./status";
+import { useHeldStatus } from "./useHeldStatus";
 import { deriveStreamMetrics } from "./stream-metrics";
 import { StatusLine } from "../ui/StatusLine";
 import { ToolUseCard } from "./tool-use-card";
@@ -99,7 +100,8 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
   const wires = useMemo(() => (combinedStream ? parseEventWires(combinedStream) : []), [combinedStream]);
   const parsedEvents = useMemo<PresentationEvent[]>(() => presentEventWires(wires), [wires]);
 
-  const derived = useMemo(() => deriveStatus(parsedEvents), [parsedEvents]);
+  const rawStatus = useMemo(() => deriveStatus(parsedEvents), [parsedEvents]);
+  const derived = useHeldStatus(rawStatus);
   const metrics = useMemo(() => deriveStreamMetrics(wires), [wires]);
   const statusText = statusLabelOverride ?? derived.text;
   const isComplete = derived.complete;

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/status.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/status.ts
@@ -8,6 +8,8 @@ function basename(p: string): string {
 export interface DerivedStatus {
   text: string;
   complete: boolean;
+  /** The label names a tool call that is still running, so it is worth holding on screen. */
+  tool?: boolean;
 }
 
 export function deriveStatus(events: PresentationEvent[]): DerivedStatus {
@@ -26,7 +28,7 @@ export function deriveStatus(events: PresentationEvent[]): DerivedStatus {
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i];
     if (e.kind === "tool-use" && e.tool.result === undefined) {
-      return { text: labelForTool(e.tool.name, e.tool.input), complete: false };
+      return { text: labelForTool(e.tool.name, e.tool.input), complete: false, tool: true };
     }
   }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/useHeldStatus.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/useHeldStatus.test.ts
@@ -1,0 +1,76 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DerivedStatus } from "./status";
+import { STATUS_HOLD_MS, useHeldStatus } from "./useHeldStatus";
+
+const tool = (text: string): DerivedStatus => ({ text, complete: false, tool: true });
+const thinking: DerivedStatus = { text: "Thinking…", complete: false };
+const completed: DerivedStatus = { text: "Completed", complete: true };
+
+describe("useHeldStatus", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("passes an active tool status straight through", () => {
+    const { result } = renderHook(({ s }) => useHeldStatus(s), {
+      initialProps: { s: tool("Reading a.ts") },
+    });
+    expect(result.current.text).toBe("Reading a.ts");
+  });
+
+  it("keeps the tool label for the hold window after the tool finishes", () => {
+    const { result, rerender } = renderHook(({ s }) => useHeldStatus(s), {
+      initialProps: { s: tool("Reading a.ts") },
+    });
+
+    rerender({ s: thinking });
+    expect(result.current.text).toBe("Reading a.ts");
+
+    act(() => void vi.advanceTimersByTime(STATUS_HOLD_MS - 1));
+    expect(result.current.text).toBe("Reading a.ts");
+  });
+
+  it("falls back to the real status once the hold expires", () => {
+    const { result, rerender } = renderHook(({ s }) => useHeldStatus(s), {
+      initialProps: { s: tool("Reading a.ts") },
+    });
+
+    rerender({ s: thinking });
+    act(() => void vi.advanceTimersByTime(STATUS_HOLD_MS));
+    expect(result.current.text).toBe("Thinking…");
+  });
+
+  it("shows a new tool call immediately, without waiting out the hold", () => {
+    const { result, rerender } = renderHook(({ s }) => useHeldStatus(s), {
+      initialProps: { s: tool("Reading a.ts") },
+    });
+
+    rerender({ s: thinking });
+    act(() => void vi.advanceTimersByTime(500));
+    rerender({ s: tool("Running command") });
+    expect(result.current.text).toBe("Running command");
+  });
+
+  it("does not extend the hold when the stream updates inside the window", () => {
+    const { result, rerender } = renderHook(({ s }) => useHeldStatus(s), {
+      initialProps: { s: tool("Reading a.ts") },
+    });
+
+    rerender({ s: thinking });
+    act(() => void vi.advanceTimersByTime(STATUS_HOLD_MS - 100));
+    /* A fresh object for the same state, as each stream update produces. */
+    rerender({ s: { ...thinking } });
+    act(() => void vi.advanceTimersByTime(100));
+    expect(result.current.text).toBe("Thinking…");
+  });
+
+  it("drops the hold as soon as the run completes", () => {
+    const { result, rerender } = renderHook(({ s }) => useHeldStatus(s), {
+      initialProps: { s: tool("Reading a.ts") },
+    });
+
+    rerender({ s: completed });
+    expect(result.current.text).toBe("Completed");
+    expect(result.current.complete).toBe(true);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/useHeldStatus.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/useHeldStatus.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import type { DerivedStatus } from "./status";
+
+/** How long a finished tool's label stays up while waiting for whatever comes next. */
+export const STATUS_HOLD_MS = 2000;
+
+/**
+ * Smooths the gap between two tool calls. A fast tool leaves the run with nothing to report for a
+ * moment, so the status falls back to "Thinking…" and snaps straight back to a tool label, which
+ * reads as a flicker. Holding the tool label for {@link STATUS_HOLD_MS} covers that gap: another
+ * tool call replaces it immediately, and a run that really has moved on to thinking says so once
+ * the hold expires.
+ */
+export function useHeldStatus(status: DerivedStatus): DerivedStatus {
+  const active = status.tool === true;
+  const done = status.complete;
+  const label = active ? status.text : null;
+  const [held, setHeld] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (label !== null) setHeld(label);
+  }, [label]);
+
+  useEffect(() => {
+    if (done) setHeld(null);
+  }, [done]);
+
+  /* The window is measured from the tool ending, so stream updates inside it do not extend it. */
+  useEffect(() => {
+    if (active || done || held === null) return;
+    const timer = setTimeout(() => setHeld(null), STATUS_HOLD_MS);
+    return () => clearTimeout(timer);
+  }, [active, done, held]);
+
+  if (active || done || held === null) return status;
+  return { text: held, complete: false, tool: true };
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 import { ChevronRight, Coins, LoaderCircle, Timer } from "lucide-react";
 import { parseEventWires, presentEventWires } from "../AgentViewer/parse-events";
 import { deriveStatus } from "../AgentViewer/status";
+import { useHeldStatus } from "../AgentViewer/useHeldStatus";
 import { deriveStreamMetrics } from "../AgentViewer/stream-metrics";
 import { StatusLine } from "../ui/StatusLine";
 import { Tooltip } from "../ui/Tooltip";
@@ -193,7 +194,8 @@ export const AssistantTurn: React.FC<AssistantTurnProps> = ({ stream, live = fal
   const wires = useMemo(() => (stream ? parseEventWires(stream) : []), [stream]);
   const events = useMemo(() => presentEventWires(wires), [wires]);
   const turn = useMemo(() => summarizeTurn(events), [events]);
-  const status = useMemo(() => deriveStatus(events), [events]);
+  const derived = useMemo(() => deriveStatus(events), [events]);
+  const status = useHeldStatus(derived);
   const metrics = useMemo(() => deriveStreamMetrics(wires), [wires]);
 
   return (

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -24,6 +24,8 @@
   --tch-danger: var(--destructive, #ef4444);
   --tch-success: color-mix(in srgb, var(--success, #16a34a) 70%, var(--foreground, #000000));
   --tch-thread-width: 775px;
+  /* Inset of the embedded (plan panel) rows; the panel itself adds no horizontal padding. */
+  --tch-embedded-inset: 16px;
   --tch-shadow: 0 12px 30px -4px rgba(0, 0, 0, 0.18), 0 4px 12px -2px rgba(0, 0, 0, 0.1);
   --tch-mono: var(--font-mono, "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace);
 
@@ -1744,15 +1746,17 @@ button.chat-system-event-plan {
    The panel that hosts the widget draws the frame, so the widget drops its title bar and the
    composer takes the prototype's tighter measurements (16px icons, 28px buttons). */
 
+/* The panel gives the widget its full width so the message list scrolls edge to edge; each row
+   carries the inset itself, which keeps the scrollbar off the text. */
 .chat-widget-root[data-embedded="true"] .chat-header--embedded {
   justify-content: flex-end;
   height: auto;
-  padding: 0 0 8px;
+  padding: 0 var(--tch-embedded-inset) 8px;
   border-bottom: none;
 }
 
 .chat-widget-root[data-embedded="true"] .chat-thread {
-  padding: 0;
+  padding: 0 var(--tch-embedded-inset);
 }
 
 .chat-widget-root[data-embedded="true"] .chat-empty-state {
@@ -1779,7 +1783,7 @@ button.chat-system-event-plan {
 }
 
 .chat-widget-root[data-embedded="true"] .chat-footer {
-  padding: 12px 0 0;
+  padding: 12px var(--tch-embedded-inset) 0;
 }
 
 .chat-widget-root[data-embedded="true"] .chat-input-box {

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/plan-workspace.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanWorkspace/plan-workspace.css
@@ -496,7 +496,9 @@
   width: var(--pws-chat-width);
   min-width: 0;
   min-height: 0;
-  padding: 0 16px 14px;
+  /* No horizontal padding: the embedded widget insets its own rows so the message list can
+     scroll at the panel's full width and the scrollbar sits by the edge, clear of the text. */
+  padding: 0 0 14px;
   border-left: 1px solid var(--pws-border);
   background: var(--pws-bg);
 }
@@ -523,7 +525,7 @@
   flex: 0 0 42%;
   width: auto;
   min-height: 220px;
-  padding: 0 12px 12px;
+  padding: 0 0 12px;
   border-left: none;
   border-top: 1px solid var(--pws-border);
 }

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -1182,6 +1182,28 @@ public class JobService : IJobService
             _planReaderService.ResetVerificationsForRetry(folderName);
 
         _planReaderService.TransitionState(folderName, target.Value);
+
+        if (job.TypedArgs is ExecutePlanArgs or CreatePrArgs)
+            DeletePlanChatSession(folderName);
+    }
+
+    /// <summary>
+    ///     Drops the side chat that belongs to a plan once the plan has been progressed. The
+    ///     conversation is about deciding whether to execute the draft or open the PR, so it has
+    ///     served its purpose and would otherwise linger in the chat list (#2530). Only a session
+    ///     that records this plan is removed: a plan's <c>chatSessionId</c> may still point at the
+    ///     general chat that created it, which must survive.
+    /// </summary>
+    private void DeletePlanChatSession(string folderName)
+    {
+        if (_chatHistoryService == null || string.IsNullOrEmpty(folderName)) return;
+
+        foreach (var session in _chatHistoryService.GetSessions()
+                     .Where(s => string.Equals(s.PlanFolderName, folderName, StringComparison.OrdinalIgnoreCase))
+                     .ToList())
+        {
+            _chatHistoryService.DeleteSession(session.Id);
+        }
     }
 
     private string? ResolvePlanChatSessionId(string planFolder)


### PR DESCRIPTION
Fixes #2536, fixes #2530, fixes #2527.

## #2536 — Status flickers when tool calls are fast

When a tool finished, the run had nothing to report for a moment, so the status fell back to `Thinking…` and snapped straight back to a tool label — read as a flicker.

`deriveStatus` now marks tool labels (`tool: true`), and a new `useHeldStatus` hook keeps the last tool label up for 2 seconds after the tool ends:

- a new tool call within the window replaces it immediately,
- a run that really has moved on to thinking says so once the hold expires,
- completion drops the hold at once,
- the window is measured from the tool ending, so stream updates inside it do not extend it.

Applied at both status call sites (`AssistantTurn`, `AgentViewer`).

## #2530 — Side chat should be deleted after the plan is progressed

Executing a draft or opening a PR retires the conversation that decided it, so it no longer lingers in the chat list.

Hooked into the existing central plan transition (`CaptureAndTransitionPlanStateForStart` in `StartJobInternal`), which already funnels both `ExecutePlanArgs` and `CreatePrArgs`, rather than patching the four UI call sites.

Scoped deliberately: only sessions whose `PlanFolderName` records this plan are deleted. A plan's `chatSessionId` may still point at the **general chat that created it**, which must survive. Update/expand/split/retry are not progressions and keep their chat.

## #2527 — Scrollbar overlapping text in the side chat panel

(The issue's title says "scrollbar missing"; the actual report is the scrollbar overlapping the text.)

`.pws-chat` applied `padding: 0 16px 14px`, which inset the whole embedded widget — including its scroll container — so the macOS overlay scrollbar was drawn **on top of the message text**.

The panel now adds no horizontal padding, and the embedded header, thread and footer carry the inset themselves via a new `--tch-embedded-inset` token. The scroll container spans the panel's full width and the scrollbar sits at the edge.

Verified in the browser (plan-workspace demo, 420px panel):

| | before | after |
|---|---|---|
| scroll container right edge | 16px inside the panel | flush with the panel (1400) |
| gap from text to scrollbar | 0 (overlapping) | **16px** |

Also verified in the narrow/stacked layout (container flush to both edges, thread inset 16px) and that the standalone, non-embedded chat is unchanged.

## Testing

- `dotnet test` — 1348 passed (Chat/JobService/Plan filters), including 5 new `JobServicePlanChatCleanupTests` covering execute, create-PR, other-plan chats, the general chat, and update-keeps-chat.
- `vitest` — 144 passed across 18 files, including 6 new `useHeldStatus` tests.
- `tsc --noEmit` and `dotnet format --verify-no-changes` clean.
- Browser-verified the panel geometry in both wide and narrow layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)