### PR TITLE
[00403] Guard the Collapsed Rail Tooltip Against Width Collapse

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -802,8 +802,14 @@
   min-height: 0;
 }
 
-/* Hover flyout for a rail plan chip: the shared tooltip, widened for the row badges. */
-.tsh-rail-tooltip {
+/* Hover flyout for a rail plan chip: the shared tooltip, widened for the row badges. The width
+   is stated here rather than inherited from the min-width Radix sets on its wrapper, and the
+   selector carries .tui-tooltip-content so this cap wins over the shared 320px one whatever
+   order the bundle emits the two stylesheets in. Never add position or transform here: the
+   wrapper positions the content, and taking it out of flow collapses the card to its
+   min-content width (issue #2444). */
+.tui-tooltip-content.tsh-rail-tooltip {
+  width: max-content;
   max-width: 260px;
 }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const cssPath = join(dirname(fileURLToPath(import.meta.url)), "shell.css");
+const css = readFileSync(cssPath, "utf-8");
+
+/** The rail tooltip's own rule, not the theme-token block that shares its class. */
+function railTooltipRule(source: string): string {
+  const start = source.indexOf(".tui-tooltip-content.tsh-rail-tooltip {");
+  expect(start).toBeGreaterThan(-1);
+  return source.slice(start, source.indexOf("}", start) + 1);
+}
+
+describe("shell.css rail plan tooltip", () => {
+  const rule = railTooltipRule(css);
+
+  it("sizes itself instead of relying on the popper wrapper", () => {
+    expect(rule).toMatch(/width:\s*max-content/);
+    expect(rule).toMatch(/max-width:\s*260px/);
+  });
+
+  /* position or transform on the shared tooltip content empties the wrapper Radix positions it
+     with, collapsing the card to its min-content width - issue #2444. */
+  it("leaves positioning to the popper wrapper", () => {
+    expect(rule).not.toMatch(/position:/);
+    expect(rule).not.toMatch(/transform:/);
+  });
+});


### PR DESCRIPTION
Fixes #2444

# Summary

## Changes

Hardened the collapsed rail tooltip against width collapse by explicitly stating its width in CSS and adding test guards to prevent regression of issue #2444. The visible defect was already fixed by PR #2492, but this change makes the fix robust and prevents it from breaking again.

## API Changes

None.

## Files Modified

**CSS and Tests:**
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css` — Updated `.tsh-rail-tooltip` selector to `.tui-tooltip-content.tsh-rail-tooltip` with explicit `width: max-content` and `max-width: 260px` declarations, plus comprehensive comment explaining the rationale
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css.test.ts` — New test file with guards verifying the rule declares width properties and doesn't declare position/transform properties

## Manual Testing

N/A — internal CSS hardening with no user-facing behavior change. The tooltip already renders correctly on origin/development. This change only makes the fix more robust by:
1. Stating the width explicitly instead of relying on Radix's implicit min-width
2. Increasing selector specificity to win over the shared tooltip's 320px cap regardless of stylesheet order
3. Adding automated guards to prevent regression

---

## Commits

- 5422a943 Guard the collapsed rail tooltip against width collapse (Plan 00403)

---
Created using [Ivy Tendril](https://ivy.app).
