### PR TITLE
[00369] Open Browser Preview for Vite Plus Review Actions

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
@@ -18,7 +18,7 @@ Project and verification configuration is available via `tendril project list` a
 - **Stack detection.** Inspect the project's repositories to determine the tech stack.
     - Look for configuration files: `package.json`, `*.csproj`, `Cargo.toml`, `go.mod`, `requirements.txt`, `pyproject.toml`, etc.
     - If a `package.json` exists, identify the package manager: check if `pnpm-lock.yaml` is present, or if the `packageManager` field in `package.json` specifies `pnpm`. If not, check for `yarn.lock`. Otherwise, assume `npm`.
-    - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
+    - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev --open`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
 - **Keep it minimal.** Only add verifications and review actions that are appropriate for the detected stack.
 
 ## Available CLI Commands
@@ -136,7 +136,7 @@ Never emit the Windows-only `start`; to open a file/URL use `Start-Process` on W
 
 Inspect each repo to determine how to run the application. For website projects, prefer commands that open the browser automatically:
 - **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
-- **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev`
+- **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev --open`
 - **Vite project**:
     - Under `pnpm`: `cd Worktrees/<RepoName>/<path-to-frontend> && pnpm install && pnpm run dev -- --open`
     - Under `npm`: `cd Worktrees/<RepoName>/<path-to-frontend> && npm install && npm run dev -- --open`

--- a/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
+++ b/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
@@ -666,6 +666,22 @@ public class SetupProjectPromptwareTests : IDisposable
     }
 
     [Fact]
+    public void BothProjectSetupPromptwares_DocumentVitePlusOpenBrowser()
+    {
+        var promptwaresRoot = Path.GetFullPath(
+            Path.Combine(System.AppContext.BaseDirectory, "..", "..", "..", "..", "Ivy.Tendril", "Promptwares"));
+
+        foreach (var name in new[] { "AddProject", "SetupProject" })
+        {
+            var programFile = Path.Combine(promptwaresRoot, name, "Program.md");
+            Assert.True(File.Exists(programFile), $"Expected to find {programFile}");
+            var content = File.ReadAllText(programFile);
+
+            Assert.Contains("vp dev --open", content);
+        }
+    }
+
+    [Fact]
     public void ExampleConfig_ShipsScreenshotsVerificationDefinition()
     {
         var configFile = Path.Combine(System.AppContext.BaseDirectory, "example.config.yaml");

--- a/src/Ivy.Tendril/Promptwares/AddProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/AddProject/Program.md
@@ -19,7 +19,7 @@ Project and verification configuration is available via `tendril project list` a
 - **Stack detection.** Inspect the project's repositories to determine the tech stack.
   - Look for configuration files: `package.json`, `*.csproj`, `Cargo.toml`, `go.mod`, `requirements.txt`, `pyproject.toml`, etc.
   - If a `package.json` exists, identify the package manager: check if `pnpm-lock.yaml` is present, or if the `packageManager` field in `package.json` specifies `pnpm`. If not, check for `yarn.lock`. Otherwise, assume `npm`.
-  - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
+  - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev --open`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
 - **Keep it minimal.** Only add verifications and review actions that are appropriate for the detected stack.
 
 ## Available CLI Commands
@@ -143,7 +143,7 @@ Never emit the Windows-only `start`; to open a file/URL use `Start-Process` on W
 
 #### Unified Monorepo Review Actions
 Detect when `project-analyzer` flags a workspace root (`isWorkspaceRoot: true`) or when the repository root contains monorepo orchestrators (such as Nx via `nx.json`, Turborepo via `turbo.json`, or a root `package.json` with workspace definitions and root `dev` or `start` scripts):
-- Configure a primary unified review action named "Fullstack" or "App" targeting the workspace root (e.g. `cd Worktrees/<RepoPath> && <packageManager> install && <packageManager> run dev`).
+- Configure a primary unified review action named "Fullstack" or "App" targeting the workspace root (e.g. `cd Worktrees/<RepoPath> && <packageManager> install && <packageManager> run dev`). When the command launches web frontends, include browser opening flags (e.g. `vp dev --open` or `-- --open`) so the browser preview launches automatically upon startup.
 - Granular review actions for individual applications or services can still be created alongside the unified one, giving reviewers the choice of launching the full system or individual components.
 
 #### Environment Template Bootstrapping
