### PR TITLE
[00378] Fix Badge Name Filtering in Datatables

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableFilterTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableFilterTests.cs
@@ -1,0 +1,127 @@
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Jobs;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Jobs;
+
+public class JobsTableFilterTests
+{
+    private static JobItem MakeJob(string id, JobStatus status, DateTime? completedAt = null) => new()
+    {
+        Id = id,
+        Type = "ExecutePlan",
+        PlanFile = $"{id}-Plan",
+        Project = "Test",
+        Status = status,
+        CompletedAt = completedAt
+    };
+
+    [Fact]
+    public void JobItemRow_Status_ContainsCleanStringWithoutPrefix_ForEveryJobStatus()
+    {
+        var planService = new FakePlanReaderService();
+        var allStatuses = Enum.GetValues<JobStatus>();
+        var jobs = allStatuses.Select((s, i) => MakeJob($"job-{i}", s)).ToList();
+
+        var rows = JobsApp.BuildJobRows(jobs, planService);
+
+        Assert.Equal(allStatuses.Length, rows.Count);
+        foreach (var row in rows)
+        {
+            Assert.False(row.Status.Contains("idle:"), $"Row status '{row.Status}' should not contain 'idle:' prefix");
+            Assert.False(row.Status.Contains("running:"), $"Row status '{row.Status}' should not contain 'running:' prefix");
+
+            var matchingStatus = allStatuses.FirstOrDefault(s => s.ToString() == row.Status);
+            Assert.Equal(matchingStatus.ToString(), row.Status);
+        }
+    }
+
+    [Fact]
+    public void BuildDataTableUpdates_GeneratesCleanStatusString_WithoutPrefix()
+    {
+        var jobService = new FilterTestFakeJobService();
+        var runningJob = MakeJob("job-running", JobStatus.Running);
+        var timeoutJob = MakeJob("job-timeout", JobStatus.Timeout, completedAt: DateTime.UtcNow);
+        jobService.Jobs.Add(runningJob);
+        jobService.Jobs.Add(timeoutJob);
+
+        var cache = new Dictionary<string, string>();
+        var updates = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+
+        var statusUpdates = updates
+            .Where(u => u.ColumnName == nameof(JobItemRow.Status))
+            .ToList();
+
+        Assert.Equal(2, statusUpdates.Count);
+
+        var runningUpdate = statusUpdates.Single(u => u.RowId?.ToString() == "job-running");
+        Assert.Equal("Running", runningUpdate.Value as string);
+
+        var timeoutUpdate = statusUpdates.Single(u => u.RowId?.ToString() == "job-timeout");
+        Assert.Equal("Timeout", timeoutUpdate.Value as string);
+    }
+
+    [Fact]
+    public void InMemoryLinqFiltering_ByStatus_MatchesExpectedRows()
+    {
+        var planService = new FakePlanReaderService();
+        var jobs = new List<JobItem>
+        {
+            MakeJob("job-1", JobStatus.Running),
+            MakeJob("job-2", JobStatus.Timeout, completedAt: DateTime.UtcNow),
+            MakeJob("job-3", JobStatus.Timeout, completedAt: DateTime.UtcNow),
+            MakeJob("job-4", JobStatus.Completed, completedAt: DateTime.UtcNow),
+            MakeJob("job-5", JobStatus.Failed, completedAt: DateTime.UtcNow)
+        };
+
+        var rows = JobsApp.BuildJobRows(jobs, planService);
+
+        var timeoutRows = rows.Where(r => r.Status == "Timeout").ToList();
+        Assert.Equal(2, timeoutRows.Count);
+        Assert.All(timeoutRows, r => Assert.Equal("Timeout", r.Status));
+
+        var runningRows = rows.Where(r => r.Status == "Running").ToList();
+        var singleRunning = Assert.Single(runningRows);
+        Assert.Equal("Running", singleRunning.Status);
+        Assert.Equal("job-1", singleRunning.Id);
+
+        var completedRows = rows.Where(r => r.Status == "Completed").ToList();
+        var singleCompleted = Assert.Single(completedRows);
+        Assert.Equal("Completed", singleCompleted.Status);
+        Assert.Equal("job-4", singleCompleted.Id);
+    }
+
+    private class FilterTestFakeJobService : IJobService
+    {
+        public List<JobItem> Jobs { get; } = new();
+
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null) => throw new NotSupportedException();
+        public void ForceStartJob(string id) => throw new NotSupportedException();
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) => throw new NotSupportedException();
+        public void StopJob(string id) => throw new NotSupportedException();
+        public int StopAllJobs() => throw new NotSupportedException();
+        public int StopQueuedJobs() => throw new NotSupportedException();
+        public void DeleteJob(string id) => throw new NotSupportedException();
+        public void ClearCompletedJobs() => throw new NotSupportedException();
+        public void ClearFailedJobs() => throw new NotSupportedException();
+        public void ClearAllJobs() => throw new NotSupportedException();
+        public List<JobItem> GetJobs() => Jobs;
+        public List<JobItem> GetJobsForPlan(string planFile) => throw new NotSupportedException();
+        public JobItem? GetJob(string id) => Jobs.FirstOrDefault(j => j.Id == id);
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => throw new NotSupportedException();
+        public void SetChatSessionId(string id, string chatSessionId) { }
+        public bool ReportJobFailure(string id, string message) => throw new NotSupportedException();
+        public bool IsInboxFileTracked(string filePath) => false;
+        public void Dispose() { }
+
+#pragma warning disable CS0067
+        public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
+        public event Action<JobNotification>? NotificationReady;
+        public event Action<JobItem>? JobFinished;
+#pragma warning restore CS0067
+    }
+}

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -10,7 +10,7 @@ public partial class JobsApp
     private Dictionary<string, string> BuildProjectColorMapping(IConfigService config) =>
         ProjectHelper.BuildColorMapping(config);
 
