### PR TITLE
[00387] Point README CI Badge at Repository Health Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p>
   <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/stargazers"><img src="https://badgen.net/github/stars/Ivy-Interactive/Ivy-Tendril?label=%E2%98%85" alt="GitHub stars" /></a>
   <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/releases/latest"><img src="https://img.shields.io/github/v/release/Ivy-Interactive/Ivy-Tendril?style=flat&label=release" alt="Latest Release" /></a>
-  <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/actions/workflows/publish-tendril.yml"><img src="https://img.shields.io/github/actions/workflow/status/Ivy-Interactive/Ivy-Tendril/publish-tendril.yml?style=flat&label=CI" alt="CI Status" /></a>
+  <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/actions/workflows/repo-health.yml"><img src="https://img.shields.io/github/actions/workflow/status/Ivy-Interactive/Ivy-Tendril/repo-health.yml?branch=development&style=flat&label=CI" alt="CI Status" /></a>
   <a href="https://tendril.ivy.app"><img src="https://img.shields.io/badge/docs-tendril.ivy.app-blue?style=flat" alt="Documentation" /></a>
   <img src="https://img.shields.io/badge/macOS%20%7C%20Windows%20%7C%20Linux-4493F8?style=flat-square" alt="Supported platforms: macOS, Windows, and Linux" />
 </p>


### PR DESCRIPTION
Fixes #2568

# Summary

## Changes

Updated the README.md CI badge to point to the repository health workflow (`repo-health.yml`) instead of the publish workflow (`publish-tendril.yml`). The badge now tracks the development branch status and accurately reflects the continuous integration health rather than release deployment status.

## API Changes

None.

## Files Modified

- **README.md** — Updated line 8 to change the CI badge anchor and image URL from `publish-tendril.yml` to `repo-health.yml`, and added `branch=development` parameter

## Manual Testing

1. Open the README.md file in a browser (e.g., view it on GitHub)
2. Observe the CI badge displays the current status of the repository health workflow
3. Click the CI badge link
4. Verify it navigates to https://github.com/Ivy-Interactive/Ivy-Tendril/actions/workflows/repo-health.yml showing the repository health workflow runs

---

**Commits:**
- 5ba5e0fe Point README CI badge to repository health workflow

---
Created using [Ivy Tendril](https://ivy.app).
