### PR TITLE
[00322] Upgrade Mocha and Glob in VS Code Extension

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -27,7 +27,7 @@
     "workflow"
   ],
   "engines": {
-    "vscode": "^1.137.0"
+    "vscode": "^1.90.0"
   },
   "packageManager": "pnpm@10.33.0",
   "categories": [
@@ -127,7 +127,7 @@
   "devDependencies": {
     "@types/mocha": "10.0.10",
     "@types/node": "22.20.2",
-    "@types/vscode": "1.137.0",
+    "@types/vscode": "1.90.0",
     "@vscode/test-electron": "3.1.0",
     "esbuild": "0.28.2",
     "glob": "13.0.6",

--- a/extensions/vscode/pnpm-lock.yaml
+++ b/extensions/vscode/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 22.20.2
         version: 22.20.2
       '@types/vscode':
-        specifier: 1.137.0
-        version: 1.137.0
+        specifier: 1.90.0
+        version: 1.90.0
       '@vscode/test-electron':
         specifier: 3.1.0
         version: 3.1.0
@@ -197,8 +197,8 @@ packages:
   '@types/node@22.20.2':
     resolution: {integrity: sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==}
 
-  '@types/vscode@1.137.0':
-    resolution: {integrity: sha512-0dc/BBWxkyUsJzXIZ7PkKSalThmS4xiBT+8YEDiWdCefRKHGVV5ZNkM5NB5ULYamallYJujIfncNoXWFlyzL8A==}
+  '@types/vscode@1.90.0':
+    resolution: {integrity: sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -671,7 +671,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/vscode@1.137.0': {}
+  '@types/vscode@1.90.0': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true


### PR DESCRIPTION
## Fix: Verify extension build/tests and complete CheckResult

The implementation (commit `caa91876`) was already complete from the prior run: pnpm migration, exact-pinned devDependency versions (mocha 12.0.0, glob 13.0.6), `.npmrc`, `.vscodeignore`, and CI workflow updates. This retry addressed the reviewer's ChangeRequest by re-running verification without redoing any implementation work: skipped the long-running `.NET` E2E test suites since no `.NET` files were touched, ran `pnpm test` / `pnpm run typecheck` / `pnpm run build` in `extensions/vscode/` to confirm the upgraded Mocha/glob/esbuild/typescript toolchain works end to end, re-confirmed `DotnetBuild`/`DotnetFormat` (no C# files changed), and wrote the `CheckResult` report comparing the commit against the plan's Solution section.

### Files Modified

None (this retry only produced verification reports under `Verification/`. No code changes were needed.)

**Note:** No user-facing behavior changed in this retry.

## Fix: Lower VS Code engine and types compatibility

Lowered `engines.vscode` to `^1.90.0` and `@types/vscode` to `1.90.0` in `extensions/vscode/package.json` and updated `pnpm-lock.yaml`. This restores extension compatibility with Antigravity IDE (running VS Code engine 1.107.0) and broader VS Code environments, while successfully building and passing the extension test suite.

### Files Modified

- `extensions/vscode/package.json`
- `extensions/vscode/pnpm-lock.yaml`

**Note:** Restores compatibility for Antigravity IDE and older VS Code runtimes without changing extension runtime behavior.

---
- 48b70876 Plan 00322: Lower engines.vscode to ^1.90.0 and @types/vscode to 1.90.0
- caa91876 Plan 00322: Upgrade mocha and glob to modern versions and migrate to pnpm in VS Code extension

---
Created using [Ivy Tendril](https://ivy.app).