-    private List<JobItemRow> BuildJobRows(List<JobItem> jobs, IPlanReaderService planService)
+    internal static List<JobItemRow> BuildJobRows(List<JobItem> jobs, IPlanReaderService planService)
     {
         return jobs.Select(j =>
         {
@@ -21,7 +21,7 @@ public partial class JobsApp
             return new JobItemRow
             {
                 Id = j.Id,
-                Status = JobsApp.FormatStatusBadge(j.Status),
+                Status = j.Status.ToString(),
                 PlanId = planId,
                 Prompt = JobsApp.GetPromptDisplay(j, planService),
                 Type = j.Type,
@@ -110,7 +110,7 @@ public partial class JobsApp
                 new DataTableCellUpdate(j.Id, nameof(JobItemRow.Cost), FormatJobCost(j)),
                 new DataTableCellUpdate(j.Id, nameof(JobItemRow.Tokens), j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : ""),
                 new DataTableCellUpdate(j.Id, nameof(JobItemRow.AgentOutput), JobsApp.FormatAgentOutput(j)),
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Status), JobsApp.FormatStatusBadge(j.Status)),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Status), j.Status.ToString()),
                 new DataTableCellUpdate(j.Id, nameof(JobItemRow.StatusMessage), JobsApp.GetStatusMessage(j))
             });
 

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -76,9 +76,8 @@ public partial class JobsApp
             .Width(t => t.Cost, Size.Px(80))
             .Width(t => t.Tokens, Size.Px(80))
             .Width(t => t.StatusMessage, Size.Auto())
