### PR TITLE
[00370] Prevent Storing Empty Plans and Chats

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -59,6 +59,7 @@ public class DeleteSessionDialogTests
         public void RemoveSpawnedJobs(string sessionId, IEnumerable<string> jobIds) { }
         public IReadOnlyList<string> GetSpawnedJobs(string sessionId) => [];
         public bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers) => false;
+        public void PruneEmptySessions(string? activeSessionId = null) { }
     }
 
     private class TestState<T> : IState<T>

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -92,6 +92,7 @@ public class ChatHistoryServiceTests
         try
         {
             var session = service.CreateSession("claude", "sonnet", "Old Title");
+            service.AddMessage(session.Id, "user", "Hello");
             var eventFired = false;
             service.SessionsChanged += (sender, args) => eventFired = true;
 
@@ -717,6 +718,127 @@ public class ChatHistoryServiceTests
             Assert.Equal("antigravity", reloaded.Settings.LastChatAgent);
             Assert.Equal("gemini-3.8-flash", reloaded.Settings.LastChatModel);
             Assert.Equal("high", reloaded.Settings.LastChatEffort);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void CreateSession_WithNoMessages_DoesNotPersistFileToDisk()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus", "Test Session");
+            var chatsDir = Path.Combine(tempDir, "Chats");
+            var sessionFile = Path.Combine(chatsDir, $"{session.Id}.json");
+            Assert.False(File.Exists(sessionFile));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadSessionsFromDisk_DeletesAndExcludesZeroMessageFiles()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var chatsDir = Path.Combine(tempDir, "Chats");
+            Directory.CreateDirectory(chatsDir);
+
+            var emptySessionId = Guid.NewGuid().ToString("N");
+            var emptySession = new ChatSessionModel(
+                Id: emptySessionId,
+                Title: "Empty Chat",
+                CreatedAt: DateTimeOffset.UtcNow,
+                UpdatedAt: DateTimeOffset.UtcNow,
+                AgentId: "claude",
+                ModelId: "opus",
+                Messages: new List<ChatMessageModel>()
+            );
+            var emptyFilePath = Path.Combine(chatsDir, $"{emptySessionId}.json");
+            File.WriteAllText(emptyFilePath, System.Text.Json.JsonSerializer.Serialize(emptySession));
+
+            var validSessionId = Guid.NewGuid().ToString("N");
+            var validSession = new ChatSessionModel(
+                Id: validSessionId,
+                Title: "Valid Chat",
+                CreatedAt: DateTimeOffset.UtcNow,
+                UpdatedAt: DateTimeOffset.UtcNow,
+                AgentId: "claude",
+                ModelId: "opus",
+                Messages: new List<ChatMessageModel>
+                {
+                    new(Guid.NewGuid().ToString("N"), "user", "Hi", DateTimeOffset.UtcNow)
+                }
+            );
+            var validFilePath = Path.Combine(chatsDir, $"{validSessionId}.json");
+            File.WriteAllText(validFilePath, System.Text.Json.JsonSerializer.Serialize(validSession));
+
+            var configService = new ConfigService(new TendrilSettings(), tempDir);
+            var service = new ChatHistoryService(configService);
+
+            Assert.False(File.Exists(emptyFilePath));
+            Assert.True(File.Exists(validFilePath));
+
+            var sessions = service.GetSessions();
+            Assert.Single(sessions);
+            Assert.Equal(validSessionId, sessions[0].Id);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void AddMessage_PersistsSessionToDisk()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            var chatsDir = Path.Combine(tempDir, "Chats");
+            var sessionFile = Path.Combine(chatsDir, $"{session.Id}.json");
+            Assert.False(File.Exists(sessionFile));
+
+            service.AddMessage(session.Id, "user", "Hello");
+            Assert.True(File.Exists(sessionFile));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void PruneEmptySessions_RemovesUnusedZeroMessageSessions()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var empty1 = service.CreateSession("claude", "opus", "Empty 1");
+            var empty2 = service.CreateSession("claude", "opus", "Empty 2");
+            var active = service.CreateSession("claude", "opus", "Active");
+            var withMessages = service.CreateSession("claude", "opus", "Has Messages");
+            service.AddMessage(withMessages.Id, "user", "Hello");
+
+            service.PruneEmptySessions(activeSessionId: active.Id);
+
+            Assert.Null(service.GetSession(empty1.Id));
+            Assert.Null(service.GetSession(empty2.Id));
+            Assert.NotNull(service.GetSession(active.Id));
+            Assert.NotNull(service.GetSession(withMessages.Id));
         }
         finally
         {

--- a/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
@@ -60,6 +60,29 @@ public class DoctorCommandPlansTests : IDisposable
     }
 
     [Fact]
