### PR TITLE
[00398] Keep the Chat Count Badge Visible on Other Pages

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/ShellAgentButtonDefaultsTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/ShellAgentButtonDefaultsTests.cs
@@ -12,4 +12,16 @@ public class ShellAgentButtonDefaultsTests
         // (Cmd+Opt+A / Ctrl+Alt+A), which is exercised by ShellAgentButton.test.tsx.
         Assert.Equal("A", new ShellAgentButton().ShortcutKey);
     }
+
+    [Fact]
+    public void Badge_Default_ReturnsNull()
+    {
+        Assert.Null(new ShellAgentButton().Badge);
+    }
+
+    [Fact]
+    public void Badge_FluentExtension_SetsValue()
+    {
+        Assert.Equal("2", new ShellAgentButton().Badge("2").Badge);
+    }
 }

--- a/src/Ivy.Tendril.Test/AppShell/TendrilAppShellSidebarTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/TendrilAppShellSidebarTests.cs
@@ -41,4 +41,12 @@ public class TendrilAppShellSidebarTests
         var result = UsesSidebarList(listAppId, currentAppId);
         Assert.Equal(expected, result);
     }
+
+    [Theory]
+    [InlineData(0, null)]
+    [InlineData(1, "1")]
+    [InlineData(2, "2")]
+    [InlineData(140, "140")]
+    public void ChatRowBadge_CountsSessionsAndHidesAtZero(int sessions, string? expected)
+        => Assert.Equal(expected, ChatRowBadge(sessions));
 }

--- a/src/Ivy.Tendril.Widgets/ShellAgentButton.cs
+++ b/src/Ivy.Tendril.Widgets/ShellAgentButton.cs
@@ -19,6 +19,13 @@ public record ShellAgentButton : WidgetBase<ShellAgentButton>
     /// <summary>Highlights the row while an agent session is the visible pane.</summary>
     [Prop] public bool IsActive { get; init; }
 
+    /// <summary>
+    ///     The count pill on the collapsed rail, already formatted ("3"), or null for no pill. Fed by
+    ///     the shell rather than derived from <see cref="Items"/>, which is only published while the
+    ///     chat page or a terminal pane is on screen (issue #2556).
+    /// </summary>
+    [Prop] public string? Badge { get; init; }
+
     [Prop] public List<ShellSectionItemDto>? Items { get; init; }
 
     [Prop] public string? SelectedId { get; init; }
@@ -42,6 +49,9 @@ public static class ShellAgentButtonExtensions
 
     public static ShellAgentButton IsActive(this ShellAgentButton w, bool isActive) =>
         w with { IsActive = isActive };
+
+    public static ShellAgentButton Badge(this ShellAgentButton w, string? badge) =>
+        w with { Badge = badge };
 
     public static ShellAgentButton OnOpen(this ShellAgentButton w, Action handler) =>
         w with { OnOpen = new(_ => { handler(); return ValueTask.CompletedTask; }) };

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx
@@ -289,4 +289,69 @@ describe("ShellAgentButton", () => {
       expect(eventHandler).toHaveBeenCalledWith("OnOpen", "agent", []);
     });
   });