-            .Renderer(t => t.Status, new AnimatedStatusLabelDisplayRenderer
+            .Renderer(t => t.Status, new LabelsDisplayRenderer
             {
-                Mode = AnimatedStatusMode.Badge,
                 BadgeColorMapping = Constants.JobStatusColors.ToDictionary(
                     kvp => kvp.Key.ToString(),
                     kvp => kvp.Value.ToString()

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
@@ -76,17 +76,6 @@ public partial class JobsApp
         return AnimatedStatusValue.Idle("-");
     }
 
-    /// <summary>
-    /// Encodes a <see cref="JobStatus"/> for the animated badge renderer.
-    /// Running jobs shimmer; everything else is a static badge.
-    /// </summary>
-    private static string FormatStatusBadge(JobStatus status)
-    {
-        var text = status.ToString();
-        return status == JobStatus.Running
-            ? AnimatedStatusValue.Running(text)
-            : AnimatedStatusValue.Idle(text);
-    }
 
     private static string FormatTimer(JobItem job)
     {

--- a/src/Ivy.Tendril/Apps/Views/PlanJobsDataTableView.cs
+++ b/src/Ivy.Tendril/Apps/Views/PlanJobsDataTableView.cs
@@ -16,9 +16,7 @@ public class PlanJobsDataTableView(List<JobItem> jobs, Action<string> showDebug,
             .Select(j => new PlanJobRow
             {
                 Id = j.Id,
-                Status = j.Status == JobStatus.Running
-                    ? AnimatedStatusValue.Running(j.Status.ToString())
-                    : AnimatedStatusValue.Idle(j.Status.ToString()),
+                Status = j.Status.ToString(),
                 Type = j.Type,
                 Cost = j.Cost.HasValue ? FormatHelper.FormatCost(j.Cost.Value) : "",
                 Tokens = j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : "",
@@ -39,9 +37,8 @@ public class PlanJobsDataTableView(List<JobItem> jobs, Action<string> showDebug,
             .Width(t => t.Cost, Size.Px(80))
             .Width(t => t.Tokens, Size.Px(80))
             .Width(t => t.StatusMessage, Size.Auto())
-            .Renderer(t => t.Status, new AnimatedStatusLabelDisplayRenderer
+            .Renderer(t => t.Status, new LabelsDisplayRenderer
             {
-                Mode = AnimatedStatusMode.Badge,
                 BadgeColorMapping = Constants.JobStatusColors.ToDictionary(
                     kvp => kvp.Key.ToString(),
                     kvp => kvp.Value.ToString()

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -351,9 +351,7 @@ public record JobItemRow
 {
     public string Id { get; init; } = "";
     /// <summary>
-    /// Encoded animated-status string: "running:Running" while the job is running
-    /// (so the Status column shimmers), "idle:Completed" / "idle:Failed" / etc.
-    /// otherwise. Built via <see cref="Ivy.AnimatedStatusValue"/>.
+    /// Clean string representation of <see cref="JobStatus"/> (e.g. "Running", "Completed", "Timeout").
     /// </summary>
     public string Status { get; init; } = "";
     public string PlanId { get; init; } = "";


### PR DESCRIPTION
Fixes #2535

# Summary

## Changes

Fixed badge name filtering in the Jobs app datatable by storing clean status strings on `JobItemRow.Status` and switching the column renderer to `LabelsDisplayRenderer`. Previously, `JobItemRow.Status` contained animated mode prefixes (such as `idle:Timeout` or `running:Running`), causing filter expressions like `[Status]="Timeout"` to evaluate to false and fail to match rows.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs` (Jobs app): Updated `BuildJobRows` and `BuildDataTableUpdates` to set `Status` directly to `j.Status.ToString()`.
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs` (Jobs app): Replaced `AnimatedStatusLabelDisplayRenderer` with `LabelsDisplayRenderer` on the `Status` column.
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs` (Jobs app): Removed the `FormatStatusBadge` helper method that prepended animation prefixes.
- `src/Ivy.Tendril/Apps/Views/PlanJobsDataTableView.cs` (Plan views): Aligned the plan jobs table to use clean status strings and `LabelsDisplayRenderer`.
- `src/Ivy.Tendril/Models/JobModels.cs` (Models): Updated XML documentation for `JobItemRow.Status`.
- `src/Ivy.Tendril.Test/Apps/Jobs/JobsTableFilterTests.cs` (Tests): Added unit tests verifying clean status string formatting, table update streaming, and LINQ filtering.

## Manual Testing

1. Launch the Tendril desktop application:
   ```bash
   dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse
   ```
2. Navigate to the Jobs app.
3. In the datatable filter bar, type or select `[Status]="Timeout"` (or another visible status such as `[Status]="Completed"` or `[Status]="Running"`).
4. Observe that rows matching the requested badge name are returned in the table and autocomplete offers clean status names without `idle:` or `running:` prefixes.

---
### Commits
- 5fb70209: Fix badge name filtering for job status in datatables (Plan 00378)

---
Created using [Ivy Tendril](https://ivy.app).