+    public void DoctorPlans_PlanWithNoRevisions_FlagsAsEmpty()
+    {
+        var draftYaml = """
+                        state: Draft
+                        project: TestProject
+                        title: Empty Draft Plan
+                        repos:
+                        - /dummy/repo
+                        commits: []
+                        prs: []
+                        """;
+        CreatePlan("00005-EmptyDraftPlan", draftYaml);
+
+        var results = DoctorCommand.ScanPlans(_plansDir);
+
+        Assert.Single(results);
+        Assert.Equal("00005", results[0].Id);
+        Assert.Equal("Draft", results[0].State);
+        Assert.False(results[0].IsHealthy);
+        Assert.Contains("Empty (no revisions)", results[0].Health);
+    }
+
+    [Fact]
     public void DoctorPlans_MissingYaml_ReportsError()
     {
         CreatePlan("00002-MissingYaml");

--- a/src/Ivy.Tendril.Test/FakePlanReaderService.cs
+++ b/src/Ivy.Tendril.Test/FakePlanReaderService.cs
@@ -4,7 +4,7 @@ namespace Ivy.Tendril.Test;
 
 internal class FakePlanReaderService : IPlanReaderService
 {
-    public string PlansDirectory => "/tmp";
+    public string PlansDirectory { get; set; } = "/tmp";
     public bool IsDatabaseReady => true;
     public PlanFile? PlanToReturn { get; set; }
 #pragma warning disable CS0067

--- a/src/Ivy.Tendril.Test/JobServiceCreatePlanVerificationTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCreatePlanVerificationTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Jobs;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceCreatePlanVerificationTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new();
+    private readonly string _plansDir;
+    private readonly string _promptsRoot;
+
+    public JobServiceCreatePlanVerificationTests()
+    {
+        _plansDir = Path.Combine(_tempDir.Path, "Plans");
+        _promptsRoot = Path.Combine(_tempDir.Path, "Prompts");
+        Directory.CreateDirectory(_plansDir);
+        Directory.CreateDirectory(_promptsRoot);
+    }
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    [Fact]
+    public void VerifyCreatePlanResult_FailsAndCleansUpWhenNoRevisionsWritten()
+    {
+        var planFolder = Path.Combine(_plansDir, "00100-EmptyPlan");
+        Directory.CreateDirectory(planFolder);
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), "state: Draft\ntitle: Empty Plan\n");
+
+        var planReader = new FakePlanReaderService { PlansDirectory = _plansDir };
+        var handler = new JobCompletionHandler(
+            configService: null,
+            logger: NullLogger.Instance,
+            modelPricingService: null,
+            planReaderService: planReader,
+            telemetryService: null,
+            planWatcherService: null,
+            promptsRoot: _promptsRoot
+        );
+
+        var job = new JobItem
+        {
+            Id = "00001",
+            Type = "CreatePlan",
+            AllocatedPlanId = "00100",
+            ReportedPlanId = "00100",
+            PlanFile = "00100-EmptyPlan",
+            Status = JobStatus.Completed
+        };
+
+        handler.VerifyCreatePlanResult(job);
+
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.False(Directory.Exists(planFolder));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -177,6 +177,7 @@ public class ChatApp : ViewBase
                 executionService.StreamUpdated -= OnStreamUpdated;
                 executionService.SessionGeneratingChanged -= OnSessionGeneratingChanged;
                 if (jobService != null) jobService.JobsChanged -= OnJobsChanged;
+                chatService.PruneEmptySessions();
             });
         });
 
@@ -201,6 +202,7 @@ public class ChatApp : ViewBase
                 navigator.Navigate(typeof(AgentApp), new AgentAppArgs(SessionId: sessionId));
                 return;
             }
+            chatService.PruneEmptySessions(activeSessionId: sessionId);
             activeSessionId.Set(sessionId);
             chatService.ClearSessionCompleted(sessionId);
             if (sess != null)
