### PR TITLE
[00366] Remove Info Icons from Ports and Environment Files Section Headers

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Settings/ProjectPortsAndEnvFilesGuidanceTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Settings/ProjectPortsAndEnvFilesGuidanceTests.cs
@@ -91,24 +91,5 @@ public class ProjectPortsAndEnvFilesGuidanceTests
         Assert.Equal("Overrides", overridesField.Label);
         Assert.Equal("KEY=VALUE override lines supporting ${ports.<name>}, ${env.<VAR>}, and %VAR% placeholder substitutions.", overridesField.Help);
     }
-
-    [Fact]
-    public void ProjectDetailView_Headers_IncludeInfoTooltipsWithGuidance()
-    {
-        var portsHeader = ProjectDetailView.BuildPortsHeader();
-        var portsLayout = Assert.IsType<LayoutView>(portsHeader);
-        var portsWidget = Assert.IsAssignableFrom<Ivy.Core.AbstractWidget>(portsLayout.Build());
-        var portsTooltip = Assert.Single(portsWidget.Children.OfType<Tooltip>());
-        var portsContentSlot = Assert.Single(portsTooltip.Children.OfType<Slot>().Where(s => s.Name == "Content"));
-        var portsGuidance = Assert.IsType<string>(Assert.Single(portsContentSlot.Children));
-        Assert.Equal("Named service ports dynamically allocated in plan worktrees to enable concurrent reviews without port conflicts.", portsGuidance);
-
-        var envFilesHeader = ProjectDetailView.BuildEnvFilesHeader();
-        var envFilesLayout = Assert.IsType<LayoutView>(envFilesHeader);
-        var envFilesWidget = Assert.IsAssignableFrom<Ivy.Core.AbstractWidget>(envFilesLayout.Build());
-        var envFilesTooltip = Assert.Single(envFilesWidget.Children.OfType<Tooltip>());
-        var envFilesContentSlot = Assert.Single(envFilesTooltip.Children.OfType<Slot>().Where(s => s.Name == "Content"));
-        var envFilesGuidance = Assert.IsType<string>(Assert.Single(envFilesContentSlot.Children));
-        Assert.Equal("Environment files recreated in plan worktrees from templates and variable overrides.", envFilesGuidance);
-    }
 }
+

--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -329,12 +329,12 @@ public class ProjectDetailView(
             | new Button("Add Verification").Icon(Icons.Plus).Outline().OnClick(() => showVerificationTrigger(null))
 
             // Section 5: Ports
-            | BuildPortsHeader()
+            | Text.H4("Ports").Bold()
             | new ProjectPortsTableView(ports, name => showPortTrigger(name))
             | new Button("Add Port").Icon(Icons.Plus).Outline().OnClick(() => showPortTrigger(null))
 
             // Section 6: Environment Files
-            | BuildEnvFilesHeader()
+            | Text.H4("Environment Files").Bold()
             | new ProjectEnvFilesTableView(envFiles, idx => showEnvFileTrigger(idx))
             | new Button("Add Environment File").Icon(Icons.Plus).Outline().OnClick(() => showEnvFileTrigger(null))
 
@@ -467,19 +467,5 @@ public class ProjectDetailView(
                 return false;
         }
         return true;
-    }
-
-    internal static object BuildPortsHeader()
-    {
-        return Layout.Horizontal().AlignContent(Align.Left)
-            | Text.H4("Ports").Bold()
-            | Icons.Info.ToIcon().Color(Colors.Muted).WithTooltip("Named service ports dynamically allocated in plan worktrees to enable concurrent reviews without port conflicts.");
-    }
-
-    internal static object BuildEnvFilesHeader()
-    {
-        return Layout.Horizontal().AlignContent(Align.Left)
-            | Text.H4("Environment Files").Bold()
-            | Icons.Info.ToIcon().Color(Colors.Muted).WithTooltip("Environment files recreated in plan worktrees from templates and variable overrides.");
     }
 }


### PR DESCRIPTION
Fixes #2545

# Summary

## Changes

Removed informational icon widgets and tooltips from the Ports and Environment Files section headers in ProjectDetailView. Section headers now render as clean text headers matching the rest of the project settings view. Also removed the obsolete unit test that asserted the presence of the header info tooltips.

## API Changes

None. Removed internal static helper methods `ProjectDetailView.BuildPortsHeader()` and `ProjectDetailView.BuildEnvFilesHeader()`.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs`: Replaced helper header calls with direct `Text.H4(...).Bold()` headers and removed unused helper methods.
- `src/Ivy.Tendril.Test/Apps/Settings/ProjectPortsAndEnvFilesGuidanceTests.cs`: Removed test method `ProjectDetailView_Headers_IncludeInfoTooltipsWithGuidance`.

## Manual Testing

1. Launch Tendril application (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj`).
2. Navigate to Settings and select a project to view its Project Detail page.
3. Scroll down to the "Ports" and "Environment Files" sections.
4. Verify that the "Ports" and "Environment Files" section headers appear as clean bold headings without any (i) info icons next to them, matching the styling of "Repositories" and "Verifications".

---
## Commits

- 9fdf5ded: Remove info icons from ports and env files section headers (Plan 00366)

---
Created using [Ivy Tendril](https://ivy.app).
