### PR TITLE
[00401] Fix Chat Tools Stuck in Running State With No Output

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
@@ -197,4 +197,98 @@ public class AntigravityEventParserTests
         Assert.Equal(2, failedResult.ExitCode);
         Assert.False(failedResult.IsSuccess);
     }
+
+    [Fact]
+    public void ParseLine_ToolActiveFollowedByDone_YieldsCallThenResult()
+    {
+        var parser = new AntigravityEventParser();
+        var activeJson = "{\"event\":\"step_update\",\"step_update\":{\"step_type\":\"tool\",\"state\":\"ACTIVE\",\"step_index\":1,\"tool_name\":\"read_file\",\"tool_info\":{\"parameters\":{\"path\":\"test.txt\"}}}}";
+        var doneJson = "{\"event\":\"step_update\",\"step_update\":{\"step_type\":\"tool\",\"state\":\"DONE\",\"step_index\":1,\"tool_name\":\"read_file\",\"tool_info\":{\"output\":\"file contents\"}}}";
+
+        var activeEvents = parser.ParseLine(activeJson);
+        Assert.Single(activeEvents);
+        var toolCall = Assert.IsType<ToolCallEvent>(activeEvents[0]);
+        Assert.Equal("read_file", toolCall.ToolName);
+        var toolUseId = toolCall.ToolUseId;
+        Assert.NotNull(toolUseId);
+
+        var doneEvents = parser.ParseLine(doneJson);
+        Assert.Single(doneEvents);
+        var toolResult = Assert.IsType<ToolResultEvent>(doneEvents[0]);
+        Assert.Equal(toolUseId, toolResult.ToolUseId);
+        Assert.Equal("read_file", toolResult.ToolName);
+        Assert.Equal("file contents", toolResult.Output);
+        Assert.False(toolResult.IsError);
+    }
+
+    [Fact]
+    public void ParseLine_TwoActiveStepsWithMissingStepIndex_GetDistinctIds()
+    {
+        var parser = new AntigravityEventParser();
+        var active1 = "{\"event\":\"step_update\",\"step_update\":{\"step_type\":\"tool\",\"state\":\"ACTIVE\",\"tool_name\":\"bash\"}}";
+        var active2 = "{\"event\":\"step_update\",\"step_update\":{\"step_type\":\"tool\",\"state\":\"ACTIVE\",\"tool_name\":\"grep\"}}";
+
+        var events1 = parser.ParseLine(active1);
+        Assert.Single(events1);
+        var call1 = Assert.IsType<ToolCallEvent>(events1[0]);
+        var id1 = call1.ToolUseId;
+
+        var events2 = parser.ParseLine(active2);
+        Assert.Single(events2);
+        var call2 = Assert.IsType<ToolCallEvent>(events2[0]);
+        var id2 = call2.ToolUseId;
+
+        Assert.NotEqual(id1, id2);
+    }
+
+    [Fact]
+    public void ParseLine_TerminalStateNotDone_YieldsResultWithIsErrorTrue()
+    {
+        var parser = new AntigravityEventParser();
+        var activeJson = "{\"event\":\"step_update\",\"step_update\":{\"step_type\":\"tool\",\"state\":\"ACTIVE\",\"step_index\":5,\"tool_name\":\"write_file\"}}";
+        var cancelledJson = "{\"event\":\"step_update\",\"step_update\":{\"step_type\":\"tool\",\"state\":\"CANCELLED\",\"step_index\":5,\"tool_name\":\"write_file\"}}";
+
+        parser.ParseLine(activeJson);
+        var events = parser.ParseLine(cancelledJson);
+
+        Assert.Single(events);
+        var result = Assert.IsType<ToolResultEvent>(events[0]);
+        Assert.True(result.IsError);
+        Assert.Contains("CANCELLED", result.Output);
+    }
+
+    [Fact]
+    public void ParseLine_DoneWithNoPrecedingActive_YieldsBothCallAndResult()
+    {
+        var parser = new AntigravityEventParser();
+        var doneJson = "{\"event\":\"step_update\",\"step_update\":{\"step_type\":\"tool\",\"state\":\"DONE\",\"step_index\":3,\"tool_name\":\"find_by_name\",\"tool_info\":{\"output\":\"found 5 files\"}}}";
+
+        var events = parser.ParseLine(doneJson);
+
+        Assert.Equal(2, events.Count);
+
+        var toolCall = Assert.IsType<ToolCallEvent>(events[0]);
+        Assert.Equal("find_by_name", toolCall.ToolName);
+        var toolUseId = toolCall.ToolUseId;
+
+        var toolResult = Assert.IsType<ToolResultEvent>(events[1]);
+        Assert.Equal(toolUseId, toolResult.ToolUseId);
+        Assert.Equal("find_by_name", toolResult.ToolName);
+        Assert.Equal("found 5 files", toolResult.Output);
+        Assert.False(toolResult.IsError);
+    }
+
+    [Fact]
+    public void ParseLine_StepIndexAsJsonString_ParsesWithoutThrowing()
+    {
+        var parser = new AntigravityEventParser();
+        var json = "{\"event\":\"step_update\",\"step_update\":{\"step_type\":\"tool\",\"state\":\"ACTIVE\",\"step_index\":\"42\",\"tool_name\":\"test_tool\"}}";
+
+        var events = parser.ParseLine(json);
+
+        Assert.Single(events);
+        var toolCall = Assert.IsType<ToolCallEvent>(events[0]);
+        Assert.Equal("test_tool", toolCall.ToolName);
+        Assert.NotNull(toolCall.ToolUseId);
+    }
 }

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
@@ -186,7 +186,7 @@ public sealed class AntigravityEventParser : IEventParser
                 var resultEvent = new ToolResultEvent
                 {
                     Kind = AgentEventKind.ToolResult,
-                    ToolUseId = toolUseId,
+                    ToolUseId = toolUseId!,
                     ToolName = toolName,
                     Output = output,
                     IsError = isError,
@@ -200,7 +200,7 @@ public sealed class AntigravityEventParser : IEventParser
                         new ToolCallEvent
                         {
                             Kind = AgentEventKind.ToolCall,
-                            ToolUseId = toolUseId,
+                            ToolUseId = toolUseId!,
                             ToolName = toolName,
                             InputJson = paramsJson,
                             Description = description,

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
 
 namespace Ivy.Tendril.Agents.Providers.Antigravity;
 
@@ -12,6 +13,8 @@ public sealed class AntigravityEventParser : IEventParser
     private static readonly IReadOnlyList<AgentEvent> Empty = Array.Empty<AgentEvent>();
     private const string StderrPrefix = "[stderr] ";
     private string? _currentModel;
+    private readonly Dictionary<string, string> _stepIdMap = new(); // step_index -> unique tool_use_id
+    private int _nextToolId;
 
     public IReadOnlyList<AgentEvent> ParseLine(string rawLine)
     {
@@ -100,13 +103,18 @@ public sealed class AntigravityEventParser : IEventParser
         }];
     }
 
