### PR TITLE
[00397] Add Button to Open Web Version of Tendril in VS Code Extension

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -44,7 +44,13 @@
     "commands": [
       {
         "command": "tendril.openDashboard",
-        "title": "Tendril: Open Dashboard"
+        "title": "Tendril: Open Dashboard",
+        "icon": "$(browser)"
+      },
+      {
+        "command": "tendril.openInBrowser",
+        "title": "Tendril: Open in Browser",
+        "icon": "$(globe)"
       },
       {
         "command": "tendril.openWorktree",
@@ -63,6 +69,20 @@
         "title": "Tendril: Restart Server"
       }
     ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "tendril.openDashboard",
+          "when": "view == tendril.quickAccess",
+          "group": "navigation@1"
+        },
+        {
+          "command": "tendril.openInBrowser",
+          "when": "view == tendril.quickAccess",
+          "group": "navigation@2"
+        }
+      ]
+    },
     "viewsContainers": {
       "activitybar": [
         {

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -1,5 +1,6 @@
 export const COMMANDS = {
   openDashboard: 'tendril.openDashboard',
+  openInBrowser: 'tendril.openInBrowser',
   openWorktree: 'tendril.openWorktree',
   startServer: 'tendril.startServer',
   stopServer: 'tendril.stopServer',

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -45,6 +45,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   context.subscriptions.push(
+    vscode.commands.registerCommand(COMMANDS.openInBrowser, async () => {
+      try {
+        const result = await serverManager!.ensureServerRunning();
+        await vscode.env.openExternal(vscode.Uri.parse(result.baseUrl));
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`Failed to open Tendril in browser: ${msg}`);
+      }
+    })
+  );
+
+  context.subscriptions.push(
     vscode.commands.registerCommand(COMMANDS.openWorktree, async (targetPath?: string) => {
       let resolvedPath = targetPath;
       if (!resolvedPath) {

--- a/extensions/vscode/src/test/suite/sidebar.test.ts
+++ b/extensions/vscode/src/test/suite/sidebar.test.ts
@@ -1,0 +1,133 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { COMMANDS } from '../../constants';
+import { ServerManager } from '../../server/serverManager';
+import { ServerHealthInfo } from '../../server/types';
+import { SidebarProvider } from '../../views/sidebarProvider';
+import { activate, deactivate } from '../../extension';
+import { vscodeMock } from '../vscodeMock';
+
+describe('Tendril Sidebar & Browser Action Suite', () => {
+  describe('SidebarProvider quick actions', () => {
+    it('should include both Open Dashboard and Open in Browser action items', async () => {
+      const mockEmitter = new vscode.EventEmitter<ServerHealthInfo>();
+      const mockServerManager = {
+        onDidChangeState: mockEmitter.event,
+        getHealthInfo: async (): Promise<ServerHealthInfo> => ({
+          isAlive: true,
+          port: 5000,
+          pid: 12345,
+          baseUrl: 'http://localhost:5000',
+          activeJobsCount: 1
+        }),
+        getRecentPlans: async () => []
+      } as unknown as ServerManager;
+
+      const provider = new SidebarProvider(mockServerManager);
+      const items = await provider.getChildren();
+
+      const actionItems = items.filter(item => item.itemType === 'action');
+      const openDashboardItem = actionItems.find(item => item.label === 'Open Dashboard');
+      const openInBrowserItem = actionItems.find(item => item.label === 'Open in Browser');
+
+      assert.ok(openDashboardItem, 'Open Dashboard action item must be present');
+      assert.strictEqual(
+        openDashboardItem?.command?.command,
+        COMMANDS.openDashboard,
+        'Open Dashboard must bind to tendril.openDashboard'
+      );
+      assert.ok(openDashboardItem?.iconPath instanceof vscode.ThemeIcon);
+      assert.strictEqual(
+        (openDashboardItem?.iconPath as vscode.ThemeIcon).id,
+        'browser',
+        'Open Dashboard must have browser icon'
+      );
+
+      assert.ok(openInBrowserItem, 'Open in Browser action item must be present');
+      assert.strictEqual(
+        openInBrowserItem?.command?.command,
+        COMMANDS.openInBrowser,
+        'Open in Browser must bind to tendril.openInBrowser'
+      );
+      assert.ok(openInBrowserItem?.iconPath instanceof vscode.ThemeIcon);
+      assert.strictEqual(
+        (openInBrowserItem?.iconPath as vscode.ThemeIcon).id,
+        'globe',
+        'Open in Browser must have globe icon'
+      );
+    });
+
+    it('should show both dashboard and browser items even when server is stopped', async () => {
+      const mockEmitter = new vscode.EventEmitter<ServerHealthInfo>();
+      const mockServerManager = {
+        onDidChangeState: mockEmitter.event,
+        getHealthInfo: async (): Promise<ServerHealthInfo> => ({
+          isAlive: false,
+          activeJobsCount: 0
+        }),
+        getRecentPlans: async () => []
+      } as unknown as ServerManager;
+
+      const provider = new SidebarProvider(mockServerManager);
+      const items = await provider.getChildren();
+
+      const openDashboardItem = items.find(item => item.label === 'Open Dashboard');
+      const openInBrowserItem = items.find(item => item.label === 'Open in Browser');
+
+      assert.ok(openDashboardItem, 'Open Dashboard should still appear when server offline');
+      assert.ok(openInBrowserItem, 'Open in Browser should still appear when server offline');
+    });
+  });
+
+  describe('Command execution', () => {
+    let originalEnsure: typeof ServerManager.prototype.ensureServerRunning;
+
+    beforeEach(async () => {
+      originalEnsure = ServerManager.prototype.ensureServerRunning;
+      vscodeMock.env.lastOpenedUri = undefined;
+      vscodeMock.window.lastErrorMessage = undefined;
+
+      const subscriptions: vscode.Disposable[] = [];
+      const context = {
+        subscriptions,
+        extensionUri: vscode.Uri.file('/mock/path')
+      } as unknown as vscode.ExtensionContext;
+
+      await activate(context);
+    });
+
+    afterEach(() => {
+      ServerManager.prototype.ensureServerRunning = originalEnsure;
+      deactivate();
+    });
+
+    it('should open external browser with baseUrl on openInBrowser', async () => {
+      ServerManager.prototype.ensureServerRunning = async () => ({
+        port: 4567,
+        pid: 9999,
+        baseUrl: 'http://localhost:4567',
+        scheme: 'http',
+        heartbeat: new Date()
+      });
+
+      await vscode.commands.executeCommand(COMMANDS.openInBrowser);
+
+      const openedUri = vscodeMock.env.lastOpenedUri as { fsPath?: string } | undefined;
+      assert.ok(openedUri, 'External URI must be opened');
+      assert.strictEqual(openedUri?.toString(), 'http://localhost:4567');
+      assert.strictEqual(vscodeMock.window.lastErrorMessage, undefined);
+    });
+
+    it('should show error message if ensureServerRunning throws', async () => {
+      ServerManager.prototype.ensureServerRunning = async () => {
+        throw new Error('Server failed to start');
+      };
+
+      await vscode.commands.executeCommand(COMMANDS.openInBrowser);
+
+      assert.strictEqual(vscodeMock.env.lastOpenedUri, undefined);
+      assert.ok(vscodeMock.window.lastErrorMessage?.includes('Failed to open Tendril in browser'));
+      assert.ok(vscodeMock.window.lastErrorMessage?.includes('Server failed to start'));
+    });
+  });
+});

--- a/extensions/vscode/src/test/vscodeMock.ts
+++ b/extensions/vscode/src/test/vscodeMock.ts
@@ -63,6 +63,11 @@ export class MockThemeColor {
 }
 
 export class MockTreeItem {
+  public iconPath?: unknown;
+  public command?: { command: string; title: string; arguments?: unknown[] };
+  public description?: string | boolean;
+  public tooltip?: string | unknown;
+
   constructor(
     public label: string,
     public collapsibleState: TreeItemCollapsibleState = TreeItemCollapsibleState.None
@@ -95,6 +100,8 @@ export class MockEventEmitter<T = unknown> {
   }
 }
 
+const registeredCommands = new Map<string, (...args: unknown[]) => unknown>();
+
 export const vscodeMock = {
   Uri: MockUri,
   Position: MockPosition,
@@ -106,7 +113,16 @@ export const vscodeMock = {
   ThemeColor: MockThemeColor,
   TreeItem: MockTreeItem,
   EventEmitter: MockEventEmitter,
+  env: {
+    lastOpenedUri: undefined as unknown,
+    openExternal: async (uri: unknown) => {
+      vscodeMock.env.lastOpenedUri = uri;
+      return true;
+    },
+    asExternalUri: async (uri: unknown) => uri
+  },
   window: {
+    lastErrorMessage: undefined as string | undefined,
     createOutputChannel: (name: string) => ({
       name,
       append: () => {},
@@ -123,7 +139,10 @@ export const vscodeMock = {
     }),
     showInformationMessage: async () => undefined,
     showWarningMessage: async () => undefined,
-    showErrorMessage: async () => undefined,
+    showErrorMessage: async (msg: string) => {
+      vscodeMock.window.lastErrorMessage = msg;
+      return undefined;
+    },
     showTextDocument: async () => ({}),
     activeColorTheme: { kind: ColorThemeKind.Dark },
     onDidChangeActiveColorTheme: () => ({ dispose: () => {} }),
@@ -138,7 +157,20 @@ export const vscodeMock = {
     updateWorkspaceFolders: () => true
   },
   commands: {
-    registerCommand: () => ({ dispose: () => {} }),
-    executeCommand: async () => undefined
+    registerCommand: (command: string, callback: (...args: unknown[]) => unknown) => {
+      registeredCommands.set(command, callback);
+      return {
+        dispose: () => {
+          registeredCommands.delete(command);
+        }
+      };
+    },
+    executeCommand: async (command: string, ...args: unknown[]) => {
+      const handler = registeredCommands.get(command);
+      if (handler) {
+        return await handler(...args);
+      }
+      return undefined;
+    }
   }
 };

--- a/extensions/vscode/src/views/sidebarProvider.ts
+++ b/extensions/vscode/src/views/sidebarProvider.ts
@@ -72,6 +72,14 @@ export class SidebarProvider implements vscode.TreeDataProvider<TendrilTreeItem>
     };
     items.push(openDashboardItem);
 
+    const openInBrowserItem = new TendrilTreeItem('action', 'Open in Browser');
+    openInBrowserItem.iconPath = new vscode.ThemeIcon('globe');
+    openInBrowserItem.command = {
+      command: COMMANDS.openInBrowser,
+      title: 'Open in Browser'
+    };
+    items.push(openInBrowserItem);
+
     if (health.isAlive) {
       const stopServerItem = new TendrilTreeItem('action', 'Stop Server');
       stopServerItem.iconPath = new vscode.ThemeIcon('debug-stop');


### PR DESCRIPTION
Fixes #2563

# Summary

## Changes

Added buttons and a dedicated command to open the web version of Tendril in an external browser directly from the VS Code extension. The Quick Access view title bar now hosts quick navigation buttons for opening the embedded dashboard and the external web interface, and the sidebar tree displays both action items with distinct icons.

## API Changes

- Added command `tendril.openInBrowser` (`COMMANDS.openInBrowser`) to open Tendril's web URL in the user's default browser.
- Contributed `tendril.openDashboard` and `tendril.openInBrowser` icons and menus to the `view/title` navigation group for `tendril.quickAccess`.

## Files Modified

- Extension Configuration:
  - `extensions/vscode/package.json`: Contributed command icons, title bar actions, and menu definitions.
  - `extensions/vscode/src/constants.ts`: Added `openInBrowser` command identifier to `COMMANDS`.
- Extension Implementation:
  - `extensions/vscode/src/extension.ts`: Registered `COMMANDS.openInBrowser` handler launching `vscode.env.openExternal` with the Tendril server base URL.
  - `extensions/vscode/src/views/sidebarProvider.ts`: Added `Open in Browser` tree item with `globe` icon to Quick Actions.
- Testing and Mocks:
  - `extensions/vscode/src/test/vscodeMock.ts`: Added mock `vscode.env` APIs and enhanced command dispatching.
  - `extensions/vscode/src/test/suite/sidebar.test.ts`: Added unit tests verifying tree action items, icons, command bindings, and browser launch logic.

## Manual Testing

1. Open VS Code with the Tendril extension loaded.
2. Navigate to the Tendril view container in the activity bar.
3. Observe the Quick Access view title bar: two navigation icons should appear (`$(browser)` and `$(globe)`).
4. In the Quick Access tree, observe the two action items: `Open Dashboard` and `Open in Browser`.
5. Click either the title bar globe icon or the `Open in Browser` tree item. The Tendril server should ensure it is running and open `http://localhost:<port>` in your default web browser.

---

## Commits

- dea5f888 Add button and command to open web version of Tendril in browser (Plan 00397)

---
Created using [Ivy Tendril](https://ivy.app).