### PR TITLE
[00397] Break Down Dashboard Cost And Token Metrics By Coding Agent

### DIFF
--- a/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
@@ -866,6 +866,95 @@ public class DatabaseMigratorTests : IDisposable
         Assert.Equal(23, GetUserVersion());
     }
 
+    [Fact]
+    public void Migration_025_CostsAgent_AddsColumnAndBackfillsFromJobs()
+    {
+        ApplyMigrationsThrough024();
+        Assert.Equal(24, GetUserVersion());
+
+        // Insert test plans
+        using (var planCmd = _connection.CreateCommand())
+        {
+            planCmd.CommandText = """
+                INSERT INTO Plans (Id, FolderName, FolderPath, Title, State, Level, Project, Created)
+                VALUES (42, '00042-TestPlan', '/plans/00042-TestPlan', 'Test Plan', 'Completed', 'Feature', 'test-project', '2026-09-01T10:00:00Z');
+                """;
+            planCmd.ExecuteNonQuery();
+        }
+
+        // Insert jobs with Provider values
+        using (var jobCmd = _connection.CreateCommand())
+        {
+            jobCmd.CommandText = """
+                INSERT INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, CompletedAt)
+                VALUES
+                    ('job-1', 'ExecutePlan', '00042-TestPlan', 'test-project', 'Completed', 'claude', '2026-09-01T11:00:00Z'),
+                    ('job-2', 'ExpandPlan', '00042-TestPlan', 'test-project', 'Completed', 'codex', '2026-09-01T12:00:00Z');
+                """;
+            jobCmd.ExecuteNonQuery();
+        }
+
+        // Insert costs without Agent column (pre-v4)
+        using (var costCmd = _connection.CreateCommand())
+        {
+            costCmd.CommandText = """
+                INSERT INTO Costs (PlanId, Promptware, Tokens, Cost)
+                VALUES
+                    (42, 'ExecutePlan', 50000, 1.25),
+                    (42, 'ExpandPlan', 25000, 0.50);
+                """;
+            costCmd.ExecuteNonQuery();
+        }
+
+        // Apply Migration_025
+        new Migration_025_CostsAgent().Apply(_connection);
+
+        Assert.Equal(25, GetUserVersion());
+
+        // Verify Agent column exists
+        var columns = new List<string>();
+        using (var pragmaCmd = _connection.CreateCommand())
+        {
+            pragmaCmd.CommandText = "PRAGMA table_info(Costs);";
+            using var reader = pragmaCmd.ExecuteReader();
+            while (reader.Read())
+                columns.Add(reader.GetString(reader.GetOrdinal("name")));
+        }
+
+        Assert.Contains("Agent", columns);
+
+        // Verify backfill from Jobs.Provider
+        using (var selectCmd = _connection.CreateCommand())
+        {
+            selectCmd.CommandText = "SELECT Agent FROM Costs WHERE Promptware = 'ExecutePlan';";
+            Assert.Equal("claude", selectCmd.ExecuteScalar()?.ToString());
+        }
+
+        using (var selectCmd = _connection.CreateCommand())
+        {
+            selectCmd.CommandText = "SELECT Agent FROM Costs WHERE Promptware = 'ExpandPlan';";
+            Assert.Equal("codex", selectCmd.ExecuteScalar()?.ToString());
+        }
+    }
+
+    [Fact]
+    public void Migration_025_CostsAgent_IsIdempotent()
+    {
+        ApplyMigrationsThrough024();
+
+        // Simulate database that already had Agent column added
+        using (var alterCmd = _connection.CreateCommand())
+        {
+            alterCmd.CommandText = "ALTER TABLE Costs ADD COLUMN Agent TEXT;";
+            alterCmd.ExecuteNonQuery();
+        }
+
+        // Should not fail when run again
+        new Migration_025_CostsAgent().Apply(_connection);
+
+        Assert.Equal(25, GetUserVersion());
+    }
+
     private void ApplyMigrationsThrough021()
     {
         new Migration_001_InitialSchema().Apply(_connection);
@@ -889,6 +978,14 @@ public class DatabaseMigratorTests : IDisposable
         new Migration_019_JobsTokenBreakdown().Apply(_connection);
         new Migration_020_JobsExecutionProfile().Apply(_connection);
         new Migration_021_JobsEffort().Apply(_connection);
+    }
+
+    private void ApplyMigrationsThrough024()
+    {
+        ApplyMigrationsThrough021();
+        new Migration_022_CostsNullableCostAndModel().Apply(_connection);
+        new Migration_023_PlanChatSessionId().Apply(_connection);
+        new Migration_024_CostsCostSource().Apply(_connection);
     }
 
     private class FakeMigration : IMigration

--- a/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
@@ -876,8 +876,8 @@ public class DatabaseMigratorTests : IDisposable
         using (var planCmd = _connection.CreateCommand())
         {
             planCmd.CommandText = """
-                INSERT INTO Plans (Id, FolderName, FolderPath, Title, State, Level, Project, Created)
-                VALUES (42, '00042-TestPlan', '/plans/00042-TestPlan', 'Test Plan', 'Completed', 'Feature', 'test-project', '2026-09-01T10:00:00Z');
+                INSERT INTO Plans (Id, FolderName, FolderPath, Title, State, Level, Project, Created, YamlRaw)
+                VALUES (42, '00042-TestPlan', '/plans/00042-TestPlan', 'Test Plan', 'Completed', 'Feature', 'test-project', '2026-09-01T10:00:00Z', 'state: Completed\ntitle: Test Plan');
                 """;
             planCmd.ExecuteNonQuery();
         }

--- a/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
@@ -876,8 +876,8 @@ public class DatabaseMigratorTests : IDisposable
         using (var planCmd = _connection.CreateCommand())
         {
             planCmd.CommandText = """
-                INSERT INTO Plans (Id, FolderName, FolderPath, Title, State, Level, Project, Created, YamlRaw)
-                VALUES (42, '00042-TestPlan', '/plans/00042-TestPlan', 'Test Plan', 'Completed', 'Feature', 'test-project', '2026-09-01T10:00:00Z', 'state: Completed\ntitle: Test Plan');
+                INSERT INTO Plans (Id, FolderName, FolderPath, Title, State, Level, Project, Created, Updated, YamlRaw)
+                VALUES (42, '00042-TestPlan', '/plans/00042-TestPlan', 'Test Plan', 'Completed', 'Feature', 'test-project', '2026-09-01T10:00:00Z', '2026-09-01T10:00:00Z', 'state: Completed\ntitle: Test Plan');
                 """;
             planCmd.ExecuteNonQuery();
         }