@@ -246,6 +248,7 @@ public class ChatApp : ViewBase
                 navigator.Navigate(typeof(AgentApp), new AgentAppArgs());
                 return;
             }
+            chatService.PruneEmptySessions();
             var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort, kind: ChatSessionKinds.Chat);
             SelectSession(newSess.Id);
         }

--- a/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
@@ -23,6 +23,7 @@ internal static class ChatLauncher
     {
         if (UsesTerminal(config)) return (typeof(AgentApp), new AgentAppArgs());
 
+        chats.PruneEmptySessions();
         var agent = config.Settings.CodingAgent ?? "claude";
         var models = ChatApp.GetModelsForAgent(runner, agent);
         var session = chats.CreateSession(agent, models.Count > 0 ? models[0].Id : "default", kind: ChatSessionKinds.Chat);

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -329,6 +329,27 @@ public static class DoctorCommand
             if (hasStaleWorktrees)
                 healthIssues.Add("StaleWorktree");
 
+            var revisionsDir = Path.Combine(dir, "Revisions");
+            var hasRevisions = (Directory.Exists(revisionsDir) && Directory.GetFiles(revisionsDir, "*.md").Length > 0)
+                || (Directory.Exists(Path.Combine(dir, "revisions")) && Directory.GetFiles(Path.Combine(dir, "revisions"), "*.md").Length > 0);
+
+            if (state.Equals(nameof(PlanStatus.Draft), StringComparison.OrdinalIgnoreCase) && !hasRevisions)
+            {
+                var hasCommits = false;
+                var hasPrs = false;
+                if (File.Exists(yamlPath))
+                {
+                    var content = File.ReadAllText(yamlPath);
+                    hasCommits = HasYamlListItems(content, "commits");
+                    hasPrs = HasYamlListItems(content, "prs");
+                }
+
+                if (!hasCommits && !hasPrs)
+                {
+                    healthIssues.Add("Empty (no revisions)");
+                }
+            }
+
             var health = healthIssues.Count == 0 ? "OK" : string.Join(",", healthIssues);
 
             results.Add(new PlanHealthResult(id, title, state, worktreeCount, health, healthIssues.Count == 0, dir));
@@ -498,6 +519,15 @@ public static class DoctorCommand
 
         try
         {
+            if (healthResult.Health.Contains("Empty (no revisions)"))
+            {
+                if (Directory.Exists(planPath))
+                {
+                    Directory.Delete(planPath, true);
+                }
+                return new RepairResult(true, "pruned empty draft plan (no revisions)");
+            }
+
             if (healthResult.Health.Contains("YAML:"))
             {
                 var yamlPath = Path.Combine(planPath, "plan.yaml");
@@ -702,6 +732,9 @@ public static class DoctorCommand
             return null;
 
         var reasons = new List<string>();
+
+        if (healthResult.Health.Contains("Empty (no revisions)"))
+            reasons.Add("empty draft (no revisions)");
 
         if (healthResult.Health.Contains("YAML:Missing"))
             reasons.Add("no plan.yaml");

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -255,6 +255,19 @@ public class ChatHistoryService : IChatHistoryService
                     var session = JsonSerializer.Deserialize<ChatSessionModel>(json, JsonOptions);
                     if (session != null && !string.IsNullOrEmpty(session.Id))
                     {
+                        if (session.Messages == null || session.Messages.Count == 0)
+                        {
+                            try
+                            {
+                                File.Delete(file);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger?.LogError(ex, "Failed to delete empty chat session file {File}", file);
+                            }
+                            continue;
+                        }
+
                         var cleanedTitle = CleanTitle(session.Title);
                         if (cleanedTitle != session.Title)
                         {
@@ -309,7 +322,10 @@ public class ChatHistoryService : IChatHistoryService
         );
 
         _sessions[id] = session;
-        PersistSessionToDisk(session);
+        if (session.Messages.Count > 0)
+        {
+            PersistSessionToDisk(session);
+        }
         if (_configService?.Settings != null)
         {
             if (!string.IsNullOrEmpty(agentId))
@@ -335,8 +351,11 @@ public class ChatHistoryService : IChatHistoryService
         if (session == null || string.IsNullOrEmpty(session.Id)) return;
         _sessions[session.Id] = session;
         CancelPendingPersist(session.Id);
-        _lastPersistTimes[session.Id] = DateTimeOffset.UtcNow;
-        PersistSessionToDisk(session);
+        if (session.Messages.Count > 0)
+        {
+            _lastPersistTimes[session.Id] = DateTimeOffset.UtcNow;
+            PersistSessionToDisk(session);
+        }
         SessionsChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -777,6 +796,7 @@ public class ChatHistoryService : IChatHistoryService
 
     private void PersistSessionToDisk(ChatSessionModel session)
     {
+        if (session == null || session.Messages == null || session.Messages.Count == 0) return;
         try
         {
             var filePath = Path.Combine(GetStorageDir(), $"{session.Id}.json");
@@ -786,6 +806,51 @@ public class ChatHistoryService : IChatHistoryService
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Failed to persist chat session {SessionId} to disk", session.Id);
+        }
+    }
+
+    public void PruneEmptySessions(string? activeSessionId = null)
+    {
+        bool changed = false;
+        foreach (var (id, session) in _sessions)
+        {
+            if (activeSessionId != null && string.Equals(id, activeSessionId, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (_generatingSessions.ContainsKey(id))
+            {
+                continue;
+            }
+
+            if (session.Messages == null || session.Messages.Count == 0)
+            {
+                if (_sessions.TryRemove(id, out _))
+                {
+                    CancelPendingPersist(id);
+                    _lastPersistTimes.TryRemove(id, out _);
+                    _queuedMessages.TryRemove(id, out _);
+                    try
+                    {
+                        var filePath = Path.Combine(GetStorageDir(), $"{id}.json");
+                        if (File.Exists(filePath))
+                        {
+                            File.Delete(filePath);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogError(ex, "Failed to delete chat session file for {SessionId}", id);
+                    }
+                    changed = true;
+                }
+            }
+        }
+
+        if (changed)
+        {
+            SessionsChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -73,4 +73,5 @@ public interface IChatHistoryService
     void RemoveSpawnedJobs(string sessionId, IEnumerable<string> jobIds);
     IReadOnlyList<string> GetSpawnedJobs(string sessionId);
     bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers);
+    void PruneEmptySessions(string? activeSessionId = null);
 }

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -157,6 +157,10 @@ internal class JobCompletionHandler
         // A cancelled job that the completion path won the race for is handled here too.
         if (job.Status is JobStatus.Failed or JobStatus.Timeout || job.CancellationRequested)
         {
+            if (job.TypedArgs is CreatePlanArgs || job.Type == Constants.JobTypes.CreatePlan)
+            {
+                CleanupEmptyCreatePlan(job);
+            }
             RevertPlanStateToPrevious(job);
             return;
         }
@@ -780,45 +784,74 @@ internal class JobCompletionHandler
     private static string CanonicalPrKey(Match m) =>
         $"{m.Groups["owner"].Value}/{m.Groups["repo"].Value}#{m.Groups["number"].Value}".ToLowerInvariant();
 
-    private void VerifyCreatePlanResult(JobItem job)
+    internal void VerifyCreatePlanResult(JobItem job)
     {
         try
         {
-            var plansDir = _planReaderService?.PlansDirectory;
+            var plansDir = _planReaderService?.PlansDirectory
+                ?? (_configService != null ? Path.Combine(_configService.TendrilHome, "Plans") : null);
             if (plansDir == null || !Directory.Exists(plansDir)) return;
 
+            string? planFolder = null;
             if (TryVerifyByReportedId(job, plansDir) ||
                 TryVerifyByOutputRegex(job, plansDir) ||
                 TryVerifyByFilesystem(job, plansDir))
             {
-                if (!string.IsNullOrEmpty(job.ChatSessionId) && !string.IsNullOrEmpty(job.PlanFile))
-                {
-                    var planFolder = Path.IsPathRooted(job.PlanFile) ? job.PlanFile : Path.Combine(plansDir, job.PlanFile);
-                    PlanYamlHelper.UpdatePlanYamlFields(planFolder, ("chatSessionId", job.ChatSessionId));
-                    _planWatcherService?.NotifyChanged(planFolder);
-                    if (_planReaderService is PlanReaderService prs)
-                    {
-                        var plan = prs.ParseSinglePlanFolder(planFolder);
-                        if (plan != null)
-                        {
-                            (_database ?? prs.Database)?.UpsertPlan(plan);
-                        }
-                    }
-                    else if (_database != null)
-                    {
-                        var plan = _planReaderService?.GetPlanByFolder(planFolder);
-                        if (plan != null)
-                        {
-                            _database.UpsertPlan(plan);
-                        }
-                    }
-                }
+                planFolder = !string.IsNullOrEmpty(job.PlanFile)
+                    ? (Path.IsPathRooted(job.PlanFile) ? job.PlanFile : Path.Combine(plansDir, job.PlanFile))
+                    : null;
+            }
 
-                MoveAttachmentsToPlanFolder(job);
-                return;
+            if (planFolder != null && Directory.Exists(planFolder))
+            {
+                if (GetPlanRevisionCount(planFolder) > 0)
+                {
+                    if (!string.IsNullOrEmpty(job.ChatSessionId) && !string.IsNullOrEmpty(job.PlanFile))
+                    {
+                        PlanYamlHelper.UpdatePlanYamlFields(planFolder, ("chatSessionId", job.ChatSessionId));
+                        _planWatcherService?.NotifyChanged(planFolder);
+                        if (_planReaderService is PlanReaderService prs)
+                        {
+                            var plan = prs.ParseSinglePlanFolder(planFolder);
+                            if (plan != null)
+                            {
+                                (_database ?? prs.Database)?.UpsertPlan(plan);
+                            }
+                        }
+                        else if (_database != null)
+                        {
+                            var plan = _planReaderService?.GetPlanByFolder(planFolder);
+                            if (plan != null)
+                            {
+                                _database.UpsertPlan(plan);
+                            }
+                        }
+                    }
+
+                    MoveAttachmentsToPlanFolder(job);
+                    return;
+                }
+                else
+                {
+                    CleanupPlanFolderAndDatabase(planFolder);
+                    job.PlanFile = "";
+                }
             }
 
             if (IsDuplicatePlan(job)) return;
+
+            if (!string.IsNullOrEmpty(job.AllocatedPlanId))
+            {
+                var allocatedFolder = PlanYamlHelper.FindPlanFolderById(plansDir, job.AllocatedPlanId);
+                if (allocatedFolder != null)
+                {
+                    var fullAllocated = Path.IsPathRooted(allocatedFolder) ? allocatedFolder : Path.Combine(plansDir, allocatedFolder);
+                    if (GetPlanRevisionCount(fullAllocated) == 0)
+                    {
+                        CleanupPlanFolderAndDatabase(fullAllocated);
+                    }
+                }
+            }
 
             MarkCreatePlanFailed(job);
         }
@@ -947,11 +980,87 @@ internal class JobCompletionHandler
                 TryVerifyByOutputRegex(job, plansDir) ||
                 TryVerifyByFilesystem(job, plansDir))
             {
-                return true;
+                if (!string.IsNullOrEmpty(job.PlanFile))
+                {
+                    var fullPath = Path.IsPathRooted(job.PlanFile) ? job.PlanFile : Path.Combine(plansDir, job.PlanFile);
+                    if (GetPlanRevisionCount(fullPath) > 0)
+                        return true;
+                }
             }
         }
 
         return IsDuplicatePlan(job);
+    }
+
+    internal static int GetPlanRevisionCount(string planFolder)
+    {
+        var revisionsDir = Path.Combine(planFolder, "Revisions");
+        if (!Directory.Exists(revisionsDir))
+        {
+            revisionsDir = Path.Combine(planFolder, "revisions");
+        }
+        return Directory.Exists(revisionsDir)
+            ? Directory.GetFiles(revisionsDir, "*.md").Length
+            : 0;
+    }
+
+    internal void CleanupPlanFolderAndDatabase(string planFolder)
+    {
+        try
+        {
+            var folderName = Path.GetFileName(planFolder);
+            var match = Regex.Match(folderName, @"^(\d{5})-");
+            if (match.Success && int.TryParse(match.Groups[1].Value, out var planId))
+            {
+                var db = _database ?? (_planReaderService as PlanReaderService)?.Database;
+                db?.DeletePlan(planId);
+            }
+
+            if (Directory.Exists(planFolder))
+            {
+                Directory.Delete(planFolder, recursive: true);
+            }
+            _planWatcherService?.NotifyChanged(planFolder);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to clean up empty plan folder {Folder}", planFolder);
+        }
+    }
+
+    private void CleanupEmptyCreatePlan(JobItem job)
+    {
+        try
+        {
+            var plansDir = _planReaderService?.PlansDirectory
+                ?? (_configService != null ? Path.Combine(_configService.TendrilHome, "Plans") : null);
+            if (plansDir == null || !Directory.Exists(plansDir)) return;
+
+            var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
+            if (string.IsNullOrEmpty(planId))
+            {
+                var outputText = string.Join("\n", job.OutputLines);
+                var planIdMatch = Regex.Match(outputText, @"PlanId:\s*([\w-]+)");
+                if (planIdMatch.Success) planId = planIdMatch.Groups[1].Value;
+            }
+
+            if (!string.IsNullOrEmpty(planId))
+            {
+                var folder = PlanYamlHelper.FindPlanFolderById(plansDir, planId);
+                if (folder != null)
+                {
+                    var fullPath = Path.IsPathRooted(folder) ? folder : Path.Combine(plansDir, folder);
+                    if (GetPlanRevisionCount(fullPath) == 0)
+                    {
+                        CleanupPlanFolderAndDatabase(fullPath);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to clean up empty CreatePlan on job failure for job {JobId}", job.Id);
+        }
     }
 
     private static bool TryVerifyByReportedId(JobItem job, string plansDir)


### PR DESCRIPTION
Fixes #2541

# Summary

## Changes

Prevented eager disk persistence of empty 0-message chat sessions and added pruning of unused empty sessions in memory and on startup. Additionally, enforced that CreatePlan execution must produce at least one revision, cleaning up empty plan directories and database records on failure or omission, and added detection and fix pruning for empty draft plans in the doctor command.

## API Changes

- Added `void PruneEmptySessions(string? activeSessionId = null)` to `IChatHistoryService` and `ChatHistoryService`.
- Added `GetPlanRevisionCount(string planFolder)` and `CleanupPlanFolderAndDatabase(string planFolder)` internal helper methods to `JobCompletionHandler`.

## Files Modified

- **Chat Management:**
  - `src/Ivy.Tendril/Services/IChatHistoryService.cs`: Declared `PruneEmptySessions` method.
  - `src/Ivy.Tendril/Services/ChatHistoryService.cs`: Deferred disk persistence until messages are added, pruned legacy empty chat files on startup, and implemented in-memory pruning.
  - `src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs`: Pruned empty sessions before initiating a new chat session target.
  - `src/Ivy.Tendril/Apps/Chat/ChatApp.cs`: Wired `PruneEmptySessions` on navigation away, session selection, and starting a new chat.
- **Plan and Job Services:**
  - `src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs`: Enforced revisions in `VerifyCreatePlanResult` and added cleanup logic for empty plan folders on job failure or missing revisions.
  - `src/Ivy.Tendril/Commands/DoctorCommand.cs`: Added detection for empty draft plans and enabled pruning under `--fix`.
- **Tests:**
  - `src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs`: Added tests for deferred chat persistence, disk cleanup of empty chats on load, and in-memory pruning.
  - `src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs`: Added test verifying empty draft plans are flagged as unhealthy.
  - `src/Ivy.Tendril.Test/JobServiceCreatePlanVerificationTests.cs`: Added test verifying empty plan folders without revisions are failed and cleaned up.
  - `src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs`: Updated test fake implementation of `IChatHistoryService`.
  - `src/Ivy.Tendril.Test/FakePlanReaderService.cs`: Made `PlansDirectory` mutable for test isolation.

## Manual Testing

1. Launch Tendril and open the Chat application.
2. Click the 'New Chat' button multiple times without typing any prompt or message. Observe that empty chat sessions do not accumulate in the Chats sidebar or disk storage directory (`~/.tendril/Chats`).
3. Send a message in a chat session and verify that it is properly saved to disk.
4. Run `tendril doctor plans` from the terminal when an empty plan directory exists (with no revisions, commits, or PRs) and observe that it is flagged as `Empty (no revisions)`.
5. Run `tendril doctor plans --fix` and observe that the empty plan directory is pruned.

---
### Commits

- b66f1b95: [00370] Prevent storing empty plan folders and add doctor verification
- 8ab8ccb9: [00370] Prevent storing and accumulating empty chat sessions

---
Created using [Ivy Tendril](https://ivy.app).