-    private static IReadOnlyList<AgentEvent> ParseStepUpdate(JsonElement root, string rawLine)
+    private IReadOnlyList<AgentEvent> ParseStepUpdate(JsonElement root, string rawLine)
     {
         if (!root.TryGetProperty("step_update", out var su)) return Empty;
 
         var stepType = su.TryGetProperty("step_type", out var st) ? st.GetString() : null;
         var state = su.TryGetProperty("state", out var s) ? s.GetString() : null;
-        var stepIndex = su.TryGetProperty("step_index", out var idx) ? idx.GetInt32().ToString() : "0";
+
+        // Use TryGetInt32Defensive to handle both numeric and string step_index values
+        var stepIndexNum = su.TryGetProperty("step_index", out var idx)
+            ? idx.TryGetInt32Defensive()
+            : null;
+        var stepIndexKey = stepIndexNum?.ToString() ?? $"unknown_{_nextToolId++}";
 
         if (stepType == "tool")
         {
@@ -128,20 +136,33 @@ public sealed class AntigravityEventParser : IEventParser
 
             if (state == "ACTIVE")
             {
+                // Allocate a unique id for this step
+                var toolUseId = $"ag-tool-{_nextToolId++}";
+                _stepIdMap[stepIndexKey] = toolUseId;
+
                 return [new ToolCallEvent
                 {
                     Kind = AgentEventKind.ToolCall,
-                    ToolUseId = stepIndex,
+                    ToolUseId = toolUseId,
                     ToolName = toolName,
                     InputJson = paramsJson,
                     Description = description,
                     RawLine = rawLine,
                 }];
             }
-            else if (state == "DONE")
+            else if (state != null && state != "ACTIVE")
             {
+                // Any terminal state (DONE, CANCELLED, FAILED, TIMEOUT, etc.) closes the step
+                // Look up the tool id, or allocate one if a terminal state arrives without ACTIVE
+                var isOrphanResult = !_stepIdMap.TryGetValue(stepIndexKey, out var toolUseId);
+                if (isOrphanResult)
+                {
+                    toolUseId = $"ag-tool-{_nextToolId++}";
+                    _stepIdMap[stepIndexKey] = toolUseId;
+                }
+
                 string? output = null;
-                bool isError = false;
+                bool isError = state != "DONE";
 
                 if (su.TryGetProperty("tool_info", out var tiDone))
                 {
@@ -156,14 +177,40 @@ public sealed class AntigravityEventParser : IEventParser
                     }
                 }
 
-                return [new ToolResultEvent
+                // If output is still null and this isn't DONE, use the state name
+                if (output == null && state != "DONE")
+                {
+                    output = $"[{state}]";
+                }
+
+                var resultEvent = new ToolResultEvent
                 {
                     Kind = AgentEventKind.ToolResult,
-                    ToolUseId = stepIndex,
+                    ToolUseId = toolUseId,
+                    ToolName = toolName,
                     Output = output,
                     IsError = isError,
                     RawLine = rawLine,
-                }];
+                };
+
+                // If this is an orphan result (no preceding ACTIVE), emit both call and result
+                if (isOrphanResult)
+                {
+                    return [
+                        new ToolCallEvent
+                        {
+                            Kind = AgentEventKind.ToolCall,
+                            ToolUseId = toolUseId,
+                            ToolName = toolName,
+                            InputJson = paramsJson,
+                            Description = description,
+                            RawLine = rawLine,
+                        },
+                        resultEvent
+                    ];
+                }
+
+                return [resultEvent];
             }
         }
         else if (stepType == "thinking")