--- a/src/Ivy.Tendril.Test/FakePlanReaderService.cs
+++ b/src/Ivy.Tendril.Test/FakePlanReaderService.cs
@@ -113,9 +113,11 @@ internal class FakePlanReaderService : IPlanReaderService
 
     public List<RecentMergedPrDto> RecentMergedPrsToReturn { get; set; } = [];
     public List<RecentPlanCostDto> RecentPlanCostsToReturn { get; set; } = [];
+    public List<DashboardAgentCost> AgentCostsToReturn { get; set; } = [];
 
     public List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50) => RecentMergedPrsToReturn;
     public List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) => RecentPlanCostsToReturn;
+    public List<DashboardAgentCost> GetAgentCostBreakdown(int days) => AgentCostsToReturn;
 
     public decimal GetPlanTotalCost(string folderPath)
     {

--- a/src/Ivy.Tendril.Test/FormatHelperTests.cs
+++ b/src/Ivy.Tendril.Test/FormatHelperTests.cs
@@ -96,6 +96,22 @@ public class FormatHelperTests
         Assert.Equal(expected, FormatHelper.FormatExecutionProfile(profile));
     }
 
+    [Theory]
+    [InlineData("claude", "Claude Code")]
+    [InlineData("openaiproxy", "OpenAI Proxy")]
+    [InlineData("opencode", "OpenCode")]
+    [InlineData("ivy", "Ivy Agent")]
+    [InlineData("unknown", "Unknown")]
+    [InlineData("Unknown", "Unknown")]
+    [InlineData("gemini", "Gemini")]
+    [InlineData("", "Unknown")]
+    [InlineData("   ", "Unknown")]
+    [InlineData(null, "Unknown")]
+    public void FormatAgent(string? agentId, string expected)
+    {
+        Assert.Equal(expected, FormatHelper.FormatAgent(agentId));
+    }
+
     [Fact]
     public void SourceFiles_DoNotContainUtf8Bom()
     {

--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -1698,4 +1698,134 @@ public class PlanDatabaseServiceTests : IDisposable
         Assert.NotNull(retrievedByFolder);
         Assert.Equal("session-from-jobs-table", retrievedByFolder.ChatSessionId);
     }
+
+    [Fact]
+    public void GetAgentCostBreakdown_GroupsByAgent()
+    {
+        var plan1 = CreateTestPlan(100, "Plan 1", PlanStatus.Completed);
+        var plan2 = CreateTestPlan(101, "Plan 2", PlanStatus.Completed);
+        var plan3 = CreateTestPlan(102, "Plan 3", PlanStatus.Completed);
+        _db.UpsertPlan(plan1);
+        _db.UpsertPlan(plan2);
+        _db.UpsertPlan(plan3);
+
+        _db.UpsertCosts(100, [
+            new CostEntry("ExecutePlan", 50000, 1.25m, DateTime.UtcNow, "claude-opus-5", "agent", "claude")
+        ]);
+        _db.UpsertCosts(101, [
+            new CostEntry("ExecutePlan", 25000, 0.50m, DateTime.UtcNow, "gpt-4o", "agent", "codex"),
+            new CostEntry("ExpandPlan", 15000, 0.30m, DateTime.UtcNow, "gpt-4o", "agent", "codex")
+        ]);
+        _db.UpsertCosts(102, [
+            new CostEntry("ExecutePlan", 10000, null, DateTime.UtcNow, "gemini-3.8-flash", "subscription", "gemini")
+        ]);
+
+        var results = _db.GetAgentCostBreakdown(7);
+
+        Assert.Equal(3, results.Count);
+
+        var claudeRow = results.First(r => r.Agent == "claude");
+        Assert.Equal(1.25m, claudeRow.Cost);
+        Assert.Equal(50000, claudeRow.Tokens);
+        Assert.Equal(1, claudeRow.PlanCount);
+
+        var codexRow = results.First(r => r.Agent == "codex");
+        Assert.Equal(0.80m, codexRow.Cost);
+        Assert.Equal(40000, codexRow.Tokens);
+        Assert.Equal(1, codexRow.PlanCount);
+
+        var geminiRow = results.First(r => r.Agent == "gemini");
+        Assert.Equal(0m, geminiRow.Cost); // Null cost treated as 0
+        Assert.Equal(10000, geminiRow.Tokens);
+        Assert.Equal(1, geminiRow.PlanCount);
+    }
+
+    [Fact]
+    public void GetAgentCostBreakdown_FoldsNullAndEmptyToUnknown()
+    {
+        var plan1 = CreateTestPlan(200, "Plan 1", PlanStatus.Completed);
+        var plan2 = CreateTestPlan(201, "Plan 2", PlanStatus.Completed);
+        var plan3 = CreateTestPlan(202, "Plan 3", PlanStatus.Completed);
+        _db.UpsertPlan(plan1);
+        _db.UpsertPlan(plan2);
+        _db.UpsertPlan(plan3);
+
+        _db.UpsertCosts(200, [
+            new CostEntry("ExecutePlan", 10000, 0.25m, DateTime.UtcNow, "claude-opus-5", "agent", null)
+        ]);
+        _db.UpsertCosts(201, [
+            new CostEntry("ExecutePlan", 5000, 0.10m, DateTime.UtcNow, "gpt-4o", "agent", "")
+        ]);
+        _db.UpsertCosts(202, [
+            new CostEntry("ExecutePlan", 3000, 0.05m, DateTime.UtcNow, "claude-opus-5", "agent", "claude")
+        ]);
+
+        var results = _db.GetAgentCostBreakdown(7);
+
+        Assert.Equal(2, results.Count);
+
+        var unknownRow = results.First(r => r.Agent == "Unknown");
+        Assert.Equal(0.35m, unknownRow.Cost);
+        Assert.Equal(15000, unknownRow.Tokens);
+        Assert.Equal(2, unknownRow.PlanCount);
+
+        var claudeRow = results.First(r => r.Agent == "claude");
+        Assert.Equal(0.05m, claudeRow.Cost);
+        Assert.Equal(3000, claudeRow.Tokens);
+        Assert.Equal(1, claudeRow.PlanCount);
+    }
+
+    [Fact]
+    public void GetAgentCostBreakdown_RespectsTimeWindow()
+    {
+        var oldPlan = CreateTestPlan(300, "Old Plan", PlanStatus.Completed);
+        oldPlan = oldPlan with
+        {
+            Created = DateTime.UtcNow.AddDays(-10),
+            Updated = DateTime.UtcNow.AddDays(-10)
+        };
+        var recentPlan = CreateTestPlan(301, "Recent Plan", PlanStatus.Completed);
+        _db.UpsertPlan(oldPlan);
+        _db.UpsertPlan(recentPlan);
+
+        _db.UpsertCosts(300, [
+            new CostEntry("ExecutePlan", 50000, 1.00m, DateTime.UtcNow.AddDays(-10), "claude-opus-5", "agent", "claude")
+        ]);
+        _db.UpsertCosts(301, [
+            new CostEntry("ExecutePlan", 25000, 0.50m, DateTime.UtcNow, "gpt-4o", "agent", "codex")
+        ]);
+
+        var results = _db.GetAgentCostBreakdown(7);
+
+        Assert.Single(results);
+        Assert.Equal("codex", results[0].Agent);
+    }
+
+    [Fact]
+    public void GetAgentCostBreakdown_OrdersByCostDescending()
+    {
+        var plan1 = CreateTestPlan(400, "Plan 1", PlanStatus.Completed);
+        var plan2 = CreateTestPlan(401, "Plan 2", PlanStatus.Completed);
+        var plan3 = CreateTestPlan(402, "Plan 3", PlanStatus.Completed);
+        _db.UpsertPlan(plan1);
+        _db.UpsertPlan(plan2);
+        _db.UpsertPlan(plan3);
+
+        _db.UpsertCosts(400, [
+            new CostEntry("ExecutePlan", 10000, 0.25m, DateTime.UtcNow, "claude-opus-5", "agent", "claude")
+        ]);
+        _db.UpsertCosts(401, [
+            new CostEntry("ExecutePlan", 50000, 1.00m, DateTime.UtcNow, "gpt-4o", "agent", "codex")
+        ]);
+        _db.UpsertCosts(402, [
+            new CostEntry("ExecutePlan", 25000, 0.50m, DateTime.UtcNow, "gemini-3.8-flash", "agent", "gemini")
+        ]);
+
+        var results = _db.GetAgentCostBreakdown(7);
+
+        Assert.Equal(3, results.Count);
+        Assert.Equal("codex", results[0].Agent);
+        Assert.Equal("gemini", results[1].Agent);
+        Assert.Equal("claude", results[2].Agent);
+    }
 }

