### PR TITLE
[00379] Add Clickable Navigation to Spawned Jobs Menu Items

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs
@@ -91,6 +91,48 @@ public class ChatAppSidebarListTests
     }
 
     [Fact]
+    public void ToJobDto_ResolvesPlanIdAndFallbackTitle_WhenReportedPlanIdIsNull()
+    {
+        var job = new JobItem
+        {
+            Id = "00150",
+            Type = Constants.JobTypes.ExecutePlan,
+            Status = JobStatus.Running,
+            PlanFile = "01579-TestPlan"
+        };
+
+        var dto = ChatApp.ToJobDto(job);
+
+        Assert.Equal("01579", dto.PlanId);
+        Assert.Equal("TestPlan", dto.PlanTitle);
+    }
+
+    [Fact]
+    public void ToJobDto_ResolvesHumanReadablePlanTitle_WhenPlanServiceIsProvided()
+    {
+        var metadata = new PlanMetadata(
+            1579, "test-project", "Feature", "Human Readable Plan Title", PlanStatus.Executing,
+            [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+        var planFile = new PlanFile(metadata, "", "/tmp/01579-TestPlan", "");
+        var planService = new FakePlanReaderService
+        {
+            Plans = [planFile]
+        };
+        var job = new JobItem
+        {
+            Id = "00151",
+            Type = Constants.JobTypes.ExecutePlan,
+            Status = JobStatus.Running,
+            PlanFile = "01579-TestPlan"
+        };
+
+        var dto = ChatApp.ToJobDto(job, planService);
+
+        Assert.Equal("01579", dto.PlanId);
+        Assert.Equal("Human Readable Plan Title", dto.PlanTitle);
+    }
+
+    [Fact]
     public void ResolveModelAndEffort_FallBackWhenThePreferenceIsUnknown()
     {
         var models = new List<(string Id, string DisplayName)> { ("opus", "Opus"), ("sonnet", "Sonnet") };

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
@@ -4,6 +4,7 @@ import {
   Check,
   CheckCircle2,
   ChevronDown,
+  ChevronRight,
   Cpu,
   Ellipsis,
   LoaderCircle,
@@ -114,6 +115,8 @@ export const JobsMenu: React.FC<JobsMenuProps> = ({ jobs, spawned, onReview, onO
           <div className="chat-jobs-dropdown-list">
             {jobs.map((job) => {
               const className = `chat-jobs-dropdown-item ${job.status.toLowerCase()}`;
+              const planId = job.planId;
+              const isClickable = Boolean(onOpenPlan && planId);
               const content = (
                 <>
                 <div className="chat-job-status-indicator">
@@ -138,10 +141,10 @@ export const JobsMenu: React.FC<JobsMenuProps> = ({ jobs, spawned, onReview, onO
                     </div>
                   )}
                 </div>
+                {isClickable && <ChevronRight size={14} className="chat-job-nav-icon" />}
                 </>
               );
-              const planId = job.planId;
-              if (onOpenPlan && planId) {
+              if (isClickable && planId) {
                 return (
                   <button
                     key={job.id}
@@ -150,7 +153,7 @@ export const JobsMenu: React.FC<JobsMenuProps> = ({ jobs, spawned, onReview, onO
                     title="Open plan"
                     onClick={() => {
                       setOpen(false);
-                      onOpenPlan(planId);
+                      onOpenPlan!(planId);
                     }}
                   >
                     {content}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -564,6 +564,68 @@ describe("ChatWidget embedded mode", () => {
     expect(screen.queryByText("Spawned Jobs (2)")).not.toBeInTheDocument();
   });
 
+  it("opens the plan a spawned job reported from the header jobs menu in embedded mode", () => {
+    const handleEvent = vi.fn();
+    const session: ChatSessionDto = {
+      id: "s1",
+      title: "Plan chat",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: "",
+      updatedAt: "",
+      messages: [{ id: "m1", role: "user", content: "hi", timestamp: "" }],
+      spawnedJobs: [
+        { id: "00148", type: "ExecutePlan", status: "Completed", planId: "00148", planTitle: "Add login" },
+      ],
+    };
+    render(
+      <ChatWidget
+        id="embedded-chat"
+        embedded
+        activeSessionId="s1"
+        sessions={[session]}
+        events={["OnOpenPlan"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "View running jobs" }));
+    fireEvent.click(screen.getByRole("button", { name: /Add login/ }));
+    expect(handleEvent).toHaveBeenCalledWith("OnOpenPlan", "embedded-chat", ["00148"]);
+  });
+
+  it("renders a job item without a planId as non-clickable without triggering onOpenPlan", () => {
+    const handleEvent = vi.fn();
+    const session: ChatSessionDto = {
+      id: "s1",
+      title: "Plan chat",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: "",
+      updatedAt: "",
+      messages: [{ id: "m1", role: "user", content: "hi", timestamp: "" }],
+      spawnedJobs: [
+        { id: "00149", type: "Promptware", status: "Running" },
+      ],
+    };
+    render(
+      <ChatWidget
+        id="chat"
+        activeSessionId="s1"
+        sessions={[session]}
+        events={["OnOpenPlan"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "View running jobs" }));
+    expect(screen.queryByRole("button", { name: /00149/ })).not.toBeInTheDocument();
+    expect(screen.getByText("00149")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("00149"));
+    expect(handleEvent).not.toHaveBeenCalledWith("OnOpenPlan", expect.anything(), expect.anything());
+  });
+
   it("shows the new-chat chord in the header button's tooltip", () => {
     vi.useFakeTimers();
     const session: ChatSessionDto = {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/TerminalSessionHeader.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/TerminalSessionHeader.test.tsx
@@ -79,6 +79,27 @@ describe("TerminalSessionHeader", () => {
     expect(handleEvent).toHaveBeenCalledWith("OnOpenPlan", "term-header", ["00151"]);
   });
 
+  it("renders a job item without a planId as non-clickable and does not emit OnOpenPlan", () => {
+    const handleEvent = vi.fn();
+    render(
+      <TerminalSessionHeader
+        id="term-header"
+        sessionId="sess-6"
+        jobs={[{ id: "00152", type: "Promptware", status: "Running" }]}
+        spawned
+        events={["OnOpenPlan"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /View running jobs/i }));
+    expect(screen.queryByRole("button", { name: /00152/ })).not.toBeInTheDocument();
+    expect(screen.getByText("00152")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("00152"));
+    expect(handleEvent).not.toHaveBeenCalledWith("OnOpenPlan", expect.anything(), expect.anything());
+  });
+
   it("renders the terminal variant host and header classes", () => {
     const { container } = render(<TerminalSessionHeader id="term-header" sessionId="sess-4" />);
     expect(container.querySelector(".chat-header-host.chat-header-host--terminal")).toBeInTheDocument();

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -399,6 +399,19 @@ button.chat-jobs-dropdown-item:hover {
   text-overflow: ellipsis;
 }
 
+.chat-job-nav-icon {
+  margin-left: auto;
+  align-self: center;
+  flex-shrink: 0;
+  color: var(--tch-muted);
+  opacity: 0.5;
+  transition: opacity 120ms ease;
+}
+
+button.chat-jobs-dropdown-item:hover .chat-job-nav-icon {
+  opacity: 1;
+}
+
 .chat-jobs-dropdown-footer {
   display: flex;
   justify-content: flex-end;

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -112,7 +112,7 @@ public class AgentApp : ViewBase
         var title = session != null ? ChatApp.DisplayTitle(session) : (args?.Title ?? agentLabel);
 
         var jobs = session != null
-            ? SessionJobs(jobService, session.Id).Select(ChatApp.ToJobDto).ToList()
+            ? SessionJobs(jobService, session.Id).Select(j => ChatApp.ToJobDto(j, planService)).ToList()
             : [];
 
         var header = new TerminalSessionHeader()

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -29,14 +29,45 @@ public class ChatApp : ViewBase
     internal static string? PlanTag(ChatSessionModel session) =>
         string.IsNullOrEmpty(session.PlanFolderName) ? null : $"#{TendrilAppShell.FormatPlanId(session.PlanFolderName)}";
 
-    internal static ChatJobDto ToJobDto(JobItem job) => new(
-        job.Id,
-        job.Type,
-        job.Status.ToString(),
-        job.ReportedPlanId,
-        job.ReportedPlanTitle,
-        job.StatusMessage,
-        Constants.JobTypeColors.TryGetValue(job.Type, out var color) ? color.ToString() : null);
+    internal static ChatJobDto ToJobDto(JobItem job, IPlanReaderService? planService = null)
+    {
+        var planId = job.ResolvePlanId();
+        if (string.IsNullOrEmpty(planId) && !string.IsNullOrEmpty(job.PlanFile))
+        {
+            var extracted = PlanYamlHelper.ExtractPlanIdFromFolder(job.PlanFile);
+            if (!string.IsNullOrEmpty(extracted)) planId = extracted;
+        }
+        if (string.IsNullOrEmpty(planId) && !string.IsNullOrEmpty(job.TypedArgs?.PlanFolder))
+        {
+            var extracted = PlanYamlHelper.ExtractPlanIdFromFolder(job.TypedArgs.PlanFolder);
+            if (!string.IsNullOrEmpty(extracted)) planId = extracted;
+        }
+        var resolvedPlanId = string.IsNullOrEmpty(planId) ? null : planId;
+
+        var planTitle = job.ReportedPlanTitle;
+        if (string.IsNullOrWhiteSpace(planTitle) && resolvedPlanId != null && planService != null)
+        {
+            planTitle = ContentView.FindPlan(planService, resolvedPlanId)?.Title;
+        }
+        if (string.IsNullOrWhiteSpace(planTitle) && !string.IsNullOrEmpty(job.PlanFile))
+        {
+            planTitle = PlanYamlHelper.ExtractSafeTitleFromFolder(job.PlanFile);
+        }
+        if (string.IsNullOrWhiteSpace(planTitle) && !string.IsNullOrEmpty(job.TypedArgs?.PlanFolder))
+        {
+            planTitle = PlanYamlHelper.ExtractSafeTitleFromFolder(job.TypedArgs.PlanFolder);
+        }
+        var resolvedPlanTitle = string.IsNullOrWhiteSpace(planTitle) ? null : planTitle;
+
+        return new(
+            job.Id,
+            job.Type,
+            job.Status.ToString(),
+            resolvedPlanId,
+            resolvedPlanTitle,
+            job.StatusMessage,
+            Constants.JobTypeColors.TryGetValue(job.Type, out var color) ? color.ToString() : null);
+    }
 
     internal static string? BuildRowState(
         ChatSessionModel session,
@@ -92,6 +123,7 @@ public class ChatApp : ViewBase
         var executionService = UseService<IChatExecutionService>();
         var agentRunner = UseService<IAgentRunner>();
         Context.TryUseService<IJobService>(out var jobService);
+        Context.TryUseService<IPlanReaderService>(out var planService);
         Context.TryUseService<IChatAgentPreferences>(out var preferences);
         var navigator = UseNavigation();
         var sidebarListSignal = Context.UseSignal<ShellSidebarListSignal, ShellSidebarListState, Unit>();
@@ -236,7 +268,7 @@ public class ChatApp : ViewBase
         // Compact DTO serialization: only serialize full message history for the active session,
         // preventing massive SignalR payload bloat when a user has hundreds of sessions.
         var sessionDtos = sessions
-            .Select(s => ToSessionDto(s, s.Id == currentSessionId, executionService, jobService, chatService))
+            .Select(s => ToSessionDto(s, s.Id == currentSessionId, executionService, jobService, chatService, planService))
             .ToList();
 
         void StartNewChat()
@@ -353,7 +385,8 @@ public class ChatApp : ViewBase
         bool isActive,
         IChatExecutionService executionService,
         IJobService? jobService,
-        IChatHistoryService chatService)
+        IChatHistoryService chatService,
+        IPlanReaderService? planService = null)
     {
         var isGenerating = executionService.IsGenerating(s.Id);
         var status = isGenerating ? "generating" : "done";
@@ -410,7 +443,7 @@ public class ChatApp : ViewBase
                 {
                     var job = jobService.GetJob(jId);
                     if (job == null) return new ChatJobDto(jId, "Job", "Unknown");
-                    return ToJobDto(job);
+                    return ToJobDto(job, planService);
                 }).ToList();
             }
         }

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -101,7 +101,7 @@ public class ContentView(
             ? jobService.GetJobs()
                 .Where(j => string.Equals(j.ChatSessionId, activeSessionId.Value, StringComparison.OrdinalIgnoreCase)
                          && (j.Status == JobStatus.Running || j.Status == JobStatus.Pending || j.Status == JobStatus.Queued))
-                .Select(ChatApp.ToJobDto).ToList()
+                .Select(j => ChatApp.ToJobDto(j, planService)).ToList()
             : new List<ChatJobDto>();
 
         var chatWidget = new ChatWidget


### PR DESCRIPTION
Fixes #2533

# Summary

## Changes

Added clickable navigation to spawned and running job items within `JobsMenu`. Job items that correspond to a plan or review now display a navigation chevron and navigate directly to the plan or review view when clicked. Backend DTO mapping has been enhanced to reliably resolve plan IDs and human-readable plan titles even when jobs have not explicitly reported them.

## API Changes

- `ChatApp.ToJobDto(JobItem job, IPlanReaderService? planService = null)`: Added optional `planService` parameter to resolve human-readable plan titles from plan metadata.
- `ChatApp.ToSessionDto(...)`: Added optional `planService` parameter to pass through to `ToJobDto`.

## Files Modified

- Backend & Controllers:
  - `src/Ivy.Tendril/Apps/Chat/ChatApp.cs` - Resolved plan ID and title in `ToJobDto`, wired `IPlanReaderService` in `Build()` and `ToSessionDto`.
  - `src/Ivy.Tendril/Apps/Chat/ContentView.cs` - Passed `planService` to `ToJobDto` for running jobs.
  - `src/Ivy.Tendril/Apps/Agent/AgentApp.cs` - Passed `planService` to `ToJobDto` for terminal session jobs.
- Frontend & Widgets:
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx` - Rendered `ChevronRight` icon when a job item has `onOpenPlan` and `planId`.
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css` - Added styling for `.chat-job-nav-icon` with muted appearance and hover transition.
- Tests:
  - `src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs` - Added unit tests for plan ID and title resolution with fallback mechanisms.
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx` - Added tests for embedded mode navigation and non-clickable job items.
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/TerminalSessionHeader.test.tsx` - Added tests for non-clickable job items.

## Manual Testing

1. Launch the Tendril desktop application:
   `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj`
2. Open or start a chat session and spawn a job (for example, run an ExecutePlan or UpdatePlan job from chat).
3. In the chat header, click on the jobs badge button to expand the `JobsMenu` dropdown.
4. Verify that any job associated with a plan shows the plan title and a right chevron icon.
5. Click on the job item in the dropdown.
6. Verify that the application navigates directly to the target plan or review view.

---
## Commits
- bd00ce1c 00379: Add navigation chevron and wire plan click handlers in jobs menu
- 50d6c288 00379: Resolve plan ID and title in chat job DTOs

---
Created using [Ivy Tendril](https://ivy.app).
