### PR TITLE
[00381] Fix Terminal Follow Link Navigation on Desktop and macOS

### DIFF
--- a/src/Ivy.Tendril.Test/Helpers/TerminalLinkHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/TerminalLinkHelperTests.cs
@@ -1,0 +1,189 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+public class TerminalLinkHelperTests : IDisposable
+{
+    public TerminalLinkHelperTests()
+    {
+        TerminalLinkHelper.BrowserLauncher = null;
+        TerminalLinkHelper.FileLauncher = null;
+        TerminalLinkHelper.DefaultPlanHandler = null;
+    }
+
+    public void Dispose()
+    {
+        TerminalLinkHelper.BrowserLauncher = null;
+        TerminalLinkHelper.FileLauncher = null;
+        TerminalLinkHelper.DefaultPlanHandler = null;
+    }
+
+    [Theory]
+    [InlineData("http://localhost:5173/")]
+    [InlineData("http://localhost:3000/dashboard")]
+    [InlineData("http://127.0.0.1:8080")]
+    [InlineData("https://github.com/ivy-interactive/ivy-tendril")]
+    [InlineData("https://docs.ivy.app/widgets/xterm")]
+    public void TryOpenTerminalLink_ValidHttpAndHttpsUrls_LaunchesBrowser(string url)
+    {
+        string? launchedUrl = null;
+        var result = TerminalLinkHelper.TryOpenTerminalLink(
+            url,
+            browserLauncher: target => launchedUrl = target);
+
+        Assert.True(result);
+        Assert.Equal(url, launchedUrl);
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("cmd:calc.exe")]
+    [InlineData("powershell:Start-Process calc")]
+    [InlineData("ftp://example.com/file.txt")]
+    [InlineData("data:text/html,<html>test</html>")]
+    [InlineData("mailto:test@example.com")]
+    [InlineData("ssh://user@host")]
+    public void TryOpenTerminalLink_UnsupportedOrMaliciousSchemes_RejectedAndNotLaunched(string url)
+    {
+        var launched = false;
+        var result = TerminalLinkHelper.TryOpenTerminalLink(
+            url,
+            browserLauncher: _ => launched = true,
+            fileLauncher: _ => launched = true);
+
+        Assert.False(result);
+        Assert.False(launched);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a url")]
+    [InlineData("http//missing-colon")]
+    [InlineData("relative/path/to/file.txt")]
+    [InlineData("::bad-uri::")]
+    public void TryOpenTerminalLink_InvalidAndUnparseableStrings_ReturnsFalseWithoutThrowing(string? url)
+    {
+        var launched = false;
+        var result = TerminalLinkHelper.TryOpenTerminalLink(
+            url,
+            browserLauncher: _ => launched = true,
+            fileLauncher: _ => launched = true);
+
+        Assert.False(result);
+        Assert.False(launched);
+    }
+
+    [Fact]
+    public void TryOpenTerminalLink_PlanScheme_InvokesCallbackWithParsedId()
+    {
+        var planIdCaptured = 0;
+        var result = TerminalLinkHelper.TryOpenTerminalLink(
+            "plan://00381",
+            onPlanClick: id => planIdCaptured = id);
+
+        Assert.True(result);
+        Assert.Equal(381, planIdCaptured);
+    }
+
+    [Fact]
+    public void TryOpenTerminalLink_PlanSchemeWithLeadingZerosAndTrailingSlash_ParsesCorrectly()
+    {
+        var planIdCaptured = 0;
+        var result = TerminalLinkHelper.TryOpenTerminalLink(
+            "plan://01234/",
+            onPlanClick: id => planIdCaptured = id);
+
+        Assert.True(result);
+        Assert.Equal(1234, planIdCaptured);
+    }
+
+    [Fact]
+    public void TryOpenTerminalLink_PlanSchemeWithoutCallback_ReturnsFalse()
+    {
+        var result = TerminalLinkHelper.TryOpenTerminalLink("plan://00381");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void TryOpenTerminalLink_PlanSchemeWithInvalidId_ReturnsFalse()
+    {
+        var planIdCaptured = 0;
+        var result = TerminalLinkHelper.TryOpenTerminalLink(
+            "plan://notanumber",
+            onPlanClick: id => planIdCaptured = id);
+
+        Assert.False(result);
+        Assert.Equal(0, planIdCaptured);
+    }
+
+    [Fact]
+    public void TryOpenTerminalLink_ExistingFileUri_LaunchesFileViewer()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            string? openedPath = null;
+            var fileUri = new Uri(tempFile).AbsoluteUri;
+
+            var result = TerminalLinkHelper.TryOpenTerminalLink(
+                fileUri,
+                fileLauncher: path => openedPath = path);
+
+            Assert.True(result);
+            Assert.NotNull(openedPath);
+            Assert.True(File.Exists(openedPath));
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    [Fact]
+    public void TryOpenTerminalLink_NonExistentFileUri_RejectedAndNotLaunched()
+    {
+        var launched = false;
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), $"missing_file_{Guid.NewGuid():N}.txt");
+        var fileUri = new Uri(nonExistentPath).AbsoluteUri;
+
+        var result = TerminalLinkHelper.TryOpenTerminalLink(
+            fileUri,
+            fileLauncher: _ => launched = true);
+
+        Assert.False(result);
+        Assert.False(launched);
+    }
+
+    [Fact]
+    public void OpenTerminalLink_VoidOverload_SafelyIgnoresInvalidInputWithoutThrowing()
+    {
+        var exception = Record.Exception(() =>
+        {
+            TerminalLinkHelper.OpenTerminalLink(null);
+            TerminalLinkHelper.OpenTerminalLink("");
+            TerminalLinkHelper.OpenTerminalLink("not a valid url");
+            TerminalLinkHelper.OpenTerminalLink("javascript:void(0)");
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void OpenTerminalLink_WhenLauncherThrows_CatchesAndSuppressesException()
+    {
+        TerminalLinkHelper.BrowserLauncher = _ => throw new InvalidOperationException("Browser crashed");
+
+        var exception = Record.Exception(() =>
+        {
+            TerminalLinkHelper.OpenTerminalLink("http://localhost:5173/");
+        });
+
+        Assert.Null(exception);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -143,6 +143,7 @@ public class AgentApp : ViewBase
             .Stream(ptyHandle.Stream)
             .OnInput(ptyHandle.HandleInput)
             .OnResize(ptyHandle.HandleResize)
+            .OnLinkClick(TerminalLinkHelper.OpenTerminalLink)
             .Closed(ptyHandle.Closed)
             .AllowClipboard()
             .Loading($"Starting {agentLabel}...")

--- a/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
@@ -94,6 +94,7 @@ public class ReviewActionApp : ViewBase
             .Stream(ptyHandle.Stream)
             .OnInput(ptyHandle.HandleInput)
             .OnResize(ptyHandle.HandleResize)
+            .OnLinkClick(TerminalLinkHelper.OpenTerminalLink)
             .Closed(ptyHandle.Closed)
             .AllowClipboard()
             .Loading($"Starting {action.Name}...")

--- a/src/Ivy.Tendril/Helpers/TerminalLinkHelper.cs
+++ b/src/Ivy.Tendril/Helpers/TerminalLinkHelper.cs
@@ -1,0 +1,138 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Unified helper for opening links clicked in terminal output (e.g. review actions or agent PTY sessions).
+///     Safely delegates valid web URLs (http/https) to the default browser, local file paths to the system
+///     file viewer, and internal plan:// URIs to the plan navigation callback.
+/// </summary>
+public static class TerminalLinkHelper
+{
+    public static Action<string>? BrowserLauncher { get; set; }
+    public static Action<string>? FileLauncher { get; set; }
+    public static Action<int>? DefaultPlanHandler { get; set; }
+
+    /// <summary>
+    ///     Opens the terminal link, suppressing any exceptions to ensure UI stability.
+    /// </summary>
+    public static void OpenTerminalLink(string? url)
+    {
+        TryOpenTerminalLink(url, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Opens the terminal link with a plan navigation callback, suppressing any exceptions.
+    /// </summary>
+    public static void OpenTerminalLink(string? url, Action<int>? onPlanClick)
+    {
+        TryOpenTerminalLink(url, onPlanClick, null, null, null);
+    }
+
+    /// <summary>
+    ///     Validates and attempts to open a terminal link.
+    ///     Returns true if the link was recognized and launched; otherwise false.
+    /// </summary>
+    public static bool TryOpenTerminalLink(
+        string? url,
+        Action<int>? onPlanClick = null,
+        Action<string>? browserLauncher = null,
+        Action<string>? fileLauncher = null,
+        ILogger? logger = null)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        var trimmed = url.Trim();
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        try
+        {
+            if (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+                uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                var launcher = browserLauncher ?? BrowserLauncher ?? DefaultLaunchBrowser;
+                launcher(trimmed);
+                return true;
+            }
+
+            if (uri.Scheme.Equals(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+            {
+                var filePath = PathHelper.ExtractPathFromFileUri(trimmed) ?? (uri.IsFile ? uri.LocalPath : null);
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    return false;
+                }
+
+                if (!File.Exists(filePath) && !Directory.Exists(filePath))
+                {
+                    logger?.LogWarning("Target file or directory not found for file URI: {FilePath}", filePath);
+                    return false;
+                }
+
+                var launcher = fileLauncher ?? FileLauncher ?? DefaultLaunchFile;
+                launcher(filePath);
+                return true;
+            }
+
+            if (uri.Scheme.Equals("plan", StringComparison.OrdinalIgnoreCase))
+            {
+                var planIdStr = trimmed["plan://".Length..].TrimEnd('/');
+                var colonIndex = planIdStr.IndexOf(':');
+                if (colonIndex >= 0)
+                {
+                    planIdStr = planIdStr[..colonIndex];
+                }
+
+                var hashIndex = planIdStr.IndexOf('#');
+                if (hashIndex >= 0)
+                {
+                    planIdStr = planIdStr[..hashIndex];
+                }
+
+                if (int.TryParse(planIdStr, out var planId))
+                {
+                    var handler = onPlanClick ?? DefaultPlanHandler;
+                    if (handler != null)
+                    {
+                        handler(planId);
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to open terminal link: {Url}", url);
+            return false;
+        }
+    }
+
+    private static void DefaultLaunchBrowser(string targetUrl)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = targetUrl,
+            UseShellExecute = true
+        });
+    }
+
+    private static void DefaultLaunchFile(string filePath)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = filePath,
+            UseShellExecute = true
+        });
+    }
+}


### PR DESCRIPTION
Fixes #2543

# Summary

## Changes

Added `TerminalLinkHelper` to handle URL and file navigation from terminal output, and wired `OnLinkClick` on `Xterm.Terminal` in both `ReviewActionApp` and `AgentApp`. This allows clicking URLs such as localhost dev server endpoints, web links, file URIs, and plan links in terminal output to open in the user's default browser or file viewer.

## API Changes

- Added `Ivy.Tendril.Helpers.TerminalLinkHelper` with public static methods `OpenTerminalLink(string? url)`, `OpenTerminalLink(string? url, Action<int>? onPlanClick)`, and `TryOpenTerminalLink(string? url, Action<int>? onPlanClick, Action<string>? browserLauncher, Action<string>? fileLauncher, ILogger? logger)`.

## Files Modified

- `src/Ivy.Tendril/Helpers/TerminalLinkHelper.cs`: Helper for parsing URIs and launching external browsers, file viewers, or internal plan navigation.
- `src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs`: Registered `TerminalLinkHelper.OpenTerminalLink` as `OnLinkClick` handler for the review action terminal.
- `src/Ivy.Tendril/Apps/Agent/AgentApp.cs`: Registered `TerminalLinkHelper.OpenTerminalLink` as `OnLinkClick` handler for the agent terminal.
- `src/Ivy.Tendril.Test/Helpers/TerminalLinkHelperTests.cs`: Unit tests for URI validation, browser/file launching, malicious scheme rejection, and exception suppression.

## Manual Testing

1. Launch Tendril or run review actions / agent chat.
2. Open a review action terminal (such as a frontend dev server) or run a command in an agent terminal that prints a URL (e.g. `http://localhost:5173/` or `https://github.com/`).
3. Click or Cmd+Click/Ctrl+Click the link in the terminal.
4. Observe that the URL opens immediately in your default system web browser.

---
### Commits
- df6384c5: 00381: Add TerminalLinkHelper and wire terminal OnLinkClick navigation

---
Created using [Ivy Tendril](https://ivy.app).