--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -1778,12 +1778,26 @@ public class PlanDatabaseServiceTests : IDisposable
     [Fact]
     public void GetAgentCostBreakdown_RespectsTimeWindow()
     {
-        var oldPlan = CreateTestPlan(300, "Old Plan", PlanStatus.Completed);
-        oldPlan = oldPlan with
-        {
-            Created = DateTime.UtcNow.AddDays(-10),
-            Updated = DateTime.UtcNow.AddDays(-10)
-        };
+        var oldPlanDate = DateTime.UtcNow.AddDays(-10);
+        var oldPlanMetadata = new PlanMetadata(
+            300, "Tendril", "Feature", "Old Plan", PlanStatus.Completed,
+            new List<string> { "D:\\Repos\\Test" },
+            new List<string> { "abc123" },
+            new List<string>(),
+            new List<PlanVerificationEntry>(),
+            new List<string>(),
+            new List<string>(),
+            oldPlanDate,
+            oldPlanDate,
+            null,
+            null
+        );
+        var oldPlan = new PlanFile(
+            oldPlanMetadata,
+            "# Old Plan",
+            $"D:\\Plans\\00300-OldPlan",
+            "state: Completed\ntitle: Old Plan"
+        );
         var recentPlan = CreateTestPlan(301, "Recent Plan", PlanStatus.Completed);
         _db.UpsertPlan(oldPlan);
         _db.UpsertPlan(recentPlan);

--- a/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
@@ -121,15 +121,15 @@ public class PlanDatabaseSyncServiceTests : IDisposable
     ///     Reads the synced Costs rows straight out of SQLite. Null and 0 are the whole point here and
     ///     no aggregate on the service can tell them apart, so the rows are inspected directly.
     /// </summary>
-    private List<(string Promptware, int Tokens, decimal? Cost, string? Model, string? CostSource)> ReadCostRows(int planId)
+    private List<(string Promptware, int Tokens, decimal? Cost, string? Model, string? CostSource, string? Agent)> ReadCostRows(int planId)
     {
         using var connection = new SqliteConnection($"Data Source={_dbPath}");
         connection.Open();
         using var cmd = connection.CreateCommand();
-        cmd.CommandText = "SELECT Promptware, Tokens, Cost, Model, CostSource FROM Costs WHERE PlanId = @p ORDER BY Id";
+        cmd.CommandText = "SELECT Promptware, Tokens, Cost, Model, CostSource, Agent FROM Costs WHERE PlanId = @p ORDER BY Id";
         cmd.Parameters.AddWithValue("@p", planId);
 
-        var rows = new List<(string, int, decimal?, string?, string?)>();
+        var rows = new List<(string, int, decimal?, string?, string?, string?)>();
         using var reader = cmd.ExecuteReader();
         while (reader.Read())
             rows.Add((
@@ -137,7 +137,8 @@ public class PlanDatabaseSyncServiceTests : IDisposable
                 reader.GetInt32(1),
                 reader.IsDBNull(2) ? null : reader.GetDecimal(2),
                 reader.IsDBNull(3) ? null : reader.GetString(3),
-                reader.IsDBNull(4) ? null : reader.GetString(4)));
+                reader.IsDBNull(4) ? null : reader.GetString(4),
+                reader.IsDBNull(5) ? null : reader.GetString(5)));
         return rows;
     }
 
@@ -307,5 +308,68 @@ public class PlanDatabaseSyncServiceTests : IDisposable
 
         var syncTime = _database.GetLastSyncTime();
         Assert.True(syncTime > DateTime.MinValue);
