### PR TITLE
[00402] Show Real Job State In Chat History Instead Of A Stuck Spinner

### DIFF
--- a/src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs
@@ -70,6 +70,8 @@ class DemoApp : ViewBase
             new("00148", "ExecutePlan", "Completed", "00059", "Add dark mode toggle to vault theme settings", "Completed successfully", "Blue"),
             new("00149", "CreatePr", "Completed", "00059", "Add dark mode toggle to vault theme settings", "PR #2431 opened", "Green"),
             new("00150", "ExecutePlan", "Completed", "00060", "Persist theme choice per user", "Completed successfully", "Blue"),
+            new("00151", "ExecutePlan", "Running", "00061", "Add keyboard shortcuts to composer", "Running verifications...", "Blue"),
+            new("00152", "ExecutePlan", "Failed", "00062", "Export chat history to markdown", "DotnetBuild failed", "Blue"),
         };
 
         var full = new ChatSessionDto(
@@ -84,6 +86,8 @@ class DemoApp : ViewBase
                 new ChatMessageDto("m2", "assistant", "Plan 00059 started.", "9:02 AM", "claude", "fable-5-1", FinishedTurn),
                 new ChatMessageDto("m3", "system", "[System Event] Job 00148 (ExecutePlan) for '00059: Add dark mode toggle to vault theme settings' has finished with status: Completed (Completed successfully). Please inspect the outcome, determine whether any action is needed or if any issues occurred, and proactively guide the user on the results and next steps.", "9:11 AM"),
                 new ChatMessageDto("m4", "assistant", CompletedMessage, "9:12 AM", "claude", "fable-5-1"),
+                new ChatMessageDto("m5", "system", "[System Event] Manual approval granted and execution started for plan 'Add keyboard shortcuts to composer' (Job 00151).", "9:13 AM"),
+                new ChatMessageDto("m6", "system", "[System Event] Manual approval granted and execution started for plan 'Export chat history to markdown' (Job 00152).", "9:14 AM"),
             ],
             Effort: "max",
             SpawnedJobs: jobs);

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
@@ -116,29 +116,31 @@ export const JobsMenu: React.FC<JobsMenuProps> = ({ jobs, spawned, onReview, onO
               const isClickable = Boolean(onOpenPlan && planId);
               const content = (
                 <>
-                <div className="chat-job-status-indicator">
-                  {isRunningJob(job) && <LoaderCircle size={13} className="spin" />}
-                  {isCompletedJob(job) && <CheckCircle2 size={13} />}
-                  {isFailedJob(job) && <XCircle size={13} />}
-                  {!isRunningJob(job) && !isCompletedJob(job) && !isFailedJob(job) && <StatusDot />}
-                </div>
-                <div className="chat-job-details">
-                  <div className="chat-job-meta">
-                    <Badge color={job.typeColor}>{job.type}</Badge>
-                    <span className="chat-job-id">{job.id}</span>
-                    {job.planTitle && (
-                      <span className="chat-job-plan-title" title={job.planTitle}>
-                        {job.planTitle}
-                      </span>
+                  <div className="chat-job-status-indicator">
+                    {isRunningJob(job) && <LoaderCircle size={13} className="spin" />}
+                    {isCompletedJob(job) && <CheckCircle2 size={13} />}
+                    {isFailedJob(job) && <XCircle size={13} />}
+                    {!isRunningJob(job) && !isCompletedJob(job) && !isFailedJob(job) && (
+                      <StatusDot />
                     )}
                   </div>
-                  {job.statusMessage && (
-                    <div className="chat-job-message" title={job.statusMessage}>
-                      {job.statusMessage}
+                  <div className="chat-job-details">
+                    <div className="chat-job-meta">
+                      <Badge color={job.typeColor}>{job.type}</Badge>
+                      <span className="chat-job-id">{job.id}</span>
+                      {job.planTitle && (
+                        <span className="chat-job-plan-title" title={job.planTitle}>
+                          {job.planTitle}
+                        </span>
+                      )}
                     </div>
-                  )}
-                </div>
-                {isClickable && <ChevronRight size={14} className="chat-job-nav-icon" />}
+                    {job.statusMessage && (
+                      <div className="chat-job-message" title={job.statusMessage}>
+                        {job.statusMessage}
+                      </div>
+                    )}
+                  </div>
+                  {isClickable && <ChevronRight size={14} className="chat-job-nav-icon" />}
                 </>
               );
               if (isClickable && planId) {
@@ -273,7 +275,11 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           />
         )}
         <div className="chat-header-icons">
-          <IconButton label="New chat" shortcut={modAltKeys(NEW_CHAT_SHORTCUT_KEY)} onClick={onNewChat}>
+          <IconButton
+            label="New chat"
+            shortcut={modAltKeys(NEW_CHAT_SHORTCUT_KEY)}
+            onClick={onNewChat}
+          >
             <MessageSquarePlus size={16} />
           </IconButton>
           {editable && (

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx
@@ -21,10 +21,7 @@ import { IconButton } from "../ui/IconButton";
 import { Tooltip } from "../ui/Tooltip";
 import { NEW_CHAT_SHORTCUT_KEY, modAltKeys } from "../ui/shortcuts";
 import type { ChatJobDto } from "./types";
-
-const isRunningJob = (job: ChatJobDto) => job.status === "Running" || job.status === "Pending";
-const isCompletedJob = (job: ChatJobDto) => job.status === "Completed";
-const isFailedJob = (job: ChatJobDto) => job.status === "Failed" || job.status === "Timeout";
+import { isRunningJob, isCompletedJob, isFailedJob } from "./jobStatus";
 
 const jobsLabel = (count: number) => `${count} job${count === 1 ? "" : "s"}`;
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -27,7 +27,7 @@ import { BlockMarkdown } from "../BlockMarkdown";
 import { AgentPicker } from "./AgentPicker";
 import { AssistantTurn } from "./AssistantTurn";
 import { ChatHeader, JobsMenu } from "./ChatHeader";
-import { Badge, CountBadge } from "../ui/Badge";
+import { Badge, CountBadge, StatusDot } from "../ui/Badge";
 import { IconButton } from "../ui/IconButton";
 import {
   ComposerAttachmentCard,
@@ -36,10 +36,11 @@ import {
   parseUserMessageContent,
 } from "./attachments";
 import { formatSystemEvent } from "./systemEvents";
+import { resolveJobState } from "./jobStatus";
 import { useAttachments } from "./useAttachments";
 import { DEFAULT_TRANSCRIPTION_URL, useSpeechInput } from "./useSpeechInput";
 import { useThreadScroll } from "./useThreadScroll";
-import type { ChatMessageDto, ChatQueuedMessageDto, ChatWidgetProps } from "./types";
+import type { ChatJobDto, ChatMessageDto, ChatQueuedMessageDto, ChatWidgetProps } from "./types";
 import "./chat-widget.css";
 
 export type {
@@ -91,24 +92,42 @@ const newOptimisticMessage = (content: string, agentId: string, modelId: string)
   modelId,
 });
 
-const SystemEventRow: React.FC<{ message: ChatMessageDto; onOpenPlan?: (planId: string) => void }> = ({
-  message,
-  onOpenPlan,
-}) => {
+const SystemEventRow: React.FC<{
+  message: ChatMessageDto;
+  onOpenPlan?: (planId: string) => void;
+  jobs?: ChatJobDto[];
+  messages?: ChatMessageDto[];
+}> = ({ message, onOpenPlan, jobs = [], messages = [] }) => {
   const view = formatSystemEvent(message.content);
-  const Icon =
-    view.kind === "completed"
-      ? CheckCheck
-      : view.kind === "failed"
-        ? XCircle
-        : view.kind === "started"
-          ? LoaderCircle
-          : Sparkles;
+  const jobState = resolveJobState(view.jobId, jobs, messages);
+
+  // For "started" events, resolve the icon from the job state
+  // For other events (completed, failed, info), use the message's own kind
+  let icon: React.ReactNode;
+
+  if (view.kind === "started") {
+    if (jobState === "completed") {
+      icon = <CheckCheck size={16} className="chat-system-event-icon" />;
+    } else if (jobState === "failed") {
+      icon = <XCircle size={16} className="chat-system-event-icon" />;
+    } else if (jobState === "running") {
+      icon = <LoaderCircle size={16} className="chat-system-event-icon spin" />;
+    } else {
+      icon = <StatusDot />;
+    }
+  } else if (view.kind === "completed") {
+    icon = <CheckCheck size={16} className="chat-system-event-icon" />;
+  } else if (view.kind === "failed") {
+    icon = <XCircle size={16} className="chat-system-event-icon" />;
+  } else {
+    icon = <Sparkles size={16} className="chat-system-event-icon" />;
+  }
+
   const plan = view.plan;
 
   return (
-    <div className="chat-system-event-row" data-kind={view.kind} title={message.timestamp}>
-      <Icon size={16} className="chat-system-event-icon" />
+    <div className="chat-system-event-row" data-kind={view.kind} data-job-state={jobState} title={message.timestamp}>
+      {icon}
       <span className="chat-system-event-text">
         {view.text}
         {plan && (
@@ -728,7 +747,15 @@ export function ChatWidget({
             <>
               {displayMessages.map((msg) => {
                 if (msg.role === "system") {
-                  return <SystemEventRow key={msg.id} message={msg} onOpenPlan={openPlan} />;
+                  return (
+                    <SystemEventRow
+                      key={msg.id}
+                      message={msg}
+                      onOpenPlan={openPlan}
+                      jobs={sessionSpawnedJobs}
+                      messages={displayMessages}
+                    />
+                  );
                 }
 
                 if (msg.role === "user") {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -70,9 +70,16 @@ const needsMultipleLines = (textarea: HTMLTextAreaElement, row: HTMLElement | nu
   if (!row || row.clientWidth === 0) return false;
   const siblings = Array.from(row.children).filter((child) => child !== textarea) as HTMLElement[];
   const gap = parseFloat(getComputedStyle(row).columnGap) || 0;
-  const inlineWidth = row.clientWidth - siblings.reduce((sum, child) => sum + child.offsetWidth, 0) - gap * siblings.length;
+  const inlineWidth =
+    row.clientWidth -
+    siblings.reduce((sum, child) => sum + child.offsetWidth, 0) -
+    gap * siblings.length;
   if (inlineWidth <= 0) return false;
-  const previous = { flex: textarea.style.flex, width: textarea.style.width, height: textarea.style.height };
+  const previous = {
+    flex: textarea.style.flex,
+    width: textarea.style.width,
+    height: textarea.style.height,
+  };
   textarea.style.flex = "0 0 auto";
   textarea.style.width = `${Math.max(inlineWidth, 0)}px`;
   textarea.style.height = "auto";
@@ -83,7 +90,11 @@ const needsMultipleLines = (textarea: HTMLTextAreaElement, row: HTMLElement | nu
   return wraps;
 };
 
-const newOptimisticMessage = (content: string, agentId: string, modelId: string): ChatMessageDto => ({
+const newOptimisticMessage = (
+  content: string,
+  agentId: string,
+  modelId: string,
+): ChatMessageDto => ({
   id: `opt-${Date.now()}-${Math.random()}`,
   role: "user",
   content,
@@ -126,7 +137,12 @@ const SystemEventRow: React.FC<{
   const plan = view.plan;
 
   return (
-    <div className="chat-system-event-row" data-kind={view.kind} data-job-state={jobState} title={message.timestamp}>
+    <div
+      className="chat-system-event-row"
+      data-kind={view.kind}
+      data-job-state={jobState}
+      title={message.timestamp}
+    >
       {icon}
       <span className="chat-system-event-text">
         {view.text}
@@ -134,7 +150,11 @@ const SystemEventRow: React.FC<{
           <>
             {" "}
             {onOpenPlan ? (
-              <button type="button" className="chat-system-event-plan" onClick={() => onOpenPlan(plan.id)}>
+              <button
+                type="button"
+                className="chat-system-event-plan"
+                onClick={() => onOpenPlan(plan.id)}
+              >
                 {plan.label}
               </button>
             ) : (
@@ -174,14 +194,21 @@ export function ChatWidget({
   eventHandler,
 }: ChatWidgetProps) {
   const [promptText, setPromptText] = useState("");
-  const [queuedMessages, setQueuedMessages] = useState<ChatQueuedMessageDto[]>(queuedMessagesProp || []);
+  const [queuedMessages, setQueuedMessages] = useState<ChatQueuedMessageDto[]>(
+    queuedMessagesProp || [],
+  );
   const [collapsedQueue, setCollapsedQueue] = useState(false);
   const [editingQueuedId, setEditingQueuedId] = useState<string | null>(null);
   const [editingQueuedText, setEditingQueuedText] = useState("");
   const [pendingRenames, setPendingRenames] = useState<Record<string, string>>({});
-  const [optimisticMessages, setOptimisticMessages] = useState<Record<string, ChatMessageDto[]>>({});
+  const [optimisticMessages, setOptimisticMessages] = useState<Record<string, ChatMessageDto[]>>(
+    {},
+  );
   const [optimisticStreaming, setOptimisticStreaming] = useState<string | null>(null);
-  const [activeLightboxImage, setActiveLightboxImage] = useState<{ url: string; title: string } | null>(null);
+  const [activeLightboxImage, setActiveLightboxImage] = useState<{
+    url: string;
+    title: string;
+  } | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [multiline, setMultiline] = useState(false);
 
@@ -274,16 +301,22 @@ export function ChatWidget({
   }, [activeLightboxImage]);
 
   const sessionSpawnedJobs = activeSession?.spawnedJobs || [];
-  const otherRunningJobs = (runningJobs || []).filter((rj) => !sessionSpawnedJobs.some((sj) => sj.id === rj.id));
+  const otherRunningJobs = (runningJobs || []).filter(
+    (rj) => !sessionSpawnedJobs.some((sj) => sj.id === rj.id),
+  );
   const headerJobs = [...sessionSpawnedJobs, ...otherRunningJobs];
   const currentOptimistic = (activeSessionId && optimisticMessages[activeSessionId]) || [];
   const displayMessages = [...(activeSession?.messages || []), ...currentOptimistic];
   const hasComposerContent = promptText.trim().length > 0 || attachments.length > 0;
   const isSendDisabled =
-    isPayloadOversized || isUploading || isAnyFailed || (!promptText.trim() && !hasValidAttachments);
+    isPayloadOversized ||
+    isUploading ||
+    isAnyFailed ||
+    (!promptText.trim() && !hasValidAttachments);
   const effectiveIsStreaming =
     isStreaming ||
-    (optimisticStreaming !== null && (optimisticStreaming === activeSessionId || optimisticStreaming === "__active__"));
+    (optimisticStreaming !== null &&
+      (optimisticStreaming === activeSessionId || optimisticStreaming === "__active__"));
   const sendTitle = isPayloadOversized
     ? "Attachments exceed the 50 MB limit"
     : isUploading
@@ -299,7 +332,8 @@ export function ChatWidget({
     if (queuedMessagesProp !== undefined) {
       setQueuedMessages((prev) => {
         const optimistic = prev.filter(
-          (item) => item.id.startsWith("q-") && !queuedMessagesProp.some((p) => p.prompt === item.prompt),
+          (item) =>
+            item.id.startsWith("q-") && !queuedMessagesProp.some((p) => p.prompt === item.prompt),
         );
         return [...queuedMessagesProp, ...optimistic];
       });
@@ -405,7 +439,14 @@ export function ChatWidget({
 
   useEffect(() => {
     if (isAtBottomRef.current) scrollToBottom("auto");
-  }, [displayMessages.length, effectiveIsStreaming, streamingText, queuedMessages, scrollToBottom, isAtBottomRef]);
+  }, [
+    displayMessages.length,
+    effectiveIsStreaming,
+    streamingText,
+    queuedMessages,
+    scrollToBottom,
+    isAtBottomRef,
+  ]);
 
   // An optimistic user message is retired once its server-side copy arrives; a pin follows it over.
   useEffect(() => {
@@ -416,7 +457,9 @@ export function ChatWidget({
     if (!serverMessages || serverMessages.length === 0) return;
 
     const remaining = current.filter((opt) => {
-      const match = serverMessages.find((m) => m.role === "user" && m.content.startsWith(opt.content));
+      const match = serverMessages.find(
+        (m) => m.role === "user" && m.content.startsWith(opt.content),
+      );
       if (match) retargetPin(opt.id, match.id);
       return !match;
     });
@@ -425,7 +468,11 @@ export function ChatWidget({
     }
   }, [sessions, activeSessionId, optimisticMessages, retargetPin]);
 
-  const handleQuestionSubmit = (messageId: string, answers: Record<string, string[]>, responseText: string) => {
+  const handleQuestionSubmit = (
+    messageId: string,
+    answers: Record<string, string[]>,
+    responseText: string,
+  ) => {
     if (!activeSession) return;
     emit("OnAnswerQuestion", { sessionId: activeSession.id, messageId, answers, responseText });
   };
@@ -441,7 +488,8 @@ export function ChatWidget({
   const submitHandlerFor = (messageId: string): QuestionSubmitCallback => {
     let handler = submitHandlersRef.current.get(messageId);
     if (!handler) {
-      handler = (answers, summaryText) => handleQuestionSubmitRef.current(messageId, answers, summaryText);
+      handler = (answers, summaryText) =>
+        handleQuestionSubmitRef.current(messageId, answers, summaryText);
       submitHandlersRef.current.set(messageId, handler);
     }
     return handler;
@@ -484,14 +532,23 @@ export function ChatWidget({
         size: att.size,
         localPath: att.localPath,
         fileId: att.fileId,
-        base64Data: uploadUrl && att.uploadStatus === "finished" ? undefined : att.base64Data || undefined,
+        base64Data:
+          uploadUrl && att.uploadStatus === "finished" ? undefined : att.base64Data || undefined,
       }));
 
-    const payload = { prompt: trimmed, attachments: payloadAttachments, sessionId: activeSessionId };
+    const payload = {
+      prompt: trimmed,
+      attachments: payloadAttachments,
+      sessionId: activeSessionId,
+    };
     if (effectiveIsStreaming) {
       setQueuedMessages((prev) => [
         ...prev,
-        { id: `q-${Date.now()}-${Math.random()}`, prompt: trimmed, attachments: payloadAttachments },
+        {
+          id: `q-${Date.now()}-${Math.random()}`,
+          prompt: trimmed,
+          attachments: payloadAttachments,
+        },
       ]);
     } else {
       setOptimisticStreaming(activeSessionId || "__active__");
@@ -565,7 +622,9 @@ export function ChatWidget({
       handleDeleteQueued(queueId);
     } else {
       emit("OnUpdateQueuedMessage", [queueId, trimmed]);
-      setQueuedMessages((prev) => prev.map((q) => (q.id === queueId ? { ...q, prompt: trimmed } : q)));
+      setQueuedMessages((prev) =>
+        prev.map((q) => (q.id === queueId ? { ...q, prompt: trimmed } : q)),
+      );
     }
     setEditingQueuedId(null);
     setEditingQueuedText("");
@@ -673,8 +732,11 @@ export function ChatWidget({
     }
   };
 
-  const openPlan = events.includes("OnOpenPlan") ? (planId: string) => emit("OnOpenPlan", planId) : undefined;
-  const title = (activeSession && pendingRenames[activeSession.id]) || activeSession?.title || "New Chat";
+  const openPlan = events.includes("OnOpenPlan")
+    ? (planId: string) => emit("OnOpenPlan", planId)
+    : undefined;
+  const title =
+    (activeSession && pendingRenames[activeSession.id]) || activeSession?.title || "New Chat";
 
   return (
     <div
@@ -685,7 +747,13 @@ export function ChatWidget({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      <input ref={fileInputRef} type="file" multiple style={{ display: "none" }} onChange={handleFileSelect} />
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        style={{ display: "none" }}
+        onChange={handleFileSelect}
+      />
 
       {isDragging && (
         <div className="chat-drop-overlay" aria-hidden="true">
@@ -706,7 +774,8 @@ export function ChatWidget({
               onOpenPlan={openPlan}
               onReview={() =>
                 emit("OnSendMessage", {
-                  prompt: "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.",
+                  prompt:
+                    "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.",
                   attachments: [],
                   sessionId: activeSession.id,
                 })
@@ -733,7 +802,8 @@ export function ChatWidget({
           onReviewJobs={() =>
             activeSession &&
             emit("OnSendMessage", {
-              prompt: "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.",
+              prompt:
+                "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.",
               attachments: [],
               sessionId: activeSession.id,
             })
@@ -770,7 +840,9 @@ export function ChatWidget({
                               <MessageAttachmentChip
                                 key={idx}
                                 filePath={filePath}
-                                onOpenImage={(url, name) => setActiveLightboxImage({ url, title: name })}
+                                onOpenImage={(url, name) =>
+                                  setActiveLightboxImage({ url, title: name })
+                                }
                               />
                             ))}
                           </div>
@@ -829,7 +901,10 @@ export function ChatWidget({
                     label={collapsedQueue ? "Expand queued messages" : "Collapse queued messages"}
                     onClick={() => setCollapsedQueue(!collapsedQueue)}
                   >
-                    <ChevronDown className={`chat-queued-chevron ${collapsedQueue ? "collapsed" : ""}`} size={16} />
+                    <ChevronDown
+                      className={`chat-queued-chevron ${collapsedQueue ? "collapsed" : ""}`}
+                      size={16}
+                    />
                   </IconButton>
                 </div>
               </div>
@@ -851,7 +926,11 @@ export function ChatWidget({
                             }}
                             autoFocus
                           />
-                          <IconButton size="sm" label="Save" onClick={() => handleSaveEditQueued(q.id)}>
+                          <IconButton
+                            size="sm"
+                            label="Save"
+                            onClick={() => handleSaveEditQueued(q.id)}
+                          >
                             <Check size={14} />
                           </IconButton>
                           <IconButton
@@ -878,10 +957,18 @@ export function ChatWidget({
                             )}
                           </div>
                           <div className="chat-queued-item-actions">
-                            <IconButton size="sm" label="Send now" onClick={() => handleSendQueuedNow(q.id)}>
+                            <IconButton
+                              size="sm"
+                              label="Send now"
+                              onClick={() => handleSendQueuedNow(q.id)}
+                            >
                               <ArrowRight size={15} />
                             </IconButton>
-                            <IconButton size="sm" label="Edit message" onClick={() => handleStartEditQueued(q)}>
+                            <IconButton
+                              size="sm"
+                              label="Edit message"
+                              onClick={() => handleStartEditQueued(q)}
+                            >
                               <Pencil size={15} />
                             </IconButton>
                             <IconButton
@@ -908,8 +995,8 @@ export function ChatWidget({
             {isPayloadOversized && (
               <div className="chat-payload-warning" role="alert">
                 <span>
-                  Attachments exceed the 50 MB limit ({formatFileSize(totalAttachmentSize)} / 50 MB). Please remove or
-                  downsize files before sending.
+                  Attachments exceed the 50 MB limit ({formatFileSize(totalAttachmentSize)} / 50
+                  MB). Please remove or downsize files before sending.
                 </span>
               </div>
             )}
@@ -971,7 +1058,9 @@ export function ChatWidget({
                   supportsEffort={supportsEffort}
                   onAgentChange={(agentId) => emit("OnAgentChanged", agentId)}
                   onModelChange={(agentId, modelId) => emit("OnModelChanged", [agentId, modelId])}
-                  onEffortChange={(agentId, effortId) => emit("OnEffortChanged", [agentId, effortId])}
+                  onEffortChange={(agentId, effortId) =>
+                    emit("OnEffortChanged", [agentId, effortId])
+                  }
                   compact={embedded}
                 />
 
@@ -1003,7 +1092,11 @@ export function ChatWidget({
                         <ListPlus size={16} />
                       </IconButton>
                     )}
-                    <IconButton className="chat-stop-btn" label="Stop agent" onClick={handleCancelStream}>
+                    <IconButton
+                      className="chat-stop-btn"
+                      label="Stop agent"
+                      onClick={handleCancelStream}
+                    >
                       <Square size={12} fill="currentColor" />
                     </IconButton>
                   </>
@@ -1032,7 +1125,10 @@ export function ChatWidget({
           aria-modal="true"
           aria-label={activeLightboxImage.title || "Image preview"}
         >
-          <div className="chat-image-lightbox-backdrop" onClick={() => setActiveLightboxImage(null)} />
+          <div
+            className="chat-image-lightbox-backdrop"
+            onClick={() => setActiveLightboxImage(null)}
+          />
           <div className="chat-image-lightbox-container">
             <button
               type="button"
@@ -1048,7 +1144,9 @@ export function ChatWidget({
               className="chat-image-lightbox-img"
               onClick={(e) => e.stopPropagation()}
             />
-            {activeLightboxImage.title && <div className="chat-image-lightbox-caption">{activeLightboxImage.title}</div>}
+            {activeLightboxImage.title && (
+              <div className="chat-image-lightbox-caption">{activeLightboxImage.title}</div>
+            )}
           </div>
         </div>
       )}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -728,6 +728,14 @@ button.chat-jobs-dropdown-item:hover .chat-job-nav-icon {
   color: var(--tch-muted);
 }
 
+.chat-system-event-row[data-job-state="completed"] .chat-system-event-icon {
+  color: var(--tch-success);
+}
+
+.chat-system-event-row[data-job-state="failed"] .chat-system-event-icon {
+  color: var(--tch-danger);
+}
+
 .chat-system-event-text {
   min-width: 0;
   line-height: 1.3;

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -13,12 +13,20 @@
   --tch-faint: color-mix(in srgb, var(--foreground, #000000) 40%, transparent);
   --tch-border: var(--border, #e0e0e0);
   --tch-surface: color-mix(in srgb, var(--foreground, #000000) 4%, var(--background, #ffffff));
-  --tch-surface-hover: color-mix(in srgb, var(--foreground, #000000) 8%, var(--background, #ffffff));
+  --tch-surface-hover: color-mix(
+    in srgb,
+    var(--foreground, #000000) 8%,
+    var(--background, #ffffff)
+  );
   --tch-input-border: color-mix(in srgb, var(--foreground, #000000) 15%, transparent);
   --tch-popover: var(--popover, #ffffff);
   --tch-bubble-bg: var(--primary, #000000);
   --tch-bubble-fg: var(--primary-foreground, #ffffff);
-  --tch-bubble-chip: color-mix(in srgb, var(--primary-foreground, #ffffff) 24%, var(--primary, #000000));
+  --tch-bubble-chip: color-mix(
+    in srgb,
+    var(--primary-foreground, #ffffff) 24%,
+    var(--primary, #000000)
+  );
   --tch-cta-bg: var(--primary, #000000);
   --tch-cta-fg: var(--primary-foreground, #ffffff);
   --tch-danger: var(--destructive, #ef4444);
@@ -38,7 +46,11 @@
 .dark .chat-agent-layer,
 .dark .chat-header-host {
   --tch-surface: color-mix(in srgb, var(--foreground, #f8f8f8) 7%, var(--background, #000000));
-  --tch-surface-hover: color-mix(in srgb, var(--foreground, #f8f8f8) 11%, var(--background, #000000));
+  --tch-surface-hover: color-mix(
+    in srgb,
+    var(--foreground, #f8f8f8) 11%,
+    var(--background, #000000)
+  );
   --tch-shadow: 0 12px 30px -4px rgba(0, 0, 0, 0.6), 0 4px 12px -2px rgba(0, 0, 0, 0.4);
 }
 
@@ -910,7 +922,10 @@ button.chat-system-event-plan {
   color: var(--tch-muted);
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .pmv-code-block:hover .pmv-code-copy,

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/jobStatus.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/jobStatus.ts
@@ -2,7 +2,10 @@ import type { ChatJobDto, ChatMessageDto } from "./types";
 import { formatSystemEvent } from "./systemEvents";
 
 export const isRunningJob = (job: ChatJobDto) =>
-  job.status === "Running" || job.status === "Pending" || job.status === "Queued" || job.status === "Blocked";
+  job.status === "Running" ||
+  job.status === "Pending" ||
+  job.status === "Queued" ||
+  job.status === "Blocked";
 
 export const isCompletedJob = (job: ChatJobDto) => job.status === "Completed";
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/jobStatus.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/jobStatus.ts
@@ -1,0 +1,49 @@
+import type { ChatJobDto, ChatMessageDto } from "./types";
+import { formatSystemEvent } from "./systemEvents";
+
+export const isRunningJob = (job: ChatJobDto) =>
+  job.status === "Running" || job.status === "Pending" || job.status === "Queued" || job.status === "Blocked";
+
+export const isCompletedJob = (job: ChatJobDto) => job.status === "Completed";
+
+export const isFailedJob = (job: ChatJobDto) =>
+  job.status === "Failed" || job.status === "Timeout" || job.status === "Stopped";
+
+export type JobDisplayState = "running" | "completed" | "failed" | "unknown";
+
+/**
+ * Resolves the display state for a job by checking the live job list first, then falling back
+ * to terminal messages in the history. Returns "unknown" if the job cannot be found or has an
+ * unrecognized status.
+ */
+export function resolveJobState(
+  jobId: string | undefined,
+  jobs: ChatJobDto[],
+  messages: ChatMessageDto[],
+): JobDisplayState {
+  // No job id: unknown
+  if (!jobId) return "unknown";
+
+  // Check live jobs first
+  const job = jobs.find((j) => j.id === jobId);
+  if (job) {
+    if (isCompletedJob(job)) return "completed";
+    if (isFailedJob(job)) return "failed";
+    if (isRunningJob(job)) return "running";
+    return "unknown";
+  }
+
+  // Fall back to terminal messages in history (job may have aged out of spawnedJobs)
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role === "system") {
+      const view = formatSystemEvent(msg.content);
+      if (view.jobId === jobId && (view.kind === "completed" || view.kind === "failed")) {
+        return view.kind;
+      }
+    }
+  }
+
+  // Job id not found anywhere
+  return "unknown";
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/systemEvents.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/systemEvents.test.ts
@@ -11,6 +11,7 @@ describe("formatSystemEvent", () => {
       text: "Completed plan",
       plan: { id: "00059", label: "#59 Add dark mode toggle" },
       detail: undefined,
+      jobId: "00148",
     });
   });
 
@@ -26,14 +27,19 @@ describe("formatSystemEvent", () => {
 
   it("quotes the job's subject when it names no plan id", () => {
     const view = formatSystemEvent("[System Event] Job 7 (Custom) for 'nightly sync' has finished with status: Timeout.");
-    expect(view).toEqual({ kind: "failed", text: "Timed out Custom 'nightly sync'", detail: undefined });
+    expect(view).toEqual({
+      kind: "failed",
+      text: "Timed out Custom 'nightly sync'",
+      detail: undefined,
+      jobId: "7",
+    });
   });
 
   it("reads a manual approval as the plan starting", () => {
     const view = formatSystemEvent(
       "[System Event] Manual approval granted and execution started for plan 'Revamp auth' (Job 00151).",
     );
-    expect(view).toEqual({ kind: "started", text: "Started plan 'Revamp auth'" });
+    expect(view).toEqual({ kind: "started", text: "Started plan 'Revamp auth'", jobId: "00151" });
   });
 
   it("passes any other text through without the prefix", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/systemEvents.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/systemEvents.ts
@@ -19,8 +19,10 @@ export interface SystemEventView {
 }
 
 const PREFIX = /^\s*\[System Event\]\s*/i;
-const FINISHED = /^Job\s+(\S+)\s+\(([^)]+)\)\s+for\s+'(.+?)'\s+has finished with status:\s*(\w+)(?:\s*\((.*?)\))?/i;
-const APPROVED = /^Manual approval granted and execution started for plan '(.+?)'\s*\(Job\s+(\S+)\)/i;
+const FINISHED =
+  /^Job\s+(\S+)\s+\(([^)]+)\)\s+for\s+'(.+?)'\s+has finished with status:\s*(\w+)(?:\s*\((.*?)\))?/i;
+const APPROVED =
+  /^Manual approval granted and execution started for plan '(.+?)'\s*\(Job\s+(\S+)\)/i;
 const PLAN_INFO = /^(\d+)\s*:\s*(.+)$/;
 
 const planRef = (info: string): SystemEventPlanRef | undefined => {
@@ -66,8 +68,13 @@ export function formatSystemEvent(content: string): SystemEventView {
     const { verb, kind } = statusVerb(status);
     const plan = planRef(info);
     const text = `${verb} ${jobNoun(type)}`;
-    const detail = kind === "failed" && summary && summary.toLowerCase() !== status.toLowerCase() ? summary : undefined;
-    return plan ? { kind, text, plan, detail, jobId } : { kind, text: `${text} '${info}'`, detail, jobId };
+    const detail =
+      kind === "failed" && summary && summary.toLowerCase() !== status.toLowerCase()
+        ? summary
+        : undefined;
+    return plan
+      ? { kind, text, plan, detail, jobId }
+      : { kind, text: `${text} '${info}'`, detail, jobId };
   }
 
   const approved = APPROVED.exec(body);

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/systemEvents.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/systemEvents.ts
@@ -14,6 +14,8 @@ export interface SystemEventView {
   plan?: SystemEventPlanRef;
   /** A trailing detail, such as the failure summary. */
   detail?: string;
+  /** The job id extracted from the message, if present. */
+  jobId?: string;
 }
 
 const PREFIX = /^\s*\[System Event\]\s*/i;
@@ -60,17 +62,17 @@ export function formatSystemEvent(content: string): SystemEventView {
 
   const finished = FINISHED.exec(body);
   if (finished) {
-    const [, , type, info, status, summary] = finished;
+    const [, jobId, type, info, status, summary] = finished;
     const { verb, kind } = statusVerb(status);
     const plan = planRef(info);
     const text = `${verb} ${jobNoun(type)}`;
     const detail = kind === "failed" && summary && summary.toLowerCase() !== status.toLowerCase() ? summary : undefined;
-    return plan ? { kind, text, plan, detail } : { kind, text: `${text} '${info}'`, detail };
+    return plan ? { kind, text, plan, detail, jobId } : { kind, text: `${text} '${info}'`, detail, jobId };
   }
 
   const approved = APPROVED.exec(body);
   if (approved) {
-    return { kind: "started", text: `Started plan '${approved[1]}'` };
+    return { kind: "started", text: `Started plan '${approved[1]}'`, jobId: approved[2] };
   }
 
   return { kind: "info", text: body };


### PR DESCRIPTION
Fixes #2497

# Summary

## Changes

Fixed GitHub issue #2497 where completed jobs displayed a loading spinner in chat history instead of a completion indicator. System event rows now resolve their icon from the live job state (via spawnedJobs or terminal messages in history) rather than from static message text, showing accurate completion checkmarks, failure indicators, animated spinners for running jobs, or neutral dots for unknown states.

## API Changes

**New exports from `ChatWidget/jobStatus.ts`:**
- `isRunningJob(job: ChatJobDto): boolean` - Identifies running, pending, queued, or blocked jobs
- `isCompletedJob(job: ChatJobDto): boolean` - Identifies completed jobs
- `isFailedJob(job: ChatJobDto): boolean` - Identifies failed, timeout, or stopped jobs
- `type JobDisplayState = "running" | "completed" | "failed" | "unknown"`
- `resolveJobState(jobId: string | undefined, jobs: ChatJobDto[], messages: ChatMessageDto[]): JobDisplayState` - Resolves job state from live data or history

**Modified interface in `ChatWidget/systemEvents.ts`:**
- `SystemEventView` now includes optional `jobId?: string` field

**Enhanced `SystemEventRow` component in `ChatWidget/ChatWidget.tsx`:**
- Added optional `jobs?: ChatJobDto[]` and `messages?: ChatMessageDto[]` props
- Icon and animation now depend on resolved job state for "started" events

## Files Modified

**Frontend:**
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/jobStatus.ts` - New shared job state resolver
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/systemEvents.ts` - Added jobId to SystemEventView
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatHeader.tsx` - Imports predicates from jobStatus
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx` - Updated SystemEventRow with job state resolution
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css` - Added data-job-state color rules
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/systemEvents.test.ts` - Updated tests for jobId field

**Sample App:**
- `src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs` - Added Running and Failed job demos

## Manual Testing

1. Run the Widgets sample app: `dotnet run --project src/Ivy.Tendril.Widgets/.samples --browse --find-available-port`
2. Navigate to the ChatWidget demo
3. Observe the chat history system event rows:
   - Job 00148 (Completed): Shows green checkmark with "Completed plan" text
   - Job 00151 (Running): Shows animated spinning loader with "Started plan" text
   - Job 00152 (Failed): Shows red X with "Started plan" text
4. In the main Tendril app, start a plan execution and observe the chat history row:
   - While running: animated spinner
   - After completion: green checkmark
   - After failure: red X
5. Verify that jobs that age out of spawnedJobs but have terminal messages in history still show the correct completion/failure icon

## Commits

- Show real job state in chat history instead of stuck spinner (dc0b2339)
- Fix formatting from WidgetsFrontendCheck (9625f351)
- Update systemEvents tests for jobId field (ca8e78bf)

---
Created using [Ivy Tendril](https://ivy.app).