### PR TITLE
[00392] Fix README Star Badge Showing HTTP Status as Star Count

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </h1>
 
 <p>
-  <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/stargazers"><img src="https://badgen.net/github/stars/Ivy-Interactive/Ivy-Tendril?label=%E2%98%85" alt="GitHub stars" /></a>
+  <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/stargazers"><img src="https://img.shields.io/github/stars/Ivy-Interactive/Ivy-Tendril?style=flat&label=%E2%98%85" alt="GitHub stars" /></a>
   <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/releases/latest"><img src="https://img.shields.io/github/v/release/Ivy-Interactive/Ivy-Tendril?style=flat&label=release" alt="Latest Release" /></a>
   <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/actions/workflows/publish-tendril.yml"><img src="https://img.shields.io/github/actions/workflow/status/Ivy-Interactive/Ivy-Tendril/publish-tendril.yml?style=flat&label=CI" alt="CI Status" /></a>
   <a href="https://tendril.ivy.app"><img src="https://img.shields.io/badge/docs-tendril.ivy.app-blue?style=flat" alt="Documentation" /></a>


### PR DESCRIPTION
Fixes #2567

## Problem

[Issue #2567](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/2567) reports a "weird number" in the README badge row. The star badge read `403`. The repository has **187** stars.

`403` is not a star count at all, it is the HTTP status of a rejected GitHub API call. The star badge is the only badge in the repo served by `badgen.net`, and badgen substitutes the upstream status code into the **value slot** of the badge when its own request fails. badgen calls the GitHub API unauthenticated from shared egress addresses, so `403` (rate limited / forbidden) is the status it hits in practice.

The damaging part is not the outage, it is that badgen's failure mode is **indistinguishable from success**: a three digit number in the value slot of a star badge reads as a star count. A reader has no way to tell `403` (an error) from `187` (the truth).

The four other badges in the same row already use `img.shields.io`, and shields reports failures as words rather than numbers. So moving the star badge to shields both removes the current wrong number and makes any future provider failure legible instead of deceptive.

## Solution

One line changes: line 6 of README.md.

**Current implementation** (README.md line 6):

```html
  <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/stargazers"><img src="https://badgen.net/github/stars/Ivy-Interactive/Ivy-Tendril?label=%E2%98%85" alt="GitHub stars" /></a>
```

Replace with:

```html
  <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/stargazers"><img src="https://img.shields.io/github/stars/Ivy-Interactive/Ivy-Tendril?style=flat&label=%E2%98%85" alt="GitHub stars" /></a>
```

Only the `src` URL changes. The replacement badge has:
- Rendered content: `★` label, `187` value
- SVG dimensions: 52x20, the same as the badgen badge it replaces
- Value colour: `#007ec6`, matching the release and docs badges

After the change, `badgen.net` no longer appears anywhere in the repository.

---

## Commits

- 787edb1 - Fix README star badge showing HTTP 403 status

---
Created using [Ivy Tendril](https://ivy.app).