+    }
+
+    [Fact]
+    public void PerformInitialSync_FiveColumnFile_ResolvesAgentFromJobsAndUpgradesFile()
+    {
+        CreateCostPlan("01600-CostPlan",
+            "Promptware,Tokens,Cost,Model,CostSource\nExecutePlan,50000,1.5000,gemini-3.8-flash,agent\n");
+
+        var job = new JobItem
+        {
+            Id = "job-1600",
+            Type = "ExecutePlan",
+            PlanFile = "01600-CostPlan",
+            ReportedPlanId = "1600",
+            Project = "Tendril",
+            Status = JobStatus.Completed,
+            Provider = "gemini",
+            CostSource = JobCostSources.Agent,
+            CompletedAt = DateTime.UtcNow
+        };
+        _database.UpsertJob(job);
+
+        _syncService.PerformInitialSync();
+
+        var rows = ReadCostRows(1600);
+        Assert.Single(rows);
+        Assert.Equal("gemini", rows[0].Agent);
+
+        var csvPath = Path.Combine(_planReader.PlansDirectory, "01600-CostPlan", "costs.csv");
+        var lines = File.ReadAllLines(csvPath);
+        Assert.Equal("Promptware,Tokens,Cost,Model,CostSource,Agent", lines[0]);
+        Assert.Equal("ExecutePlan,50000,1.5000,gemini-3.8-flash,agent,gemini", lines[1]);
+    }
+
+    [Fact]
+    public void PerformInitialSync_SixColumnFile_PreservesAgent()
+    {
+        CreateCostPlan("01700-CostPlan",
+            "Promptware,Tokens,Cost,Model,CostSource,Agent\nExecutePlan,50000,1.5000,claude-opus-5,agent,claude\n");
+
+        _syncService.PerformInitialSync();
+
+        var rows = ReadCostRows(1700);
+        Assert.Single(rows);
+        Assert.Equal("claude", rows[0].Agent);
+
+        var csvPath = Path.Combine(_planReader.PlansDirectory, "01700-CostPlan", "costs.csv");
+        var lines = File.ReadAllLines(csvPath);
+        Assert.Equal("Promptware,Tokens,Cost,Model,CostSource,Agent", lines[0]);
+        Assert.Equal("ExecutePlan,50000,1.5000,claude-opus-5,agent,claude", lines[1]);
+    }
+
+    [Fact]
+    public void PerformInitialSync_FiveColumnFile_NoMatchingJob_LeavesAgentNull()
+    {
+        CreateCostPlan("01800-CostPlan",
+            "Promptware,Tokens,Cost,Model,CostSource\nExecutePlan,50000,1.5000,gemini-3.8-flash,agent\n");
+
+        _syncService.PerformInitialSync();
+
+        var rows = ReadCostRows(1800);
+        Assert.Single(rows);
+        Assert.Null(rows[0].Agent);
     }
 }

--- a/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
@@ -170,8 +170,8 @@ public class PlanDatabaseSyncServiceTests : IDisposable
 
         var csvPath = Path.Combine(_planReader.PlansDirectory, "01500-CostPlan", "costs.csv");
         var lines = File.ReadAllLines(csvPath);
-        Assert.Equal("Promptware,Tokens,Cost,Model,CostSource", lines[0]);
-        Assert.Equal("ExecutePlan,50000,1.5000,gemini-3.8-flash,estimated", lines[1]);
+        Assert.Equal("Promptware,Tokens,Cost,Model,CostSource,Agent", lines[0]);
+        Assert.Equal("ExecutePlan,50000,1.5000,gemini-3.8-flash,estimated,antigravity", lines[1]);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
+++ b/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
@@ -185,6 +185,67 @@ public class KpiBreakdownSheetTests
         Assert.IsType<Callout>(avgCostPlanContent);
     }
 
+    [Fact]
+    public void KpiBreakdownSheet_MoneyMetrics_RenderAgentBreakdownWithData()
+    {
+        _fakeService.AgentCostsToReturn =
+        [
+            new DashboardAgentCost("claude", 50.00m, 50000, 3),
+            new DashboardAgentCost("codex", 25.00m, 25000, 2),
+            new DashboardAgentCost("Unknown", 10.00m, 10000, 1)
+        ];
+
+        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, _today, _fakeService);
+
+        var avgCostMonthSection = ExtractAgentSection(avgCostMonthSheet.Build());
+        var forecastSection = ExtractAgentSection(forecastSheet.Build());
+        var avgCostPlanSection = ExtractAgentSection(avgCostPlanSheet.Build());
+
+        Assert.NotNull(avgCostMonthSection);
+        Assert.StartsWith("DataTableBuilder", avgCostMonthSection.GetType().Name);
+        Assert.NotNull(forecastSection);
+        Assert.StartsWith("DataTableBuilder", forecastSection.GetType().Name);
+        Assert.NotNull(avgCostPlanSection);
+        Assert.StartsWith("DataTableBuilder", avgCostPlanSection.GetType().Name);
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_DailyPrs_DoesNotRenderAgentBreakdown()
+    {
+        _fakeService.AgentCostsToReturn =
+        [
+            new DashboardAgentCost("claude", 50.00m, 50000, 3)
+        ];
+
+        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", _stats, _activity, _prDays, _today, _fakeService);
+        var result = dailyPrsSheet.Build();
+
+        // dailyPrs should not have an agent section (only 3 children, not 4)
+        var layout = Assert.IsAssignableFrom<LayoutView>(result);
+        var stack = Assert.IsAssignableFrom<IWidget>(layout.Build());
+        Assert.Equal(3, stack.Children.Count);
+    }
+
+    [Fact]
+    public void KpiBreakdownSheet_MoneyMetrics_EmptyAgentData_ProducesCallout()
+    {
+        _fakeService.AgentCostsToReturn = [];
+
+        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, _today, _fakeService);
+
+        var avgCostMonthSection = ExtractAgentSection(avgCostMonthSheet.Build());
+        var forecastSection = ExtractAgentSection(forecastSheet.Build());
+        var avgCostPlanSection = ExtractAgentSection(avgCostPlanSheet.Build());
+
+        Assert.IsType<Callout>(avgCostMonthSection);
+        Assert.IsType<Callout>(forecastSection);
+        Assert.IsType<Callout>(avgCostPlanSection);
+    }
+
     private static object ExtractTableContent(object buildResult)
     {
         var layout = Assert.IsAssignableFrom<LayoutView>(buildResult);
@@ -192,5 +253,16 @@ public class KpiBreakdownSheetTests
         var innerLayout = Assert.IsAssignableFrom<LayoutView>(stack.Children[2]);
         var innerStack = Assert.IsAssignableFrom<IWidget>(innerLayout.Build());
         return innerStack.Children[1];
+    }
+
+    private static object ExtractAgentSection(object buildResult)
+    {
+        var layout = Assert.IsAssignableFrom<LayoutView>(buildResult);
+        var stack = Assert.IsAssignableFrom<IWidget>(layout.Build());
+        // Agent section is the 4th child (index 3) for money metrics
+        var agentLayout = Assert.IsAssignableFrom<LayoutView>(stack.Children[3]);
+        var agentStack = Assert.IsAssignableFrom<IWidget>(agentLayout.Build());
+        // Return the second child (index 1), which is either the DataTable or Callout
+        return agentStack.Children[1];
     }
 }