--- a/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
@@ -857,6 +857,70 @@ public class ChatExecutionServiceTests
             }
         }
     }
+
+    [Fact]
+    public async Task CancelAsync_WithUnclosedToolCall_ReconcilesSyntheticResult()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatReconcileTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+            var execService = new ChatExecutionService(configService, chatService, agentRunner, namingService, serializer);
+
+            var sess = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            _ = execService.SendMessageAsync(sess.Id, "test reconciliation");
+            Assert.True(execService.IsGenerating(sess.Id));
+
+            // Emit a tool_call with no matching tool_result (simulates dropped result)
+            execService.EmitStreamLine(sess.Id, "{\"kind\":\"tool_call\",\"tool_use_id\":\"test-tool-1\",\"tool_name\":\"bash\",\"input\":{}}");
+
+            // Cancel execution to trigger reconciliation
+            await execService.CancelAsync(sess.Id);
+            Assert.False(execService.IsGenerating(sess.Id));
+
+            // Verify the persisted RawStream contains both the original tool_call and a synthetic tool_result
+            var persistedSession = chatService.GetSession(sess.Id);
+            Assert.NotNull(persistedSession);
+            var assistantMsg = persistedSession.Messages.Last();
+            Assert.NotNull(assistantMsg.RawStream);
+
+            // Parse the raw stream lines
+            var lines = assistantMsg.RawStream.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            var toolCallFound = false;
+            var toolResultFound = false;
+
+            foreach (var line in lines)
+            {
+                if (line.Contains("\"kind\":\"tool_call\"") && line.Contains("test-tool-1"))
+                {
+                    toolCallFound = true;
+                }
+                if (line.Contains("\"kind\":\"tool_result\"") && line.Contains("test-tool-1") && line.Contains("[Cancelled]"))
+                {
+                    toolResultFound = true;
+                }
+            }
+
+            Assert.True(toolCallFound, "Original tool_call should be in the stream");
+            Assert.True(toolResultFound, "Synthetic tool_result with [Cancelled] should be in the stream");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
 }
 
 