+
+  describe("count pill", () => {
+    it("renders badge on rail without list (issue #2556 regression guard)", () => {
+      const eventHandler = vi.fn();
+      const { container } = render(
+        <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+          <ShellAgentButton
+            id="agent"
+            label="Chat"
+            badge="2"
+            events={["OnOpen"]}
+            eventHandler={eventHandler}
+          />
+        </ShellContext.Provider>,
+      );
+
+      const row = screen.getByRole("button", { name: "Chat" });
+      expect(container.querySelector(".tsh-agent-count")).toHaveTextContent("2");
+      expect(container.querySelector(".tsh-agent-pin")).toBeNull();
+      expect(row).toHaveAttribute("data-has-list", "false");
+
+      fireEvent.click(row);
+      expect(eventHandler).toHaveBeenCalledWith("OnOpen", "agent", []);
+    });
+
+    it("caps badge at 99", () => {
+      const { container } = render(
+        <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+          <ShellAgentButton id="agent" label="Chat" badge="140" events={[]} eventHandler={vi.fn()} />
+        </ShellContext.Provider>,
+      );
+
+      expect(container.querySelector(".tsh-agent-count")).toHaveTextContent("99");
+    });
+
+    it("hides pill when badge is zero", () => {
+      const { container } = render(
+        <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+          <ShellAgentButton id="agent" label="Chat" badge="0" events={[]} eventHandler={vi.fn()} />
+        </ShellContext.Provider>,
+      );
+
+      expect(container.querySelector(".tsh-agent-count")).toBeNull();
+    });
+
+    it("hides pill when badge is absent and no items", () => {
+      const { container } = render(
+        <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+          <ShellAgentButton id="agent" label="Chat" events={[]} eventHandler={vi.fn()} />
+        </ShellContext.Provider>,
+      );
+
+      expect(container.querySelector(".tsh-agent-count")).toBeNull();
+    });
+
+    it("hides pill when sidebar is expanded (recommended answer to question)", () => {
+      const { container } = render(
+        <ShellContext.Provider value={{ collapsed: false, toggle: () => {} }}>
+          <ShellAgentButton id="agent" label="Chat" badge="2" events={[]} eventHandler={vi.fn()} />
+        </ShellContext.Provider>,
+      );
+
+      expect(container.querySelector(".tsh-agent-count")).toBeNull();
+    });
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.tsx
@@ -17,6 +17,7 @@ interface ShellAgentButtonProps extends ShellWidgetProps {
   icon?: string;
   shortcutKey?: string;
   isActive?: boolean;
+  badge?: string;
   items?: ShellSectionItemDto[];
   selectedId?: string;
   listTitle?: string;
@@ -37,6 +38,7 @@ export const ShellAgentButton: React.FC<ShellAgentButtonProps> = ({
   icon,
   shortcutKey = NEW_CHAT_SHORTCUT_KEY,
   isActive = false,
+  badge,
   items,
   selectedId,
   listTitle,
@@ -86,7 +88,11 @@ export const ShellAgentButton: React.FC<ShellAgentButtonProps> = ({
 
   const hintKeys = modAltKeys(shortcutKey);
   const hasList = collapsed && !!items?.length;
-  const count = items && items.length > 99 ? "99" : String(items?.length ?? 0);
+  // The pill is the host's badge when it sends one, else the floated list's length. Reading it from
+  // the badge is what keeps the count on screen once the chats list is no longer published (#2556).
+  const rawCount = badge ?? String(items?.length ?? 0);
+  const count = rawCount.length > 2 ? "99" : rawCount;
+  const showCount = collapsed && rawCount !== "" && rawCount !== "0";
 
   const renderButton = (trigger?: RailFlyoutTrigger) => (
     <button
@@ -118,7 +124,7 @@ export const ShellAgentButton: React.FC<ShellAgentButtonProps> = ({
           <Kbd keys={hintKeys} variant="bare" className="tsh-kbd" />
         </span>
       </span>
-      {trigger && (
+      {showCount && (
         <Badge numeric className="tsh-nav-badge tsh-agent-count">
           {count}
         </Badge>

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -281,6 +281,14 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         return result;
     }
 
+    /// <summary>
+    ///     The Chat row's count pill: the number of chat sessions, or null when there are none. The
+    ///     rail's chats flyout is only published while the chat page or a terminal pane is showing, so
+    ///     the count cannot be derived from it (issue #2556). The client caps the digits.
+    /// </summary>
+    internal static string? ChatRowBadge(int sessionCount) =>
+        sessionCount > 0 ? sessionCount.ToString() : null;
+
     public override object Build()
     {
         // All hooks must be at the top level of Build()
@@ -992,6 +1000,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             .IsActive(chatIsActive)
             .Label("Chat")
             .Icon(Icons.MessageCircle.ToString())
+            .Badge(ChatRowBadge(chatService.GetSessions().Count))
             .OnOpen(OpenChat)
             .OnNewChat(StartNewChat);
         if (list is { CollapsedMenu: true })


### PR DESCRIPTION
Fixes #2556

# Summary

## Changes

Added Badge property to ShellAgentButton widget to display the chat count pill independently of the flyout list. The badge is now fed by TendrilAppShell on every render using the total chat session count, keeping the count visible on all pages instead of only when the chat page is active. Implemented recommended options: count all sessions and show badge on rail only.

## API Changes

**ShellAgentButton widget (C# + TSX):**
- Added `Badge` property (string?, nullable) - the formatted count pill text or null for no badge
- Added `Badge(string?)` fluent extension method

**TendrilAppShell:**
- Added `ChatRowBadge(int sessionCount)` internal static method - returns session count as string or null when zero

## Files Modified

**Core implementation:**
- `src/Ivy.Tendril.Widgets/ShellAgentButton.cs` - Badge property and extension
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.tsx` - Updated pill rendering logic
- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs` - ChatRowBadge helper and badge feed

**Tests:**
- `src/Ivy.Tendril.Test/AppShell/TendrilAppShellSidebarTests.cs` - ChatRowBadge tests
- `src/Ivy.Tendril.Test/AppShell/ShellAgentButtonDefaultsTests.cs` - Badge property defaults
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx` - Frontend pill tests

## Manual Testing

1. Run the app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Collapse the sidebar to rail mode (click the collapse button)
3. Open Chat and create at least 2 chat sessions
4. Observe the "2" badge on the Chat icon in the rail
5. Navigate to Plans, Jobs, Inbox, or any other page
6. **Expected:** The "2" badge remains visible on the Chat icon across all pages
7. Delete or complete chats until none remain - badge should disappear
8. Create a new chat - badge should show "1" immediately

The fix prevents the issue reported in #2556 where the badge disappeared when navigating away from the chat view.

---

## Commits
- d82dd4dd Add tests for chat count badge visibility
- 181529f6 Feed chat count badge from shell on every render
- 6254fd7d Add Badge property to ShellAgentButton and update widget rendering

---
Created using [Ivy Tendril](https://ivy.app).