--- a/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
+++ b/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
@@ -225,7 +225,7 @@ public class KpiBreakdownSheetTests
         // dailyPrs should not have an agent section (only 3 children, not 4)
         var layout = Assert.IsAssignableFrom<LayoutView>(result);
         var stack = Assert.IsAssignableFrom<IWidget>(layout.Build());
-        Assert.Equal(3, stack.Children.Count);
+        Assert.Equal(3, stack.Children.Count());
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
@@ -171,12 +171,15 @@ public class KpiBreakdownSheet(
                 c.ShowSearch = false;
             });
 
+        var agentSection = BuildAgentBreakdownSection(180);
+
         return Layout.Vertical().Gap(4)
                | Callout.Info("Average Cost/Month shows retrospective monthly spend across complete historical calendar months, strictly excluding the currently in-flight month to prevent partial-month bias.", "Retrospective Spend")
                | details
                | (Layout.Vertical().Gap(2)
                   | Text.H4("Historical Monthly Breakdown")
-                  | table);
+                  | table)
+               | agentSection;
     }
 
     private object BuildForecastMonthBreakdown()
@@ -272,12 +275,15 @@ public class KpiBreakdownSheet(
                     c.ShowSearch = false;
                 });
 
+        var agentSection = BuildAgentBreakdownSection(30);
+
         return Layout.Vertical().Gap(4)
                | Callout.Info(calloutMessage, "Usage & Subsidized Analysis")
                | details
                | (Layout.Vertical().Gap(2)
                   | Text.H4("Daily Spend (Last 30 Days)")
-                  | tableContent);
+                  | tableContent)
+               | agentSection;
     }
 
     private object BuildAvgCostPlanBreakdown()
@@ -334,12 +340,15 @@ public class KpiBreakdownSheet(
                     c.ShowSearch = false;
                 });
 
+        var agentSection = BuildAgentBreakdownSection(7);
+
         return Layout.Vertical().Gap(4)
                | Callout.Info("Average Cost per Plan calculates the mean execution and promptware spend for plans created in the last 7 days that reached Completed, Failed, or Review state. Unpriced plans (e.g. subscription runs where cost is null) are excluded from the divisor so they do not artificially deflate the average.", "7-Day Rolling Average")
                | details
                | (Layout.Vertical().Gap(2)
                   | Text.H4("Plans in Rolling Window (Last 7 Days)")
-                  | tableContent);
+                  | tableContent)
+               | agentSection;
     }
 
     private static (decimal Last, decimal Previous) LastTwo(
@@ -401,5 +410,70 @@ public class KpiBreakdownSheet(
         public required string CreatedDate { get; init; }
         public required string Tokens { get; init; }
         public required string Cost { get; init; }
+    }
+
+    private sealed record AgentCostRow
+    {
+        public required string Agent { get; init; }
+        public required string Spend { get; init; }
+        public required string SpendShare { get; init; }
+        public required string Tokens { get; init; }
+        public required string TokenShare { get; init; }
+        public required string Plans { get; init; }
+    }
+
+    private object BuildAgentBreakdownSection(int days)
+    {
+        var agentCosts = planService.GetAgentCostBreakdown(days);
+
+        if (agentCosts.Count == 0)
+        {
+            return Layout.Vertical().Gap(2)
+                   | Text.H4("Spend by Coding Agent")
+                   | Callout.Info("No agent-attributed spend in this window.", "No Data");
+        }
+
+        var totalCost = agentCosts.Sum(a => a.Cost);
+        var totalTokens = agentCosts.Sum(a => a.Tokens);
+        var hasUnknown = agentCosts.Any(a => a.Agent == "Unknown");
+
+        var rows = agentCosts
+            .Select(a => new AgentCostRow
+            {
+                Agent = FormatHelper.FormatAgent(a.Agent),
+                Spend = FormatCost(a.Cost),
+                SpendShare = totalCost > 0 ? $"{(a.Cost / totalCost * 100m):0.#}%" : "N/A",
+                Tokens = FormatHelper.FormatCount(a.Tokens),
+                TokenShare = totalTokens > 0 ? $"{((decimal)a.Tokens / totalTokens * 100m):0.#}%" : "N/A",
+                Plans = a.PlanCount.ToString(CultureInfo.InvariantCulture)
+            })
+            .AsQueryable()
+            .ToDataTable(x => x.Agent)
+            .Header(x => x.Agent, "Coding Agent")
+            .Header(x => x.Spend, "Spend")
+            .Header(x => x.SpendShare, "Spend Share")
+            .Header(x => x.Tokens, "Tokens")
+            .Header(x => x.TokenShare, "Token Share")
+            .Header(x => x.Plans, "Plans")
+            .Width(Size.Full())
+            .Height(Size.Px(360))
+            .Config(c =>
+            {
+                c.AllowSorting = true;
+                c.SelectionMode = SelectionModes.None;
+                c.ShowIndexColumn = false;
+                c.ShowSearch = false;
+            });
+
+        var result = Layout.Vertical().Gap(2)
+                     | Text.H4("Spend by Coding Agent")
+                     | rows;
+
+        if (hasUnknown)
+        {
+            result = result | Callout.Info("Rows predating agent capture appear as Unknown and cannot be attributed to a specific agent.", "Partial Attribution");
+        }
+
+        return result;
     }
 }

--- a/src/Ivy.Tendril/Database/DashboardRepository.cs
+++ b/src/Ivy.Tendril/Database/DashboardRepository.cs
@@ -428,4 +428,40 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
             return results;
         }
     }
