### PR TITLE
[00368] Add Search Filter to Reviewer Selection in Create PR Dialog

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Review/CreatePrDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Review/CreatePrDialogTests.cs
@@ -59,4 +59,20 @@ public class CreatePrDialogTests
         var textInput = Assert.IsType<TextInput<string>>(Assert.Single(field.Children));
         Assert.Equal("custom-epic-branch", textInput.Value);
     }
+
+    [Fact]
+    public void BuildReviewersField_RendersSearchableSelect()
+    {
+        var reviewers = new State<string[]>(Array.Empty<string>());
+        var assignees = new[] { "alice", "bob", "charlie" };
+
+        var fieldObj = CreatePrDialog.BuildReviewersField(reviewers, assignees);
+
+        Assert.NotNull(fieldObj);
+        var field = Assert.IsType<Field>(fieldObj);
+        Assert.Equal("Reviewers", field.Label);
+
+        var select = Assert.IsType<SelectInput<string[]>>(Assert.Single(field.Children));
+        Assert.True(select.Searchable);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
@@ -106,9 +106,7 @@ public class CreatePrDialog(
                     .Disabled(!createPrMerge.Value)
                 | createPrIncludeArtifacts.ToBoolInput("Include Artifacts")
                 | createPrDraft.ToBoolInput("Create as Draft")
-                | createPrReviewers.ToSelectInput((assigneesQuery.Value ?? Array.Empty<string>()).ToOptions())
-                    .Placeholder("Select reviewers...")
-                    .WithField().Label("Reviewers")
+                | BuildReviewersField(createPrReviewers, assigneesQuery.Value ?? Array.Empty<string>())
                 | (assigneesError.Value is { } err
                     ? Text.Danger(err).Small()
                     : null)
@@ -204,5 +202,15 @@ public class CreatePrDialog(
             .Searchable(true)
             .Placeholder("Select target branch...")
             .WithField().Label("Target Branch");
+    }
+
+    public static object BuildReviewersField(
+        IState<string[]> createPrReviewers,
+        IReadOnlyList<string> assignees)
+    {
+        return createPrReviewers.ToSelectInput((assignees ?? Array.Empty<string>()).ToOptions())
+            .Searchable(true)
+            .Placeholder("Select reviewers...")
+            .WithField().Label("Reviewers");
     }
 }


### PR DESCRIPTION
Fixes #2521

# Summary

## Changes

Enabled dynamic search filtering on the reviewers selection dropdown in the Create PR dialog. Users can now filter the list of repository assignees by typing in the search input rather than scrolling through all collaborators.

## API Changes

Added `CreatePrDialog.BuildReviewersField(IState<string[]> createPrReviewers, IReadOnlyList<string> assignees)` helper method to construct and configure the reviewers select input with search enabled.

## Files Modified

- **UI / Review App:** `src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs` (configured searchable select input for reviewers via `BuildReviewersField`)
- **Tests:** `src/Ivy.Tendril.Test/Apps/Review/CreatePrDialogTests.cs` (added unit test asserting `Searchable == true` for reviewer select field)

## Manual Testing

1. Launch the Tendril desktop application or web UI.
2. Navigate to the **Review** tab and select any plan ready for PR creation.
3. Click the **Create PR** button in the header toolbar to open the Create PR dialog.
4. Click on the **Reviewers** input.
5. Verify that an embedded search input is visible at the top of the dropdown.
6. Type a collaborator name or partial string and verify that the dropdown options filter down to matching entries.

---
## Commits
df47ecb4 [#00368] Enable search filtering on Reviewers field in Create PR dialog

---
Created using [Ivy Tendril](https://ivy.app).
