### PR TITLE
[00484] Add Repository Health Check Script And CI Workflow

### DIFF
--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -1,0 +1,17 @@
+# Verifies the top-level repository layout has not drifted.
+# Runs on every push and pull request targeting the development branch.
+
+name: Repo health
+
+on:
+  push:
+    branches: [development]
+  pull_request:
+    branches: [development]
+
+jobs:
+  check-repo-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check-repo-health.sh

--- a/docs/repo-health.md
+++ b/docs/repo-health.md
@@ -1,0 +1,29 @@
+# Repository health check
+
+`scripts/check-repo-health.sh` verifies that the top-level repository layout has not drifted. It checks that each of the following exists and is a directory:
+
+- `.config`
+- `docs`
+- `scripts`
+- `src`
+- `.github`
+
+For each one it prints `OK <path>` or `MISSING <path>`, and exits `1` if any check failed, `0` otherwise. It is dependency-free POSIX shell, so it runs on a bare runner with no `jq` or `node` required.
+
+The check runs in CI via `.github/workflows/repo-health.yml` on every push and pull request targeting `development`.
+
+## Running locally
+
+```sh
+bash scripts/check-repo-health.sh
+```
+
+To exercise both the pass and fail branches of the checker:
+
+```sh
+bash scripts/test-check-repo-health.sh
+```
+
+## Adding a required directory
+
+Edit the `required_dirs` list near the top of `scripts/check-repo-health.sh` and add the new directory name. If the addition changes what the test script's temporary-directory fixture reports, update the assertions in `scripts/test-check-repo-health.sh` to match.

--- a/scripts/check-repo-health.sh
+++ b/scripts/check-repo-health.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Checks that the top-level repository layout has not drifted.
+# Prints "OK <path>" or "MISSING <path>" for each required directory and
+# exits 1 if any check failed.
+set -eu
+
+script_dir=$(dirname "$0")
+repo_root=${1:-$(cd "$script_dir/.." && pwd)}
+
+required_dirs=".config docs scripts src .github"
+
+failed=0
+
+for dir in $required_dirs; do
+    path="$repo_root/$dir"
+    if [ -d "$path" ]; then
+        echo "OK $dir"
+    else
+        echo "MISSING $dir"
+        failed=1
+    fi
+done
+
+exit "$failed"

--- a/scripts/test-check-repo-health.sh
+++ b/scripts/test-check-repo-health.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Exercises both branches of check-repo-health.sh: the pass case against the
+# real repo root, and the fail case against an incomplete temporary tree.
+set -eu
+
+script_dir=$(dirname "$0")
+repo_root=$(cd "$script_dir/.." && pwd)
+checker="$script_dir/check-repo-health.sh"
+
+overall=0
+
+echo "== pass branch =="
+set +e
+bash "$checker" "$repo_root"
+pass_status=$?
+set -e
+if [ "$pass_status" -eq 0 ]; then
+    echo "PASS: checker succeeded against repo root"
+else
+    echo "FAIL: checker exited $pass_status against repo root, expected 0"
+    overall=1
+fi
+
+echo "== fail branch =="
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+set +e
+fail_output=$(bash "$checker" "$tmp" 2>&1)
+fail_status=$?
+set -e
+
+if [ "$fail_status" -eq 0 ]; then
+    echo "FAIL: checker exited 0 against incomplete tree, expected non-zero"
+    overall=1
+elif ! printf '%s\n' "$fail_output" | grep -q '^MISSING '; then
+    echo "FAIL: checker did not print a MISSING line against incomplete tree"
+    overall=1
+else
+    echo "PASS: checker exited $fail_status and reported at least one MISSING line"
+fi
+
+exit "$overall"


### PR DESCRIPTION
# Summary

## Changes

Added a dependency-free POSIX shell script that verifies the top-level repository layout
(`.config`, `docs`, `scripts`, `src`, `.github`) exists and is directories, printing `OK`/`MISSING`
per check and exiting non-zero on any failure. Wired it into a new GitHub Actions workflow that
runs on push and pull request against `development`, and documented usage in `docs/repo-health.md`.
A companion test script exercises both the pass and fail branches.

## API Changes

None. New CLI scripts:
- `scripts/check-repo-health.sh [root]` — optional root argument overrides the auto-detected repo
  root (used by the test script).
- `scripts/test-check-repo-health.sh` — no arguments.

## Files Modified

- `scripts/check-repo-health.sh` (new, mode 755)
- `scripts/test-check-repo-health.sh` (new, mode 755)
- `.github/workflows/repo-health.yml` (new)
- `docs/repo-health.md` (new)

## Manual Testing

1. From the repo root, run `bash scripts/check-repo-health.sh`. Expect five `OK <dir>` lines and
   exit code `0`.
2. Run `bash scripts/test-check-repo-health.sh`. Expect `PASS` for both the pass branch and the
   fail branch, and overall exit code `0`.
3. Open a pull request targeting `development` and confirm the "Repo health" workflow run appears
   and succeeds.
4. To see the fail path in CI, temporarily rename one of the five required directories on a branch
   and push; the workflow run should fail with a `MISSING <dir>` line in the step output.

---
## Commits

- 74527477 Document repository health check (Plan 00484)
- efc6137a Add repo-health CI workflow (Plan 00484)
- 27e9d4bc Add repository health check script (Plan 00484)

---
Created using [Ivy Tendril](https://ivy.app).