+
+    public List<DashboardAgentCost> GetAgentCostBreakdown(int days)
+    {
+        using (new ReadLockHandle(lockSlim))
+        {
+            var cutoff = DateTime.UtcNow.Date.AddDays(-(days - 1)).ToString("yyyy-MM-dd");
+            var results = new List<DashboardAgentCost>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT COALESCE(NULLIF(c.Agent, ''), 'Unknown') AS AgentGroup,
+                       SUM(c.Cost) AS TotalCost,
+                       COUNT(CASE WHEN c.Cost IS NOT NULL THEN 1 END) AS PricedRows,
+                       COALESCE(SUM(c.Tokens), 0) AS TotalTokens,
+                       COUNT(DISTINCT c.PlanId) AS PlanCount
+                FROM Costs c
+                INNER JOIN Plans p ON p.Id = c.PlanId
+                WHERE p.Created >= @cutoff
+                GROUP BY AgentGroup
+                ORDER BY TotalCost DESC
+                """;
+            cmd.Parameters.AddWithValue("@cutoff", cutoff);
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                var agent = r.GetString(0);
+                var pricedRows = r.GetInt32(2);
+                decimal cost = pricedRows > 0 && !r.IsDBNull(1)
+                    ? Convert.ToDecimal(r.GetValue(1), CultureInfo.InvariantCulture)
+                    : 0m;
+                var tokens = Convert.ToInt64(r.GetValue(3), CultureInfo.InvariantCulture);
+                var planCount = r.GetInt32(4);
+                results.Add(new DashboardAgentCost(agent, cost, tokens, planCount));
+            }
+            return results;
+        }
+    }
 }

--- a/src/Ivy.Tendril/Database/Migrations/Migration_025_CostsAgent.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_025_CostsAgent.cs
@@ -1,0 +1,64 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_025_CostsAgent : IMigration
+{
+    public int Version => 25;
+    public string Description => "Add Agent column to Costs table";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        var hasColumn = false;
+        using (var checkCmd = connection.CreateCommand())
+        {
+            checkCmd.CommandText = "PRAGMA table_info(Costs);";
+            using var reader = checkCmd.ExecuteReader();
+            while (reader.Read())
+            {
+                if (string.Equals(reader.GetString(reader.GetOrdinal("name")), "Agent", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasColumn = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasColumn)
+        {
+            using var alterCmd = connection.CreateCommand();
+            alterCmd.CommandText = "ALTER TABLE Costs ADD COLUMN Agent TEXT;";
+            alterCmd.ExecuteNonQuery();
+        }
+
+        // Populate existing Costs.Agent where possible by correlating against Jobs.Provider
+        using (var updateCmd = connection.CreateCommand())
+        {
+            updateCmd.CommandText = """
+                UPDATE Costs
+                SET Agent = (
+                    SELECT j.Provider
+                    FROM Jobs j
+                    LEFT JOIN Plans p ON p.Id = Costs.PlanId
+                    WHERE j.Provider IS NOT NULL
+                      AND j.Type = Costs.Promptware
+                      AND (
+                          j.ReportedPlanId = CAST(Costs.PlanId AS TEXT)
+                          OR (p.FolderPath IS NOT NULL AND j.PlanFile = p.FolderPath)
+                          OR (p.FolderName IS NOT NULL AND j.PlanFile = p.FolderName)
+                          OR j.PlanFile LIKE '%' || PRINTF('%05d', Costs.PlanId) || '%'
+                      )
+                    ORDER BY j.CompletedAt DESC
+                    LIMIT 1
+                )
+                WHERE Agent IS NULL;
+                """;
+            updateCmd.ExecuteNonQuery();
+        }
+
+        using var versionCmd = connection.CreateCommand();
+        versionCmd.CommandText = "PRAGMA user_version = 25;";
+        versionCmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Helpers/FormatHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FormatHelper.cs
@@ -52,4 +52,25 @@ public static class FormatHelper
         string.IsNullOrWhiteSpace(profile)
             ? null
             : char.ToUpperInvariant(profile[0]) + profile[1..];
+
+    /// <summary>
+    ///     Formats a coding agent id for display. Maps known ids to proper labels and capitalizes
+    ///     the first letter for unmapped ids. Used in agent cost breakdowns to avoid injecting
+    ///     <c>IAgentRunner</c> into views just for a display string.
+    /// </summary>
+    public static string FormatAgent(string? agentId)
+    {
+        if (string.IsNullOrWhiteSpace(agentId))
+            return "Unknown";
+
+        return agentId.ToLowerInvariant() switch
+        {
+            "claude" => "Claude Code",
+            "openaiproxy" => "OpenAI Proxy",
+            "opencode" => "OpenCode",
+            "ivy" => "Ivy Agent",
+            "unknown" => "Unknown",
+            _ => char.ToUpperInvariant(agentId[0]) + agentId[1..]
+        };
+    }
 }

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -201,18 +201,24 @@ internal static class PlanYamlHelper
     ///         and free are different facts, and the parser turns the empty field back into SQL NULL so
     ///         the aggregates skip it instead of averaging a zero in.
     ///     </para>
+    ///     <para>
+    ///         <paramref name="agent" /> is the coding agent id (e.g. <c>claude</c>, <c>codex</c>) that
+    ///         produced this cost. Written to a sixth column (costs.csv v4). Absent in files created before
+    ///         agent tracking, and retained because <c>PurgeOldJobs</c> drops the <c>Jobs</c> row long
+    ///         before the plan folder is archived.
+    ///     </para>
     /// </summary>
-    internal static void LogCostToCsv(string planFolder, string jobType, int tokens, decimal? cost, string? model = null, string? costSource = null)
+    internal static void LogCostToCsv(string planFolder, string jobType, int tokens, decimal? cost, string? model = null, string? costSource = null, string? agent = null)
     {
         if (!Directory.Exists(planFolder)) return;
 
         var csvPath = Path.Combine(planFolder, "costs.csv");
         // An existing file keeps whatever header it was created with, including the 3 column one: the
         // parser reads by position and tolerates a short header with long rows appended under it.
-        if (!File.Exists(csvPath)) FileHelper.WriteAllText(csvPath, "Promptware,Tokens,Cost,Model,CostSource\n");
+        if (!File.Exists(csvPath)) FileHelper.WriteAllText(csvPath, "Promptware,Tokens,Cost,Model,CostSource,Agent\n");
 
         var costField = cost?.ToString("F4", System.Globalization.CultureInfo.InvariantCulture) ?? "";
-        var line = $"{jobType},{tokens},{costField},{model},{costSource}\n";
+        var line = $"{jobType},{tokens},{costField},{model},{costSource},{agent}\n";
         FileHelper.AppendAllText(csvPath, line);
     }
 

--- a/src/Ivy.Tendril/Models/DashboardModels.cs
+++ b/src/Ivy.Tendril/Models/DashboardModels.cs
@@ -82,3 +82,10 @@ public record RecentPlanCostDto(
     long Tokens
 );
 
+public record DashboardAgentCost(
+    string Agent,
+    decimal Cost,
+    long Tokens,
+    int PlanCount
+);
+

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -313,7 +313,7 @@ internal class JobCompletionHandler
                     }
 
                     if (jobPlanFolder != null)
-                        PlanYamlHelper.LogCostToCsv(jobPlanFolder, jobType, usage.Tokens, usage.Cost, usage.Model, usage.CostSource);
+                        PlanYamlHelper.LogCostToCsv(jobPlanFolder, jobType, usage.Tokens, usage.Cost, usage.Model, usage.CostSource, provider);
                 }
             }
             catch (Exception ex)
@@ -414,7 +414,7 @@ internal class JobCompletionHandler
 
         var jobPlanFolder = job.TypedArgs?.PlanFolder;
         if (jobPlanFolder != null)
-            PlanYamlHelper.LogCostToCsv(jobPlanFolder, job.Type, usage.Tokens, usage.Cost, usage.Model, usage.CostSource);
+            PlanYamlHelper.LogCostToCsv(jobPlanFolder, job.Type, usage.Tokens, usage.Cost, usage.Model, usage.CostSource, job.Provider);
     }
 
     /// <summary>

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -17,12 +17,14 @@ public interface IPlanDatabaseService : IDisposable
     List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days = 30);
     List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50) => [];
     List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) => [];
+    List<DashboardAgentCost> GetAgentCostBreakdown(int days) => [];
 
     // Costs and tokens
     decimal GetPlanTotalCost(int planId);
     int GetPlanTotalTokens(int planId);
     List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null);
     string? ResolveCostSource(int planId, string promptware, string? folderPath = null, string? folderName = null) => null;
+    string? ResolveAgent(int planId, string promptware, string? folderPath = null, string? folderName = null) => null;
 
     // Recommendations
     List<Recommendation> GetRecommendations();
@@ -78,4 +80,4 @@ public interface IPlanDatabaseService : IDisposable
 ///     What the tokens went on, carried through the CSV because <c>PurgeOldJobs</c> drops the
 ///     <c>Jobs</c> row long before the plan folder is archived. Null for a pre v2 file.
 /// </param>
-public record CostEntry(string Promptware, int Tokens, decimal? Cost, DateTime? LogTimestamp, string? Model = null, string? CostSource = null);
+public record CostEntry(string Promptware, int Tokens, decimal? Cost, DateTime? LogTimestamp, string? Model = null, string? CostSource = null, string? Agent = null);

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -50,6 +50,7 @@ public interface IPlanReaderService
     List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days);
     List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50) => [];
     List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) => [];
+    List<DashboardAgentCost> GetAgentCostBreakdown(int days) => [];
     decimal GetPlanTotalCost(string folderPath);
     int GetPlanTotalTokens(string folderPath);
     List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null);

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -259,6 +259,9 @@ public class PlanDatabaseService : IPlanDatabaseService
     public List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) =>
         _dashboardRepository.GetRecentPlanCosts(days);
 
+    public List<DashboardAgentCost> GetAgentCostBreakdown(int days) =>
+        _dashboardRepository.GetAgentCostBreakdown(days);
+
     public List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days = 30)
     {
         using (new ReadLockHandle(_lock))
@@ -354,6 +357,39 @@ public class PlanDatabaseService : IPlanDatabaseService
             var costsResult = costsCmd.ExecuteScalar();
             if (costsResult is string costSource && !string.IsNullOrWhiteSpace(costSource))
                 return costSource;
+
+            return null;
+        }
+    }
+
+    public string? ResolveAgent(int planId, string promptware, string? folderPath = null, string? folderName = null)
+    {
+        using (new ReadLockHandle(_lock))
+        {
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT j.Provider
+                FROM Jobs j
+                WHERE j.Provider IS NOT NULL
+                  AND j.Type = @promptware
+                  AND (
+                      j.ReportedPlanId = @planIdText
+                      OR (@folderPath IS NOT NULL AND j.PlanFile = @folderPath)
+                      OR (@folderName IS NOT NULL AND j.PlanFile = @folderName)
+                      OR j.PlanFile LIKE '%' || @planIdPadded || '%'
+                  )
+                ORDER BY j.CompletedAt DESC
+                LIMIT 1;
+                """;
+            cmd.Parameters.AddWithValue("@promptware", promptware);
+            cmd.Parameters.AddWithValue("@planIdText", planId.ToString(CultureInfo.InvariantCulture));
+            cmd.Parameters.AddWithValue("@folderPath", (object?)folderPath ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@folderName", (object?)folderName ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@planIdPadded", planId.ToString("D5", CultureInfo.InvariantCulture));
+
+            var result = cmd.ExecuteScalar();
+            if (result is string agent && !string.IsNullOrWhiteSpace(agent))
+                return agent;
 
             return null;
         }
@@ -614,8 +650,8 @@ public class PlanDatabaseService : IPlanDatabaseService
 
             using var insertCmd = _connection.CreateCommand();
             insertCmd.CommandText = """
-                                    INSERT INTO Costs (PlanId, Promptware, Tokens, Cost, Model, LogTimestamp, CostSource)
-                                    VALUES (@planId, @promptware, @tokens, @cost, @model, @logTimestamp, @costSource)
+                                    INSERT INTO Costs (PlanId, Promptware, Tokens, Cost, Model, LogTimestamp, CostSource, Agent)
+                                    VALUES (@planId, @promptware, @tokens, @cost, @model, @logTimestamp, @costSource, @agent)
                                     """;
             insertCmd.Parameters.AddWithValue("@planId", planId);
             insertCmd.Parameters.AddWithValue("@promptware", string.Empty);
@@ -624,6 +660,7 @@ public class PlanDatabaseService : IPlanDatabaseService
             insertCmd.Parameters.AddWithValue("@model", DBNull.Value);
             insertCmd.Parameters.AddWithValue("@logTimestamp", DBNull.Value);
             insertCmd.Parameters.AddWithValue("@costSource", DBNull.Value);
+            insertCmd.Parameters.AddWithValue("@agent", DBNull.Value);
 
             foreach (var cost in costs)
             {
@@ -638,6 +675,7 @@ public class PlanDatabaseService : IPlanDatabaseService
                     ? cost.LogTimestamp.Value.ToString("O", CultureInfo.InvariantCulture)
                     : DBNull.Value;
                 insertCmd.Parameters["@costSource"].Value = (object?)cost.CostSource ?? DBNull.Value;
+                insertCmd.Parameters["@agent"].Value = (object?)cost.Agent ?? DBNull.Value;
                 insertCmd.ExecuteNonQuery();
             }
         }

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
@@ -221,6 +221,21 @@ public class PlanDatabaseSyncService : IDisposable
                         needsFileUpgrade = true;
                 }
 
