### PR TITLE
[00398] Find Available Port in VS Code Extension When Tendril Is Already Running

### DIFF
--- a/extensions/vscode/src/server/serverManager.ts
+++ b/extensions/vscode/src/server/serverManager.ts
@@ -9,6 +9,16 @@ import {
 } from './masterDiscovery';
 import { DiscoveryResult, ServerHealthInfo, TendrilPlanSummary } from './types';
 
+export function buildServerArgs(port = 0): string[] {
+  const args = ['--web'];
+  if (typeof port === 'number' && port > 0) {
+    args.push(`--port=${port}`);
+  } else {
+    args.push('--find-available-port');
+  }
+  return args;
+}
+
 export class ServerManager implements vscode.Disposable {
   private readonly outputChannel: vscode.OutputChannel;
   private spawnedChild: cp.ChildProcess | null = null;
@@ -115,10 +125,7 @@ export class ServerManager implements vscode.Disposable {
       const port = config.get<number>(CONFIG_KEYS.serverPort, 0);
       const pollTimeoutMs = config.get<number>(CONFIG_KEYS.serverPollTimeout, 15000);
 
-      const args = ['--web'];
-      if (port > 0) {
-        args.push(`--port=${port}`);
-      }
+      const args = buildServerArgs(port);
 
       this.outputChannel.show(true);
       this.outputChannel.appendLine(`Starting Tendril server: ${executable} ${args.join(' ')}`);

--- a/extensions/vscode/src/test/suite/serverManager.test.ts
+++ b/extensions/vscode/src/test/suite/serverManager.test.ts
@@ -1,0 +1,29 @@
+import * as assert from 'assert';
+import { buildServerArgs } from '../../server/serverManager';
+
+describe('ServerManager Suite', () => {
+  describe('buildServerArgs', () => {
+    it('should return --find-available-port when port is 0', () => {
+      const args = buildServerArgs(0);
+      assert.deepStrictEqual(args, ['--web', '--find-available-port']);
+    });
+
+    it('should return --find-available-port when port is undefined or omitted', () => {
+      const argsOmitted = buildServerArgs();
+      assert.deepStrictEqual(argsOmitted, ['--web', '--find-available-port']);
+
+      const argsUndefined = buildServerArgs(undefined);
+      assert.deepStrictEqual(argsUndefined, ['--web', '--find-available-port']);
+    });
+
+    it('should return --find-available-port when port is negative', () => {
+      const args = buildServerArgs(-1);
+      assert.deepStrictEqual(args, ['--web', '--find-available-port']);
+    });
+
+    it('should return --port flag when port is positive', () => {
+      const args = buildServerArgs(5015);
+      assert.deepStrictEqual(args, ['--web', '--port=5015']);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2560

# Summary

## Changes

Updated the VS Code extension server startup logic to include `--find-available-port` when the configured port is 0 (auto-assign) or unset. This allows the extension to launch Tendril on the next available port when port 5010 is already occupied by another instance or process.

## API Changes

- Added exported function `buildServerArgs(port = 0): string[]` in `extensions/vscode/src/server/serverManager.ts`.

## Files Modified

- **Server Management**: `extensions/vscode/src/server/serverManager.ts` (extracted `buildServerArgs` and updated `startServer` spawn arguments)
- **Unit Tests**: `extensions/vscode/src/test/suite/serverManager.test.ts` (added test coverage for `buildServerArgs` across 0, unset, negative, and positive port values)

## Manual Testing

1. Start Tendril or another service on port 5010 (e.g. `tendril --web --port=5010`).
2. In VS Code, run the command **Tendril: Start Server** with setting `tendril.server.port` set to `0`.
3. Open the **Tendril Server** Output channel in VS Code. Observe that Tendril starts with `--web --find-available-port` and successfully binds to the next free port (e.g. 5011) without failing.

---
- 1ce19509 00398: Pass --find-available-port in VS Code extension when port is 0 or unset

---
Created using [Ivy Tendril](https://ivy.app).