@@ -158,7 +158,7 @@ For commands executing in subdirectories or workspace roots (e.g. after `cd Work
 
 Inspect each repo to determine how to run the application. For website projects, prefer commands that open the browser automatically:
 - **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
-- **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev`
+- **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev --open`
 - **Vite project**:
   - Under `pnpm`: `cd Worktrees/<RepoName>/<path-to-frontend> && pnpm install && pnpm run dev -- --open`
   - Under `npm`: `cd Worktrees/<RepoName>/<path-to-frontend> && npm install && npm run dev -- --open`

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -18,7 +18,7 @@ Project and verification configuration is available via `tendril project list` a
 - **Stack detection.** Inspect the project's repositories to determine the tech stack.
   - Look for configuration files: `package.json`, `*.csproj`, `Cargo.toml`, `go.mod`, `requirements.txt`, `pyproject.toml`, etc.
   - If a `package.json` exists, identify the package manager: check if `pnpm-lock.yaml` is present, or if the `packageManager` field in `package.json` specifies `pnpm`. If not, check for `yarn.lock`. Otherwise, assume `npm`.
-  - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
+  - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev --open`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
 - **Keep it minimal.** Only add verifications and review actions that are appropriate for the detected stack.
 
 ## Available CLI Commands
@@ -142,7 +142,7 @@ Never emit the Windows-only `start`; to open a file/URL use `Start-Process` on W
 
 #### Unified Monorepo Review Actions
 Detect when `project-analyzer` flags a workspace root (`isWorkspaceRoot: true`) or when the repository root contains monorepo orchestrators (such as Nx via `nx.json`, Turborepo via `turbo.json`, or a root `package.json` with workspace definitions and root `dev` or `start` scripts):
-- Configure a primary unified review action named "Fullstack" or "App" targeting the workspace root (e.g. `cd Worktrees/<RepoPath> && <packageManager> install && <packageManager> run dev`).
+- Configure a primary unified review action named "Fullstack" or "App" targeting the workspace root (e.g. `cd Worktrees/<RepoPath> && <packageManager> install && <packageManager> run dev`). When the command launches web frontends, include browser opening flags (e.g. `vp dev --open` or `-- --open`) so the browser preview launches automatically upon startup.
 - Granular review actions for individual applications or services can still be created alongside the unified one, giving reviewers the choice of launching the full system or individual components.
 
 #### Environment Template Bootstrapping
@@ -157,7 +157,7 @@ For commands executing in subdirectories or workspace roots (e.g. after `cd Work
 
 Inspect each repo to determine how to run the application. For website projects, prefer commands that open the browser automatically:
 - **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
-- **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev`
+- **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev --open`
 - **Vite project**:
   - Under `pnpm`: `cd Worktrees/<RepoName>/<path-to-frontend> && pnpm install && pnpm run dev -- --open`
   - Under `npm`: `cd Worktrees/<RepoName>/<path-to-frontend> && npm install && npm run dev -- --open`


### PR DESCRIPTION
Fixes #2544

# Summary

## Changes

Updated the `AddProject` and `SetupProject` promptwares so that review action commands configured for Vite+ (`vite-plus`) web projects include the `--open` flag (`vp dev --open`). Also clarified in the monorepo review actions guidance that review action commands launching web frontends should include browser opening flags so previews open automatically, and added regression unit tests to verify both setup promptwares.

## API Changes

None.

## Files Modified

- Promptware instructions:
  - `src/Ivy.Tendril/Promptwares/AddProject/Program.md`
  - `src/Ivy.Tendril/Promptwares/SetupProject/Program.md`
  - `src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md`
- Tests:
  - `src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs`

## Manual Testing

1. Run the test suite:
   ```bash
   dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~BothProjectSetupPromptwares_DocumentVitePlusOpenBrowser"
   ```
2. Verify that the test passes with 1 test executed and 0 failures.
3. Inspect `src/Ivy.Tendril/Promptwares/AddProject/Program.md`, `src/Ivy.Tendril/Promptwares/SetupProject/Program.md`, and `src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md` to confirm the review action launch command for Vite+ specifies `vp dev --open`.

---
### Commits
- a1459ad2: 00369: Add --open flag to Vite+ review action templates and add test

---
Created using [Ivy Tendril](https://ivy.app).