+                // Sixth column since costs.csv v4; files written before it have three to five.
+                var agent = parts.Length > 5 && !string.IsNullOrWhiteSpace(parts[5]) ? parts[5].Trim() : null;
+
+                if (agent == null)
+                {
+                    agent = _database.ResolveAgent(
+                        plan.Id,
+                        promptware,
+                        plan.FolderPath,
+                        Path.GetFileName(plan.FolderPath));
+
+                    if (agent != null || parts.Length < 6)
+                        needsFileUpgrade = true;
+                }
+
                 DateTime? timestamp = null;
                 if (logsByPromptware.TryGetValue(promptware, out var queue) && queue.Count > 0)
                 {
@@ -228,7 +243,7 @@ public class PlanDatabaseSyncService : IDisposable
                     timestamp = ExtractCompletedTimestamp(logEntry.Path);
                 }
 
-                costs.Add(new CostEntry(promptware, tokens, cost, timestamp, model, costSource));
+                costs.Add(new CostEntry(promptware, tokens, cost, timestamp, model, costSource, agent));
             }
 
             _database.UpsertCosts(plan.Id, costs);
@@ -249,11 +264,11 @@ public class PlanDatabaseSyncService : IDisposable
         try
         {
             var sb = new StringBuilder();
-            sb.Append("Promptware,Tokens,Cost,Model,CostSource\n");
+            sb.Append("Promptware,Tokens,Cost,Model,CostSource,Agent\n");
             foreach (var cost in costs)
             {
                 var costField = cost.Cost?.ToString("F4", CultureInfo.InvariantCulture) ?? "";
-                sb.Append($"{cost.Promptware},{cost.Tokens},{costField},{cost.Model ?? ""},{cost.CostSource ?? ""}\n");
+                sb.Append($"{cost.Promptware},{cost.Tokens},{costField},{cost.Model ?? ""},{cost.CostSource ?? ""},{cost.Agent ?? ""}\n");
             }
             FileHelper.WriteAllText(costsPath, sb.ToString());
         }

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -663,6 +663,16 @@ public class PlanReaderService(
         return [];
     }
 