--- a/src/Ivy.Tendril.Test/Helpers/ToolStreamReconcilerTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/ToolStreamReconcilerTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Runtime;
+using Ivy.Tendril.Helpers;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+public sealed class ToolStreamReconcilerTests
+{
+    private readonly JsonEventSerializer _serializer = new();
+
+    [Fact]
+    public void CallWithMatchingResult_YieldsNothing()
+    {
+        var toolCall = new ToolCallEvent
+        {
+            Kind = AgentEventKind.ToolCall,
+            ToolUseId = "test-1",
+            ToolName = "read_file",
+            Timestamp = DateTimeOffset.UtcNow
+        };
+        var toolResult = new ToolResultEvent
+        {
+            Kind = AgentEventKind.ToolResult,
+            ToolUseId = "test-1",
+            Output = "file contents",
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        var lines = new List<string>
+        {
+            _serializer.Serialize(toolCall),
+            _serializer.Serialize(toolResult)
+        };
+
+        var missing = ToolStreamReconciler.BuildMissingResultLines(
+            lines,
+            _serializer,
+            "[No output]",
+            isError: true);
+
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void CallWithNoResult_YieldsOneLine()
+    {
+        var toolCall = new ToolCallEvent
+        {
+            Kind = AgentEventKind.ToolCall,
+            ToolUseId = "test-2",
+            ToolName = "write_file",
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        var lines = new List<string>
+        {
+            _serializer.Serialize(toolCall)
+        };
+
+        var missing = ToolStreamReconciler.BuildMissingResultLines(
+            lines,
+            _serializer,
+            "[No output]",
+            isError: true);
+
+        Assert.Single(missing);
+
+        using var doc = JsonDocument.Parse(missing[0]);
+        var root = doc.RootElement;
+
+        Assert.Equal("tool_result", root.GetProperty("kind").GetString());
+        Assert.Equal("test-2", root.GetProperty("tool_use_id").GetString());
+        Assert.Equal("write_file", root.GetProperty("tool_name").GetString());
+        Assert.Equal("[No output]", root.GetProperty("output").GetString());
+        Assert.True(root.GetProperty("is_error").GetBoolean());
+    }
+
+    [Fact]
+    public void TwoUnclosedCalls_YieldTwoLinesInOrder()
+    {
+        var call1 = new ToolCallEvent
+        {
+            Kind = AgentEventKind.ToolCall,
+            ToolUseId = "test-3",
+            ToolName = "tool_a",
+            Timestamp = DateTimeOffset.UtcNow
+        };
+        var call2 = new ToolCallEvent
+        {
+            Kind = AgentEventKind.ToolCall,
+            ToolUseId = "test-4",
+            ToolName = "tool_b",
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        var lines = new List<string>
+        {
+            _serializer.Serialize(call1),
+            _serializer.Serialize(call2)
+        };
+
+        var missing = ToolStreamReconciler.BuildMissingResultLines(
+            lines,
+            _serializer,
+            "[Cancelled]",
+            isError: true);
+
+        Assert.Equal(2, missing.Count);
+
+        using var doc1 = JsonDocument.Parse(missing[0]);
+        Assert.Equal("test-3", doc1.RootElement.GetProperty("tool_use_id").GetString());
+        Assert.Equal("tool_a", doc1.RootElement.GetProperty("tool_name").GetString());
+
+        using var doc2 = JsonDocument.Parse(missing[1]);
+        Assert.Equal("test-4", doc2.RootElement.GetProperty("tool_use_id").GetString());
+        Assert.Equal("tool_b", doc2.RootElement.GetProperty("tool_name").GetString());
+    }
+
+    [Fact]
+    public void Idempotent_RunningTwiceYieldsNothingOnSecondRun()
+    {
+        var toolCall = new ToolCallEvent
+        {
+            Kind = AgentEventKind.ToolCall,
+            ToolUseId = "test-5",
+            ToolName = "bash",
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        var lines = new List<string>
+        {
+            _serializer.Serialize(toolCall)
+        };
+
+        var firstRun = ToolStreamReconciler.BuildMissingResultLines(
+            lines,
+            _serializer,
+            "[No output]",
+            isError: true);
+
+        Assert.Single(firstRun);
+
+        // Add the synthetic result to the lines
+        lines.AddRange(firstRun);
+
+        var secondRun = ToolStreamReconciler.BuildMissingResultLines(
+            lines,
+            _serializer,
+            "[No output]",
+            isError: true);
+
+        Assert.Empty(secondRun);
+    }
+
+    [Fact]
+    public void MalformedAndNonToolLines_AreIgnored()
+    {
+        var toolCall = new ToolCallEvent
+        {
+            Kind = AgentEventKind.ToolCall,
+            ToolUseId = "test-6",
+            ToolName = "grep",
+            Timestamp = DateTimeOffset.UtcNow
+        };
+        var textEvent = new TextEvent
+        {
+            Kind = AgentEventKind.Text,
+            Text = "Some text",
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        var lines = new List<string>
+        {
+            "not json at all",
+            _serializer.Serialize(toolCall),
+            "{ malformed json",
+            _serializer.Serialize(textEvent),
+            ""
+        };
+
+        var missing = ToolStreamReconciler.BuildMissingResultLines(
+            lines,
+            _serializer,
+            "[No output]",
+            isError: true);
+
+        Assert.Single(missing);
+
+        using var doc = JsonDocument.Parse(missing[0]);
+        Assert.Equal("test-6", doc.RootElement.GetProperty("tool_use_id").GetString());
+    }
+
+    [Fact]
+    public void EmptyInput_YieldsNothing()
+    {
+        var missing = ToolStreamReconciler.BuildMissingResultLines(
+            Array.Empty<string>(),
+            _serializer,
+            "[No output]",
+            isError: true);
+
+        Assert.Empty(missing);
+    }
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.test.ts
@@ -95,4 +95,20 @@ describe("parseEventWireStream", () => {
       expect(events[0].text).toBe("Valid assistant message");
     }
   });
+
+  it("creates orphan tool-use presentation for unmatched tool_result", () => {
+    const stream =
+      '{"kind":"tool_result","timestamp":"T","tool_use_id":"orphan-1","tool_name":"grep","output":"found matches","is_error":false}';
+
+    const events = parseEventWireStream(stream);
+    expect(events).toHaveLength(1);
+    const toolEvent = events.find((e) => e.kind === "tool-use");
+    expect(toolEvent).toBeDefined();
+    if (toolEvent?.kind === "tool-use") {
+      expect(toolEvent.tool.toolUseId).toBe("orphan-1");
+      expect(toolEvent.tool.name).toBe("grep");
+      expect(toolEvent.tool.result).toBe("found matches");
+      expect(toolEvent.tool.isError).toBe(false);
+    }
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.ts
@@ -79,6 +79,16 @@ export function presentEventWires(events: EventWire[]): PresentationEvent[] {
         if (existing) {
           existing.result = evt.output ?? "";
           existing.isError = evt.is_error;
+        } else {
+          // Unmatched result - create a standalone presentation so the output is visible
+          const orphanTool: ToolUsePresentation = {
+            toolUseId: evt.tool_use_id,
+            name: evt.tool_name ?? "(unknown tool)",
+            result: evt.output ?? "",
+            isError: evt.is_error,
+          };
+          toolMap.set(evt.tool_use_id, orphanTool);
+          out.push({ kind: "tool-use", tool: orphanTool });
         }
         break;
       }

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.ts
@@ -84,6 +84,7 @@ export function presentEventWires(events: EventWire[]): PresentationEvent[] {
           const orphanTool: ToolUsePresentation = {
             toolUseId: evt.tool_use_id,
             name: evt.tool_name ?? "(unknown tool)",
+            input: {},
             result: evt.output ?? "",
             isError: evt.is_error,
           };

--- a/src/Ivy.Tendril/Helpers/ToolStreamReconciler.cs
+++ b/src/Ivy.Tendril/Helpers/ToolStreamReconciler.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Ivy.Tendril.Agents.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+/// Scans persisted agent event wire lines and synthesizes missing tool_result events for any
+/// tool_call that lacks a matching result. Idempotent: running over already-reconciled lines
+/// returns nothing.
+/// </summary>
+internal static class ToolStreamReconciler
+{
+    /// <summary>
+    /// Builds one synthetic tool_result wire line per tool_call id that has no matching result.
+    /// </summary>
+    /// <param name="rawLines">The wire lines from the agent stream.</param>
+    /// <param name="serializer">The event serializer used to produce wire format.</param>
+    /// <param name="output">The output text to put in synthetic results.</param>
+    /// <param name="isError">Whether to mark synthetic results as errors.</param>
+    /// <param name="logger">Optional logger to record warnings when synthetic results are created.</param>
+    /// <returns>A list of synthetic tool_result wire lines, in first-appearance order of the unclosed calls.</returns>
+    public static IReadOnlyList<string> BuildMissingResultLines(
+        IReadOnlyList<string> rawLines,
+        IEventSerializer serializer,
+        string output,
+        bool isError,
+        ILogger? logger = null)
+    {
+        if (rawLines == null || rawLines.Count == 0)
+            return Array.Empty<string>();
+
+        var toolCalls = new Dictionary<string, string>(StringComparer.Ordinal); // tool_use_id -> tool_name
+        var toolResults = new HashSet<string>(StringComparer.Ordinal); // tool_use_id
+
+        foreach (var line in rawLines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(line);
+                var root = doc.RootElement;
+
+                if (!root.TryGetProperty("kind", out var kindProp))
+                    continue;
+
+                var kind = kindProp.GetString();
+                if (kind == "tool_call")
+                {
+                    if (root.TryGetProperty("tool_use_id", out var idProp))
+                    {
+                        var toolUseId = idProp.GetString();
+                        if (!string.IsNullOrEmpty(toolUseId))
+                        {
+                            var toolName = root.TryGetProperty("tool_name", out var nameProp)
+                                ? nameProp.GetString() ?? "unknown"
+                                : "unknown";
+                            toolCalls[toolUseId] = toolName;
+                        }
+                    }
+                }
+                else if (kind == "tool_result")
+                {
+                    if (root.TryGetProperty("tool_use_id", out var idProp))
+                    {
+                        var toolUseId = idProp.GetString();
+                        if (!string.IsNullOrEmpty(toolUseId))
+                        {
+                            toolResults.Add(toolUseId);
+                        }
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // Malformed lines are ignored
+            }
+        }
+
+        var missing = toolCalls.Where(kv => !toolResults.Contains(kv.Key)).ToList();
+        if (missing.Count == 0)
+            return Array.Empty<string>();
+
+        var syntheticLines = new List<string>(missing.Count);
+        foreach (var (toolUseId, toolName) in missing)
+        {
+            logger?.LogWarning(
+                "Tool call {ToolName} (id: {ToolUseId}) had no result — synthesizing one.",
+                toolName,
+                toolUseId);
+
+            var syntheticResult = new ToolResultEvent
+            {
+                Kind = AgentEventKind.ToolResult,
+                Timestamp = DateTimeOffset.UtcNow,
+                ToolUseId = toolUseId,
+                ToolName = toolName,
+                Output = output,
+                IsError = isError
+            };
+
+            var wireJson = serializer.Serialize(syntheticResult);
+            if (!string.IsNullOrEmpty(wireJson))
+            {
+                syntheticLines.Add(wireJson);
+            }
+        }
+
+        return syntheticLines;
+    }
+}

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -511,7 +511,6 @@ public sealed class ChatExecutionService : IChatExecutionService
         var executionTask = Task.Run(async () =>
         {
             string? lastTextEvent = null;
-            var openToolCalls = new HashSet<string>();
 
             try
             {
@@ -538,22 +537,8 @@ public sealed class ChatExecutionService : IChatExecutionService
                 {
                     try
                     {
-                        if (evt is ToolCallEvent toolCall && !string.IsNullOrEmpty(toolCall.ToolUseId))
+                        if (evt is ToolResultEvent toolResult)
                         {
-                            lock (activeExec.Lock)
-                            {
-                                openToolCalls.Add(toolCall.ToolUseId);
-                            }
-                        }
-                        else if (evt is ToolResultEvent toolResult)
-                        {
-                            if (!string.IsNullOrEmpty(toolResult.ToolUseId))
-                            {
-                                lock (activeExec.Lock)
-                                {
-                                    openToolCalls.Remove(toolResult.ToolUseId);
-                                }
-                            }
                             if (!string.IsNullOrWhiteSpace(toolResult.Output))
                             {
                                 TryTrackSpawnedJob(sessionId, toolResult.Output);
@@ -615,6 +600,21 @@ public sealed class ChatExecutionService : IChatExecutionService
                 lock (activeExec.Lock)
                 {
                     collectedText = lastTextEvent ?? activeExec.LastText;
+
+                    // Reconcile any unclosed tool calls
+                    var missingResults = ToolStreamReconciler.BuildMissingResultLines(
+                        activeExec.RawLines,
+                        _serializer,
+                        "[No output received]",
+                        isError: true,
+                        _logger);
+
+                    foreach (var syntheticLine in missingResults)
+                    {
+                        activeExec.RawLines.Add(syntheticLine);
+                        StreamLineEmitted?.Invoke(sessionId, syntheticLine);
+                    }
+
                     if (activeExec.RawLines.Count > 0)
                         fullRawStream = string.Join("\n", activeExec.RawLines);
                 }
@@ -642,24 +642,19 @@ public sealed class ChatExecutionService : IChatExecutionService
                 {
                     collectedText = lastTextEvent ?? activeExec.LastText;
 
-                    foreach (var toolUseId in openToolCalls)
+                    // Reconcile any unclosed tool calls
+                    var missingResults = ToolStreamReconciler.BuildMissingResultLines(
+                        activeExec.RawLines,
+                        _serializer,
+                        "[Cancelled]",
+                        isError: true,
+                        _logger);
+
+                    foreach (var syntheticLine in missingResults)
                     {
-                        var cancelToolResult = new ToolResultEvent
-                        {
-                            Kind = AgentEventKind.ToolResult,
-                            Timestamp = DateTimeOffset.UtcNow,
-                            ToolUseId = toolUseId,
-                            Output = "[Cancelled]",
-                            IsError = true
-                        };
-                        var cancelToolJson = _serializer.Serialize(cancelToolResult);
-                        if (!string.IsNullOrEmpty(cancelToolJson))
-                        {
-                            activeExec.RawLines.Add(cancelToolJson);
-                            StreamLineEmitted?.Invoke(sessionId, cancelToolJson);
-                        }
+                        activeExec.RawLines.Add(syntheticLine);
+                        StreamLineEmitted?.Invoke(sessionId, syntheticLine);
                     }
-                    openToolCalls.Clear();
 
                     var cancelEvt = new TextEvent
                     {
@@ -696,24 +691,19 @@ public sealed class ChatExecutionService : IChatExecutionService
                 {
                     collectedText = lastTextEvent ?? activeExec.LastText;
 
-                    foreach (var toolUseId in openToolCalls)
+                    // Reconcile any unclosed tool calls
+                    var missingResults = ToolStreamReconciler.BuildMissingResultLines(
+                        activeExec.RawLines,
+                        _serializer,
+                        $"[Error: {ex.Message}]",
+                        isError: true,
+                        _logger);
+
+                    foreach (var syntheticLine in missingResults)
                     {
-                        var errToolResult = new ToolResultEvent
-                        {
-                            Kind = AgentEventKind.ToolResult,
-                            Timestamp = DateTimeOffset.UtcNow,
-                            ToolUseId = toolUseId,
-                            Output = $"[Error: {ex.Message}]",
-                            IsError = true
-                        };
-                        var errToolJson = _serializer.Serialize(errToolResult);
-                        if (!string.IsNullOrEmpty(errToolJson))
-                        {
-                            activeExec.RawLines.Add(errToolJson);
-                            StreamLineEmitted?.Invoke(sessionId, errToolJson);
-                        }
+                        activeExec.RawLines.Add(syntheticLine);
+                        StreamLineEmitted?.Invoke(sessionId, syntheticLine);
                     }
-                    openToolCalls.Clear();
 
                     var errorEvt = new ErrorEvent
                     {
@@ -984,6 +974,21 @@ public sealed class ChatExecutionService : IChatExecutionService
             lock (exec.Lock)
             {
                 collectedText = exec.LastText;
+
+                // Reconcile any unclosed tool calls
+                var missingResults = ToolStreamReconciler.BuildMissingResultLines(
+                    exec.RawLines,
+                    _serializer,
+                    "[Cancelled]",
+                    isError: true,
+                    _logger);
+
+                foreach (var syntheticLine in missingResults)
+                {
+                    exec.RawLines.Add(syntheticLine);
+                    StreamLineEmitted?.Invoke(sessionId, syntheticLine);
+                }
+
                 if (exec.RawLines.Count > 0)
                     fullRawStream = string.Join("\n", exec.RawLines);
             }


### PR DESCRIPTION
Fixes #2498

# Summary

## Changes

Fixed tool cards stuck in running state by adding reconciliation for unclosed tool calls across all completion paths (success, cancel, error). The backend now synthesizes missing tool_result events, AntigravityEventParser handles all terminal states correctly, and the frontend renders orphan results instead of silently dropping them.

## API Changes

**New internal class:**
- `ToolStreamReconciler` - Static helper that scans persisted wire lines and synthesizes missing tool_result events for any tool_call lacking a matching result

**Modified behavior:**
- `ChatExecutionService` - Now reconciles unclosed tool calls before persisting streams on all completion paths (success, cancel, error) and in FlushExecution
- `AntigravityEventParser` - Now uses instance-state tool id generation, handles non-DONE terminal states, and sets ToolName on results
- Frontend `parse-events.ts` - Now renders orphan tool_result events as standalone cards instead of silently dropping them

## Files Modified

**Backend:**
- `src/Ivy.Tendril/Helpers/ToolStreamReconciler.cs` (new)
- `src/Ivy.Tendril/Services/ChatExecutionService.cs`
- `src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs`

**Frontend:**
- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.ts`

**Tests:**
- `src/Ivy.Tendril.Test/Helpers/ToolStreamReconcilerTests.cs` (new)
- `src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs`
- `src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs`
- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.test.ts`

## Manual Testing

1. Start an agent conversation in the chat app that uses tools (e.g., Antigravity provider with file operations)
2. While tools are running, cancel the execution mid-stream using the stop button
3. Observe that all tool cards show either green (completed) or red (cancelled) status dots - no gray "running" dots should remain
4. Reload the page and verify the tool cards still render correctly with no stuck spinners
5. For Antigravity runs specifically, verify that tools which fail or timeout (non-DONE states) render as error cards with the state name in output

---

**Commits:**
- 1c5241f1 Fix tool cards stuck in running state with no output
- 2b291ea0 Fix build errors: add null-forgiving operators and input property

---
Created using [Ivy Tendril](https://ivy.app).