+    public List<DashboardAgentCost> GetAgentCostBreakdown(int days)
+    {
+        if (_useDatabaseForReads && _database != null)
+        {
+            return _database.GetAgentCostBreakdown(days);
+        }
+
+        return [];
+    }
+
     /// <summary>
     ///     Calculates the total cost for a plan. Delegates to database when available,
     ///     otherwise parses costs.csv with a short cache to reduce file I/O.


### PR DESCRIPTION
Fixes #2534

# Summary

## Changes

Added agent breakdown to dashboard cost metrics. When clicking avgCostMonth, forecastMonth, or avgCostPlan KPI tiles, the breakdown sheet now displays a "Spend by Coding Agent" section showing cost and token distribution across coding agents (Claude Code, OpenAI Proxy, Codex, etc.). Historical costs with no recorded agent appear as "Unknown".

## API Changes

- `DashboardAgentCost(string Agent, decimal Cost, long Tokens, int PlanCount)` - New model for agent cost aggregation
- `IPlanDatabaseService.GetAgentCostBreakdown(int days)` - New repository method returning agent cost breakdown for a time window
- `CostEntry` - Added `Agent` parameter (costs.csv v4)
- `PlanYamlHelper.LogCostToCsv` - Added `agent` parameter
- `FormatHelper.FormatAgent(string?)` - Maps agent ids to display labels
- Migration 025 - Adds `Agent` column to `Costs` table with backfill from `Jobs.Provider`

## Files Modified

**Database/Migrations:**
- `Migration_025_CostsAgent.cs` - New migration for Agent column

**Models:**
- `DashboardModels.cs` - Added DashboardAgentCost record
- `IPlanDatabaseService.cs` - Extended CostEntry with Agent, added GetAgentCostBreakdown
- `IPlanReaderService.cs` - Added GetAgentCostBreakdown

**Services:**
- `PlanDatabaseService.cs` - Added ResolveAgent method, updated UpsertCosts for Agent column
- `PlanReaderService.cs` - Delegated GetAgentCostBreakdown
- `PlanDatabaseSyncService.cs` - Updated to read/write costs.csv v4 (6 columns)
- `JobCompletionHandler.cs` - Pass job.Provider to LogCostToCsv

**Repository:**
- `DashboardRepository.cs` - Added GetAgentCostBreakdown with Unknown folding

**Helpers:**
- `PlanYamlHelper.cs` - Updated LogCostToCsv for v4 format
- `FormatHelper.cs` - Added FormatAgent

**Views:**
- `KpiBreakdownSheet.cs` - Added BuildAgentBreakdownSection and AgentCostRow

**Tests:**
- `FakePlanReaderService.cs` - Added AgentCostsToReturn property
- `KpiBreakdownSheetTests.cs` - Added agent section rendering tests
- `DatabaseMigratorTests.cs` - Added Migration_025 tests
- `FormatHelperTests.cs` - Added FormatAgent tests
- `PlanDatabaseServiceTests.cs` - Added GetAgentCostBreakdown tests
- `PlanDatabaseSyncServiceTests.cs` - Added costs.csv v4 sync tests

## Manual Testing

1. Launch the Tendril app
2. Navigate to the Dashboard view
3. Click on any of the three money KPI tiles (Avg Cost/Month, Forecast This Month, or Avg Cost/Plan)
4. Scroll down in the breakdown sheet to the "Spend by Coding Agent" section
5. Verify the table shows agents with their spend, spend share, tokens, token share, and plan count
6. Verify agents are ordered by cost descending
7. If any "Unknown" rows exist, verify the callout explains that rows predating agent capture cannot be attributed
8. Verify clicking the Daily PRs tile does NOT show an agent breakdown (it's not a money metric)

---

## Commits

- ee591691 Add Updated column to Plans INSERT
- 2a09b2b3 Fix test failures
- cf1e014d Fix test compilation errors
- e7e22068 Add tests for agent cost breakdown
- 9e3c5ae3 Add agent breakdown to dashboard cost metrics

---
Created using [Ivy Tendril](https://ivy.app).
