### PR TITLE
[00399] Support Agent Communication and Command Execution in VS Code Extension

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -67,6 +67,48 @@
       {
         "command": "tendril.restartServer",
         "title": "Tendril: Restart Server"
+      },
+      {
+        "command": "tendril.createPlan",
+        "title": "Tendril: Create Plan"
+      },
+      {
+        "command": "tendril.executePlan",
+        "title": "Tendril: Execute Plan"
+      },
+      {
+        "command": "tendril.checkJobStatus",
+        "title": "Tendril: Check Job Status"
+      },
+      {
+        "command": "tendril.retryPlan",
+        "title": "Tendril: Retry Plan"
+      }
+    ],
+    "chatParticipants": [
+      {
+        "id": "tendril.chatParticipant",
+        "name": "tendril",
+        "description": "Interact with Tendril agents, execute commands, and manage plans",
+        "isDefault": true,
+        "commands": [
+          {
+            "name": "plan",
+            "description": "Create a new plan for a task or feature"
+          },
+          {
+            "name": "run",
+            "description": "Execute a plan"
+          },
+          {
+            "name": "status",
+            "description": "Check status of active or recent jobs"
+          },
+          {
+            "name": "retry",
+            "description": "Retry an executed plan with reviewer feedback"
+          }
+        ]
       }
     ],
     "menus": {

--- a/extensions/vscode/src/bridge/bridgeHandler.ts
+++ b/extensions/vscode/src/bridge/bridgeHandler.ts
@@ -1,12 +1,15 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import {
+  ExecuteCommandMessage,
   OpenDiffMessage,
   OpenFileMessage,
   OpenWorktreeMessage,
+  StartJobMessage,
   validateBridgeMessage,
   WebToHostMessage
 } from './bridgeProtocol';
+import { IJobRunner } from '../jobs/jobRunner';
 
 export interface BridgeHost {
   openTextDocument(path: string): Thenable<vscode.TextDocument>;
@@ -21,6 +24,7 @@ export interface BridgeHost {
     ...workspaceFoldersToAdd: { uri: vscode.Uri; name?: string }[]
   ): boolean;
   executeCommand<T>(command: string, ...rest: unknown[]): Thenable<T>;
+  startJob?(message: StartJobMessage): Promise<unknown>;
 }
 
 export const defaultBridgeHost: BridgeHost = {
@@ -34,25 +38,56 @@ export const defaultBridgeHost: BridgeHost = {
 };
 
 export class BridgeHandler {
-  constructor(private readonly host: BridgeHost = defaultBridgeHost) {}
+  constructor(
+    private readonly host: BridgeHost = defaultBridgeHost,
+    private readonly jobRunner?: IJobRunner
+  ) {}
 
-  public async handleRawMessage(rawMessage: unknown): Promise<void> {
+  public async handleRawMessage(rawMessage: unknown): Promise<unknown> {
     const message = validateBridgeMessage(rawMessage);
-    await this.handleMessage(message);
+    return await this.handleMessage(message);
   }
 
-  public async handleMessage(message: WebToHostMessage): Promise<void> {
+  public async handleMessage(message: WebToHostMessage): Promise<unknown> {
     switch (message.type) {
       case 'openFile':
         await this.handleOpenFile(message);
-        break;
+        return undefined;
       case 'openWorktree':
         await this.handleOpenWorktree(message);
-        break;
+        return undefined;
       case 'openDiff':
         await this.handleOpenDiff(message);
-        break;
+        return undefined;
+      case 'executeCommand':
+        return await this.handleExecuteCommand(message);
+      case 'startJob':
+        return await this.handleStartJob(message);
     }
+  }
+
+  private async handleExecuteCommand(msg: ExecuteCommandMessage): Promise<unknown> {
+    const args = msg.args ?? [];
+    return await this.host.executeCommand(msg.command, ...args);
+  }
+
+  private async handleStartJob(msg: StartJobMessage): Promise<unknown> {
+    if (this.host.startJob) {
+      return await this.host.startJob(msg);
+    }
+    if (this.jobRunner) {
+      switch (msg.jobType) {
+        case 'CreatePlan':
+          return await this.jobRunner.startCreatePlan(msg.description!, msg.project);
+        case 'ExecutePlan':
+          return await this.jobRunner.startExecutePlan(msg.planId!);
+        case 'RetryPlan':
+          return await this.jobRunner.startRetryPlan(msg.planId!, msg.changeRequest!);
+        case 'UpdatePlan':
+          return await this.jobRunner.startUpdatePlan(msg.planId!, msg.description ?? '');
+      }
+    }
+    throw new Error('Host does not support startJob');
   }
 
   private async handleOpenFile(msg: OpenFileMessage): Promise<void> {

--- a/extensions/vscode/src/bridge/bridgeProtocol.ts
+++ b/extensions/vscode/src/bridge/bridgeProtocol.ts
@@ -17,17 +17,42 @@ export interface OpenDiffMessage {
   title?: string;
 }
 
+export interface ExecuteCommandMessage {
+  type: 'executeCommand';
+  command: string;
+  args?: unknown[];
+}
+
+export interface StartJobMessage {
+  type: 'startJob';
+  jobType: 'CreatePlan' | 'ExecutePlan' | 'RetryPlan' | 'UpdatePlan';
+  planId?: string;
+  description?: string;
+  project?: string;
+  changeRequest?: string;
+}
+
 export type WebToHostMessage =
   | OpenFileMessage
   | OpenWorktreeMessage
-  | OpenDiffMessage;
+  | OpenDiffMessage
+  | ExecuteCommandMessage
+  | StartJobMessage;
 
 export interface ThemeSyncMessage {
   type: 'themeChanged';
   theme: 'dark' | 'light' | 'hc';
 }
 
-export type HostToWebMessage = ThemeSyncMessage;
+export interface JobStatusUpdateMessage {
+  type: 'jobStatus';
+  jobId: string;
+  status: string;
+  message?: string;
+  planId?: string;
+}
+
+export type HostToWebMessage = ThemeSyncMessage | JobStatusUpdateMessage;
 
 export function validateBridgeMessage(raw: unknown): WebToHostMessage {
   if (!raw || typeof raw !== 'object') {
@@ -74,6 +99,50 @@ export function validateBridgeMessage(raw: unknown): WebToHostMessage {
         leftPath: obj.leftPath,
         rightPath: obj.rightPath,
         title: typeof obj.title === 'string' && obj.title.trim().length > 0 ? obj.title : undefined
+      };
+    }
+
+    case 'executeCommand': {
+      if (typeof obj.command !== 'string' || obj.command.trim().length === 0) {
+        throw new Error('executeCommand message requires a non-empty string "command"');
+      }
+      if (obj.args !== undefined && !Array.isArray(obj.args)) {
+        throw new Error('executeCommand message "args" must be an array if provided');
+      }
+      return {
+        type: 'executeCommand',
+        command: obj.command,
+        args: obj.args as unknown[] | undefined
+      };
+    }
+
+    case 'startJob': {
+      const validJobTypes = ['CreatePlan', 'ExecutePlan', 'RetryPlan', 'UpdatePlan'];
+      if (typeof obj.jobType !== 'string' || !validJobTypes.includes(obj.jobType)) {
+        throw new Error(`startJob message requires a valid "jobType" (${validJobTypes.join(', ')})`);
+      }
+      if (obj.jobType === 'CreatePlan') {
+        if (typeof obj.description !== 'string' || obj.description.trim().length === 0) {
+          throw new Error('startJob CreatePlan requires a non-empty string "description"');
+        }
+      }
+      if (obj.jobType === 'ExecutePlan' || obj.jobType === 'RetryPlan' || obj.jobType === 'UpdatePlan') {
+        if (typeof obj.planId !== 'string' || obj.planId.trim().length === 0) {
+          throw new Error(`startJob ${obj.jobType} requires a non-empty string "planId"`);
+        }
+      }
+      if (obj.jobType === 'RetryPlan') {
+        if (typeof obj.changeRequest !== 'string' || obj.changeRequest.trim().length === 0) {
+          throw new Error('startJob RetryPlan requires a non-empty string "changeRequest"');
+        }
+      }
+      return {
+        type: 'startJob',
+        jobType: obj.jobType as 'CreatePlan' | 'ExecutePlan' | 'RetryPlan' | 'UpdatePlan',
+        planId: typeof obj.planId === 'string' ? obj.planId : undefined,
+        description: typeof obj.description === 'string' ? obj.description : undefined,
+        project: typeof obj.project === 'string' ? obj.project : undefined,
+        changeRequest: typeof obj.changeRequest === 'string' ? obj.changeRequest : undefined
       };
     }
 

--- a/extensions/vscode/src/chat/chatParticipant.ts
+++ b/extensions/vscode/src/chat/chatParticipant.ts
@@ -1,0 +1,190 @@
+import * as vscode from 'vscode';
+import { IJobRunner } from '../jobs/jobRunner';
+import { ServerManager } from '../server/serverManager';
+
+export const CHAT_PARTICIPANT_ID = 'tendril.chatParticipant';
+
+export async function handleChatRequest(
+  request: vscode.ChatRequest,
+  response: vscode.ChatResponseStream,
+  jobRunner: IJobRunner,
+  serverManager: ServerManager,
+  _token?: vscode.CancellationToken
+): Promise<void> {
+  const prompt = (request.prompt || '').trim();
+
+  switch (request.command) {
+    case 'plan': {
+      if (!prompt) {
+        response.markdown(
+          'Please provide a description for the plan, for example: `@tendril /plan Add dark mode support`.'
+        );
+        return;
+      }
+
+      response.progress('Ensuring Tendril server is running...');
+      await serverManager.ensureServerRunning();
+
+      response.progress('Determining project...');
+      const projects = await jobRunner.listProjects();
+      let project = projects.length > 0 ? projects[0] : 'default';
+
+      const wsFolders = vscode.workspace.workspaceFolders;
+      if (wsFolders && wsFolders.length > 0) {
+        const wsName = wsFolders[0].name.toLowerCase();
+        const matched = projects.find(p => p.toLowerCase() === wsName);
+        if (matched) {
+          project = matched;
+        }
+      }
+
+      response.progress(`Starting CreatePlan job for project "${project}"...`);
+      const res = await jobRunner.startCreatePlan(prompt, project);
+
+      const jobHeader = res.jobId
+        ? `Started **CreatePlan** job: \`${res.jobId}\``
+        : 'Started **CreatePlan** job.';
+
+      response.markdown(
+        `${jobHeader}\n\n` +
+          `- **Project:** ${project}\n` +
+          `- **Description:** ${prompt}\n\n` +
+          (res.jobId ? `Use \`@tendril /status ${res.jobId}\` to monitor progress.` : '')
+      );
+      break;
+    }
+
+    case 'run': {
+      if (!prompt) {
+        response.markdown(
+          'Please specify a plan ID to run, for example: `@tendril /run 00399`.'
+        );
+        return;
+      }
+
+      const planId = prompt.split(/\s+/)[0];
+      response.progress(`Starting ExecutePlan job for plan ${planId}...`);
+      await serverManager.ensureServerRunning();
+      const res = await jobRunner.startExecutePlan(planId);
+
+      const jobHeader = res.jobId
+        ? `Started **ExecutePlan** job for Plan \`${planId}\` (Job ID: \`${res.jobId}\`).`
+        : `Started **ExecutePlan** job for Plan \`${planId}\`.`;
+
+      response.markdown(
+        `${jobHeader}\n\n` +
+          (res.jobId ? `Use \`@tendril /status ${res.jobId}\` to monitor execution.` : '')
+      );
+      break;
+    }
+
+    case 'status': {
+      await serverManager.ensureServerRunning();
+
+      if (prompt) {
+        const jobId = prompt.split(/\s+/)[0];
+        response.progress(`Checking status for job ${jobId}...`);
+        const status = await jobRunner.getJobStatus(jobId);
+        response.markdown(
+          `### Job \`${status.id}\`\n\n` +
+            `- **Status:** ${status.status}\n` +
+            `- **Message:** ${status.message || 'No status message'}`
+        );
+      } else {
+        response.progress('Fetching active jobs...');
+        const jobs = await jobRunner.listJobs();
+        if (jobs.length === 0) {
+          response.markdown('No active jobs found.');
+          return;
+        }
+
+        let md =
+          '### Active Jobs\n\n' +
+          '| Job ID | Type | Plan | Status | Message |\n' +
+          '| --- | --- | --- | --- | --- |\n';
+
+        for (const j of jobs) {
+          md += `| ${j.id} | ${j.type} | ${j.planId || '-'} | ${j.status} | ${j.message || '-'} |\n`;
+        }
+
+        response.markdown(md);
+      }
+      break;
+    }
+
+    case 'retry': {
+      const match = prompt.match(/^([^\s]+)\s+(.+)$/s);
+      if (!match) {
+        response.markdown(
+          'Please specify both a plan ID and feedback, for example: `@tendril /retry 00399 Fix failing tests`.'
+        );
+        return;
+      }
+
+      const planId = match[1];
+      const feedback = match[2];
+
+      response.progress(`Starting RetryPlan job for plan ${planId}...`);
+      await serverManager.ensureServerRunning();
+      const res = await jobRunner.startRetryPlan(planId, feedback);
+
+      const jobHeader = res.jobId
+        ? `Started **RetryPlan** job for Plan \`${planId}\` (Job ID: \`${res.jobId}\`).`
+        : `Started **RetryPlan** job for Plan \`${planId}\`.`;
+
+      response.markdown(
+        `${jobHeader}\n\n` +
+          `- **Feedback:** ${feedback}\n\n` +
+          (res.jobId ? `Use \`@tendril /status ${res.jobId}\` to monitor execution.` : '')
+      );
+      break;
+    }
+
+    default: {
+      response.markdown(
+        'Hello! I am **Tendril**, your autonomous agent planning and execution assistant.\n\n' +
+          'Here are the commands you can run:\n' +
+          '- `@tendril /plan <description>`: Create a new implementation plan\n' +
+          '- `@tendril /run <planId>`: Execute an approved plan in an isolated worktree\n' +
+          '- `@tendril /status [jobId]`: Check the status of active or specific jobs\n' +
+          '- `@tendril /retry <planId> <feedback>`: Retry an executed plan with reviewer feedback\n\n' +
+          'How can I help you today?'
+      );
+      break;
+    }
+  }
+}
+
+export function registerChatParticipant(
+  context: vscode.ExtensionContext,
+  jobRunner: IJobRunner,
+  serverManager: ServerManager
+): vscode.Disposable {
+  if (typeof vscode.chat?.createChatParticipant !== 'function') {
+    return { dispose: () => {} };
+  }
+
+  const handler: vscode.ChatRequestHandler = async (
+    request: vscode.ChatRequest,
+    _chatContext: vscode.ChatContext,
+    response: vscode.ChatResponseStream,
+    token: vscode.CancellationToken
+  ) => {
+    try {
+      await handleChatRequest(request, response, jobRunner, serverManager, token);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      response.markdown(`An error occurred while processing your request: ${msg}`);
+    }
+  };
+
+  const participant = vscode.chat.createChatParticipant(CHAT_PARTICIPANT_ID, handler);
+  try {
+    participant.iconPath = vscode.Uri.joinPath(context.extensionUri, 'resources', 'icon.png');
+  } catch {
+    // Optional icon
+  }
+
+  context.subscriptions.push(participant);
+  return participant;
+}

--- a/extensions/vscode/src/commands/planCommands.ts
+++ b/extensions/vscode/src/commands/planCommands.ts
@@ -1,0 +1,179 @@
+import * as vscode from 'vscode';
+import { COMMANDS } from '../constants';
+import { IJobRunner } from '../jobs/jobRunner';
+import { ServerManager } from '../server/serverManager';
+
+export function registerPlanCommands(
+  context: vscode.ExtensionContext,
+  jobRunner: IJobRunner,
+  serverManager: ServerManager
+): void {
+  // 1. Create Plan
+  context.subscriptions.push(
+    vscode.commands.registerCommand(COMMANDS.createPlan, async () => {
+      const description = await vscode.window.showInputBox({
+        title: 'Tendril: Create Plan',
+        prompt: 'Enter a description for the new plan',
+        placeHolder: 'e.g. Add dark mode support to settings app'
+      });
+
+      if (!description || description.trim().length === 0) {
+        return;
+      }
+
+      let selectedProject: string | undefined;
+      const projects = await jobRunner.listProjects();
+
+      if (projects.length === 1) {
+        selectedProject = projects[0];
+      } else if (projects.length > 1) {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (workspaceFolders && workspaceFolders.length > 0) {
+          const wsName = workspaceFolders[0].name.toLowerCase();
+          const matched = projects.find(p => p.toLowerCase() === wsName);
+          if (matched) {
+            selectedProject = matched;
+          }
+        }
+
+        if (!selectedProject) {
+          selectedProject = await vscode.window.showQuickPick(projects, {
+            title: 'Select Project for Plan',
+            placeHolder: 'Choose a Tendril project'
+          });
+        }
+      }
+
+      if (!selectedProject) {
+        selectedProject = 'default';
+      }
+
+      try {
+        await serverManager.ensureServerRunning();
+        const res = await jobRunner.startCreatePlan(description.trim(), selectedProject);
+        const jobMsg = res.jobId ? ` (Job ${res.jobId})` : '';
+        vscode.window.showInformationMessage(
+          `Started CreatePlan${jobMsg} for project "${selectedProject}".`
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`Failed to start CreatePlan: ${msg}`);
+      }
+    })
+  );
+
+  // 2. Execute Plan
+  context.subscriptions.push(
+    vscode.commands.registerCommand(COMMANDS.executePlan, async (planIdArg?: string) => {
+      let planId = planIdArg;
+      if (!planId || typeof planId !== 'string') {
+        planId = await vscode.window.showInputBox({
+          title: 'Tendril: Execute Plan',
+          prompt: 'Enter Plan ID to execute',
+          placeHolder: 'e.g. 00399'
+        });
+      }
+
+      if (!planId || planId.trim().length === 0) {
+        return;
+      }
+
+      try {
+        await serverManager.ensureServerRunning();
+        const res = await jobRunner.startExecutePlan(planId.trim());
+        const jobMsg = res.jobId ? ` (Job ${res.jobId})` : '';
+        vscode.window.showInformationMessage(
+          `Started ExecutePlan${jobMsg} for plan ${planId.trim()}.`
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`Failed to start ExecutePlan: ${msg}`);
+      }
+    })
+  );
+
+  // 3. Retry Plan
+  context.subscriptions.push(
+    vscode.commands.registerCommand(COMMANDS.retryPlan, async (planIdArg?: string) => {
+      let planId = planIdArg;
+      if (!planId || typeof planId !== 'string') {
+        planId = await vscode.window.showInputBox({
+          title: 'Tendril: Retry Plan',
+          prompt: 'Enter Plan ID to retry',
+          placeHolder: 'e.g. 00399'
+        });
+      }
+
+      if (!planId || planId.trim().length === 0) {
+        return;
+      }
+
+      const feedback = await vscode.window.showInputBox({
+        title: 'Tendril: Retry Plan',
+        prompt: 'Enter reviewer feedback or change request',
+        placeHolder: 'e.g. Fix failing unit tests and update documentation'
+      });
+
+      if (!feedback || feedback.trim().length === 0) {
+        return;
+      }
+
+      try {
+        await serverManager.ensureServerRunning();
+        const res = await jobRunner.startRetryPlan(planId.trim(), feedback.trim());
+        const jobMsg = res.jobId ? ` (Job ${res.jobId})` : '';
+        vscode.window.showInformationMessage(
+          `Started RetryPlan${jobMsg} for plan ${planId.trim()}.`
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`Failed to start RetryPlan: ${msg}`);
+      }
+    })
+  );
+
+  // 4. Check Job Status
+  context.subscriptions.push(
+    vscode.commands.registerCommand(COMMANDS.checkJobStatus, async (jobIdArg?: string) => {
+      try {
+        let jobId = jobIdArg;
+        if (!jobId || typeof jobId !== 'string') {
+          const jobs = await jobRunner.listJobs();
+          if (jobs.length > 0) {
+            const items = jobs.map(j => ({
+              label: `${j.id} (${j.type}) - ${j.status}`,
+              description: j.planId ? `Plan ${j.planId}` : j.project,
+              detail: j.message || 'No status message',
+              jobId: j.id
+            }));
+            const picked = await vscode.window.showQuickPick(items, {
+              title: 'Select Job to Check Status',
+              placeHolder: 'Choose a job to view status'
+            });
+            if (!picked) {
+              return;
+            }
+            jobId = picked.jobId;
+          } else {
+            jobId = await vscode.window.showInputBox({
+              title: 'Tendril: Check Job Status',
+              prompt: 'Enter Job ID',
+              placeHolder: 'e.g. 01864'
+            });
+          }
+        }
+
+        if (!jobId || jobId.trim().length === 0) {
+          return;
+        }
+
+        const status = await jobRunner.getJobStatus(jobId.trim());
+        const detail = status.message ? `: ${status.message}` : '';
+        vscode.window.showInformationMessage(`Job ${status.id} is ${status.status}${detail}`);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`Failed to check job status: ${msg}`);
+      }
+    })
+  );
+}

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -4,7 +4,11 @@ export const COMMANDS = {
   openWorktree: 'tendril.openWorktree',
   startServer: 'tendril.startServer',
   stopServer: 'tendril.stopServer',
-  restartServer: 'tendril.restartServer'
+  restartServer: 'tendril.restartServer',
+  createPlan: 'tendril.createPlan',
+  executePlan: 'tendril.executePlan',
+  checkJobStatus: 'tendril.checkJobStatus',
+  retryPlan: 'tendril.retryPlan'
 } as const;
 
 export const VIEWS = {

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
 import { BridgeHandler } from './bridge/bridgeHandler';
+import { registerChatParticipant } from './chat/chatParticipant';
+import { registerPlanCommands } from './commands/planCommands';
 import { COMMANDS, CONFIG_KEYS, VIEWS } from './constants';
+import { JobRunner } from './jobs/jobRunner';
 import { ServerManager } from './server/serverManager';
 import { StatusBarItem } from './statusbar/statusBarItem';
 import { SidebarProvider } from './views/sidebarProvider';
@@ -13,9 +16,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   serverManager = new ServerManager();
   context.subscriptions.push(serverManager);
 
-  const bridgeHandler = new BridgeHandler();
+  const jobRunner = new JobRunner(serverManager);
+  const bridgeHandler = new BridgeHandler(undefined, jobRunner);
   const statusBar = new StatusBarItem();
   context.subscriptions.push(statusBar);
+
+  registerPlanCommands(context, jobRunner, serverManager);
+  registerChatParticipant(context, jobRunner, serverManager);
 
   const sidebarProvider = new SidebarProvider(serverManager);
   context.subscriptions.push(

--- a/extensions/vscode/src/jobs/jobRunner.ts
+++ b/extensions/vscode/src/jobs/jobRunner.ts
@@ -1,0 +1,226 @@
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import { CONFIG_KEYS } from '../constants';
+import { resolveTendrilHome } from '../server/masterDiscovery';
+import { ServerManager } from '../server/serverManager';
+
+export interface JobResult {
+  jobId?: string;
+  status?: string;
+  message: string;
+}
+
+export interface JobStatusResult {
+  id: string;
+  status: string;
+  message?: string;
+}
+
+export interface JobListItem {
+  id: string;
+  type: string;
+  project: string;
+  status: string;
+  message?: string;
+  planId?: string;
+  started?: string;
+  duration?: string;
+}
+
+export interface IJobRunner {
+  startCreatePlan(description: string, project?: string): Promise<JobResult>;
+  startExecutePlan(planId: string, note?: string): Promise<JobResult>;
+  startRetryPlan(planId: string, changeRequest: string): Promise<JobResult>;
+  startUpdatePlan(planId: string, instructions: string): Promise<JobResult>;
+  getJobStatus(jobId: string): Promise<JobStatusResult>;
+  listJobs(): Promise<JobListItem[]>;
+  listProjects(): Promise<string[]>;
+  executeCli(args: string[]): Promise<{ stdout: string; stderr: string }>;
+}
+
+export class JobRunner implements IJobRunner {
+  constructor(private readonly serverManager?: ServerManager) {}
+
+  public async executeCli(args: string[]): Promise<{ stdout: string; stderr: string }> {
+    const config = vscode.workspace.getConfiguration();
+    const executable = config.get<string>(CONFIG_KEYS.executablePath, 'tendril');
+    const tendrilHome = this.serverManager
+      ? this.serverManager.tendrilHome
+      : resolveTendrilHome(config.get<string>(CONFIG_KEYS.homeDirectory));
+
+    return new Promise((resolve, reject) => {
+      cp.execFile(
+        executable,
+        args,
+        {
+          env: {
+            ...process.env,
+            TENDRIL_HOME: tendrilHome
+          }
+        },
+        (err, stdout, stderr) => {
+          if (err) {
+            const errorOutput = stderr ? stderr.toString().trim() : '';
+            const stdOutput = stdout ? stdout.toString().trim() : '';
+            reject(new Error(errorOutput || stdOutput || err.message));
+          } else {
+            resolve({
+              stdout: stdout ? stdout.toString() : '',
+              stderr: stderr ? stderr.toString() : ''
+            });
+          }
+        }
+      );
+    });
+  }
+
+  private extractJobId(output: string): string | undefined {
+    const match = output.match(/Job started:\s*([^\s\r\n]+)/i);
+    return match ? match[1] : undefined;
+  }
+
+  public async startCreatePlan(description: string, project?: string): Promise<JobResult> {
+    const proj = project || 'default';
+    const args = [
+      'job',
+      'start',
+      'CreatePlan',
+      `--description=${description}`,
+      `--project=${proj}`
+    ];
+    const { stdout } = await this.executeCli(args);
+    const jobId = this.extractJobId(stdout);
+    return {
+      jobId,
+      status: 'Started',
+      message: stdout.trim()
+    };
+  }
+
+  public async startExecutePlan(planId: string, note?: string): Promise<JobResult> {
+    const args = ['job', 'start', 'ExecutePlan', planId];
+    if (note) {
+      args.push(`--note=${note}`);
+    }
+    const { stdout } = await this.executeCli(args);
+    const jobId = this.extractJobId(stdout);
+    return {
+      jobId,
+      status: 'Started',
+      message: stdout.trim()
+    };
+  }
+
+  public async startRetryPlan(planId: string, changeRequest: string): Promise<JobResult> {
+    const args = [
+      'job',
+      'start',
+      'RetryPlan',
+      planId,
+      `--change-request=${changeRequest}`
+    ];
+    const { stdout } = await this.executeCli(args);
+    const jobId = this.extractJobId(stdout);
+    return {
+      jobId,
+      status: 'Started',
+      message: stdout.trim()
+    };
+  }
+
+  public async startUpdatePlan(planId: string, instructions: string): Promise<JobResult> {
+    const args = [
+      'job',
+      'start',
+      'UpdatePlan',
+      planId,
+      `--instructions=${instructions}`
+    ];
+    const { stdout } = await this.executeCli(args);
+    const jobId = this.extractJobId(stdout);
+    return {
+      jobId,
+      status: 'Started',
+      message: stdout.trim()
+    };
+  }
+
+  public async listJobs(): Promise<JobListItem[]> {
+    try {
+      const { stdout } = await this.executeCli(['job', 'list', '--json']);
+      const lines = stdout.split(/\r?\n/).filter(l => l.trim().length > 0);
+      if (lines.length <= 1) {
+        return [];
+      }
+      const result: JobListItem[] = [];
+      for (let i = 1; i < lines.length; i++) {
+        const cols = lines[i].split('\t');
+        if (cols.length >= 4) {
+          result.push({
+            id: cols[0].trim(),
+            type: cols[1].trim(),
+            project: cols[2].trim(),
+            status: cols[3].trim(),
+            message: cols[4] && cols[4].trim().length > 0 ? cols[4].trim() : undefined,
+            planId: cols[5] && cols[5].trim().length > 0 ? cols[5].trim() : undefined,
+            started: cols[6] && cols[6].trim().length > 0 ? cols[6].trim() : undefined,
+            duration: cols[7] && cols[7].trim().length > 0 ? cols[7].trim() : undefined
+          });
+        }
+      }
+      return result;
+    } catch {
+      return [];
+    }
+  }
+
+  public async getJobStatus(jobId: string): Promise<JobStatusResult> {
+    if (this.serverManager) {
+      try {
+        const health = await this.serverManager.getHealthInfo();
+        if (health.isAlive && health.baseUrl) {
+          const url = `${health.baseUrl.replace(/\/+$/, '')}/api/jobs/${encodeURIComponent(jobId)}`;
+          const res = await fetch(url);
+          if (res.ok) {
+            const data = (await res.json()) as { id: string; status: string; message?: string };
+            return {
+              id: data.id,
+              status: data.status,
+              message: data.message
+            };
+          }
+        }
+      } catch {
+        // Fall back to listing jobs
+      }
+    }
+
+    const jobs = await this.listJobs();
+    const found = jobs.find(j => j.id === jobId || j.id.endsWith(jobId));
+    if (found) {
+      return {
+        id: found.id,
+        status: found.status,
+        message: found.message
+      };
+    }
+
+    return {
+      id: jobId,
+      status: 'Unknown',
+      message: 'Job status not found'
+    };
+  }
+
+  public async listProjects(): Promise<string[]> {
+    try {
+      const { stdout } = await this.executeCli(['project', 'list']);
+      return stdout
+        .split(/\r?\n/)
+        .map(l => l.trim())
+        .filter(l => l.length > 0 && !l.startsWith('Error'));
+    } catch {
+      return [];
+    }
+  }
+}

--- a/extensions/vscode/src/test/suite/bridge.test.ts
+++ b/extensions/vscode/src/test/suite/bridge.test.ts
@@ -52,6 +52,70 @@ describe('Tendril IDE Bridge Suite', () => {
       }
     });
 
+    it('should validate valid executeCommand message', () => {
+      const msg = validateBridgeMessage({
+        type: 'executeCommand',
+        command: 'tendril.createPlan',
+        args: ['test-arg']
+      });
+
+      assert.strictEqual(msg.type, 'executeCommand');
+      if (msg.type === 'executeCommand') {
+        assert.strictEqual(msg.command, 'tendril.createPlan');
+        assert.deepStrictEqual(msg.args, ['test-arg']);
+      }
+    });
+
+    it('should validate valid startJob message for all supported types', () => {
+      const createMsg = validateBridgeMessage({
+        type: 'startJob',
+        jobType: 'CreatePlan',
+        description: 'New feature plan',
+        project: 'ivy-tendril'
+      });
+      assert.strictEqual(createMsg.type, 'startJob');
+      if (createMsg.type === 'startJob') {
+        assert.strictEqual(createMsg.jobType, 'CreatePlan');
+        assert.strictEqual(createMsg.description, 'New feature plan');
+        assert.strictEqual(createMsg.project, 'ivy-tendril');
+      }
+
+      const execMsg = validateBridgeMessage({
+        type: 'startJob',
+        jobType: 'ExecutePlan',
+        planId: '00399'
+      });
+      assert.strictEqual(execMsg.type, 'startJob');
+      if (execMsg.type === 'startJob') {
+        assert.strictEqual(execMsg.jobType, 'ExecutePlan');
+        assert.strictEqual(execMsg.planId, '00399');
+      }
+
+      const retryMsg = validateBridgeMessage({
+        type: 'startJob',
+        jobType: 'RetryPlan',
+        planId: '00399',
+        changeRequest: 'Fix unit tests'
+      });
+      assert.strictEqual(retryMsg.type, 'startJob');
+      if (retryMsg.type === 'startJob') {
+        assert.strictEqual(retryMsg.jobType, 'RetryPlan');
+        assert.strictEqual(retryMsg.planId, '00399');
+        assert.strictEqual(retryMsg.changeRequest, 'Fix unit tests');
+      }
+
+      const updateMsg = validateBridgeMessage({
+        type: 'startJob',
+        jobType: 'UpdatePlan',
+        planId: '00399'
+      });
+      assert.strictEqual(updateMsg.type, 'startJob');
+      if (updateMsg.type === 'startJob') {
+        assert.strictEqual(updateMsg.jobType, 'UpdatePlan');
+        assert.strictEqual(updateMsg.planId, '00399');
+      }
+    });
+
     it('should throw for unknown or malformed messages', () => {
       assert.throws(() => validateBridgeMessage(null));
       assert.throws(() => validateBridgeMessage(123));
@@ -61,6 +125,14 @@ describe('Tendril IDE Bridge Suite', () => {
       assert.throws(() => validateBridgeMessage({ type: 'openFile', path: '   ' }));
       assert.throws(() => validateBridgeMessage({ type: 'openWorktree' }));
       assert.throws(() => validateBridgeMessage({ type: 'openDiff', leftPath: '/a' }));
+      assert.throws(() => validateBridgeMessage({ type: 'executeCommand' }));
+      assert.throws(() => validateBridgeMessage({ type: 'executeCommand', command: '' }));
+      assert.throws(() => validateBridgeMessage({ type: 'executeCommand', command: 'cmd', args: 'invalid' }));
+      assert.throws(() => validateBridgeMessage({ type: 'startJob', jobType: 'InvalidType' }));
+      assert.throws(() => validateBridgeMessage({ type: 'startJob', jobType: 'CreatePlan' }));
+      assert.throws(() => validateBridgeMessage({ type: 'startJob', jobType: 'ExecutePlan' }));
+      assert.throws(() => validateBridgeMessage({ type: 'startJob', jobType: 'RetryPlan', planId: '001' }));
+      assert.throws(() => validateBridgeMessage({ type: 'startJob', jobType: 'UpdatePlan' }));
     });
   });
 
@@ -179,6 +251,154 @@ describe('Tendril IDE Bridge Suite', () => {
       assert.strictEqual(executedArgs[0].fsPath, path.resolve('/old/file.txt'));
       assert.strictEqual(executedArgs[1].fsPath, path.resolve('/new/file.txt'));
       assert.strictEqual(executedArgs[2], 'Revision Comparison');
+    });
+
+    it('should route executeCommand to host.executeCommand', async () => {
+      let executedCmd = '';
+      let executedArgs: any[] = [];
+
+      const mockHost: BridgeHost = {
+        openTextDocument: async () => ({} as any),
+        showTextDocument: async () => ({} as any),
+        getWorkspaceFolders: () => [],
+        updateWorkspaceFolders: () => true,
+        executeCommand: async (cmd: string, ...args: any[]) => {
+          executedCmd = cmd;
+          executedArgs = args;
+          return 'command-result' as any;
+        }
+      };
+
+      const handler = new BridgeHandler(mockHost);
+      const result = await handler.handleRawMessage({
+        type: 'executeCommand',
+        command: 'tendril.createPlan',
+        args: ['arg1', 42]
+      });
+
+      assert.strictEqual(executedCmd, 'tendril.createPlan');
+      assert.deepStrictEqual(executedArgs, ['arg1', 42]);
+      assert.strictEqual(result, 'command-result');
+    });
+
+    it('should route startJob to host.startJob if host supports it', async () => {
+      let startedJobMessage: any = null;
+
+      const mockHost: BridgeHost = {
+        openTextDocument: async () => ({} as any),
+        showTextDocument: async () => ({} as any),
+        getWorkspaceFolders: () => [],
+        updateWorkspaceFolders: () => true,
+        executeCommand: async () => ({} as any),
+        startJob: async (msg: any) => {
+          startedJobMessage = msg;
+          return { jobId: '09999', status: 'Started' };
+        }
+      };
+
+      const handler = new BridgeHandler(mockHost);
+      const res = (await handler.handleRawMessage({
+        type: 'startJob',
+        jobType: 'CreatePlan',
+        description: 'Test create plan',
+        project: 'ivy-tendril'
+      })) as any;
+
+      assert.ok(startedJobMessage);
+      assert.strictEqual(startedJobMessage.jobType, 'CreatePlan');
+      assert.strictEqual(startedJobMessage.description, 'Test create plan');
+      assert.strictEqual(startedJobMessage.project, 'ivy-tendril');
+      assert.strictEqual(res.jobId, '09999');
+    });
+
+    it('should route startJob to jobRunner if jobRunner is provided', async () => {
+      let createPlanCalledWith: any = null;
+      let executePlanCalledWith: any = null;
+      let retryPlanCalledWith: any = null;
+      let updatePlanCalledWith: any = null;
+
+      const mockJobRunner: any = {
+        startCreatePlan: async (desc: string, proj?: string) => {
+          createPlanCalledWith = { desc, proj };
+          return { jobId: '01001', status: 'Started', message: 'OK' };
+        },
+        startExecutePlan: async (planId: string) => {
+          executePlanCalledWith = { planId };
+          return { jobId: '01002', status: 'Started', message: 'OK' };
+        },
+        startRetryPlan: async (planId: string, req: string) => {
+          retryPlanCalledWith = { planId, req };
+          return { jobId: '01003', status: 'Started', message: 'OK' };
+        },
+        startUpdatePlan: async (planId: string, inst: string) => {
+          updatePlanCalledWith = { planId, inst };
+          return { jobId: '01004', status: 'Started', message: 'OK' };
+        }
+      };
+
+      const mockHost: BridgeHost = {
+        openTextDocument: async () => ({} as any),
+        showTextDocument: async () => ({} as any),
+        getWorkspaceFolders: () => [],
+        updateWorkspaceFolders: () => true,
+        executeCommand: async () => ({} as any)
+      };
+
+      const handler = new BridgeHandler(mockHost, mockJobRunner);
+
+      const res1 = (await handler.handleRawMessage({
+        type: 'startJob',
+        jobType: 'CreatePlan',
+        description: 'New task',
+        project: 'test-project'
+      })) as any;
+      assert.deepStrictEqual(createPlanCalledWith, { desc: 'New task', proj: 'test-project' });
+      assert.strictEqual(res1.jobId, '01001');
+
+      const res2 = (await handler.handleRawMessage({
+        type: 'startJob',
+        jobType: 'ExecutePlan',
+        planId: '00123'
+      })) as any;
+      assert.deepStrictEqual(executePlanCalledWith, { planId: '00123' });
+      assert.strictEqual(res2.jobId, '01002');
+
+      const res3 = (await handler.handleRawMessage({
+        type: 'startJob',
+        jobType: 'RetryPlan',
+        planId: '00123',
+        changeRequest: 'Fix review feedback'
+      })) as any;
+      assert.deepStrictEqual(retryPlanCalledWith, { planId: '00123', req: 'Fix review feedback' });
+      assert.strictEqual(res3.jobId, '01003');
+
+      const res4 = (await handler.handleRawMessage({
+        type: 'startJob',
+        jobType: 'UpdatePlan',
+        planId: '00123',
+        description: 'Updated instructions'
+      })) as any;
+      assert.deepStrictEqual(updatePlanCalledWith, { planId: '00123', inst: 'Updated instructions' });
+      assert.strictEqual(res4.jobId, '01004');
+    });
+
+    it('should throw if startJob is invoked without host or jobRunner support', async () => {
+      const mockHost: BridgeHost = {
+        openTextDocument: async () => ({} as any),
+        showTextDocument: async () => ({} as any),
+        getWorkspaceFolders: () => [],
+        updateWorkspaceFolders: () => true,
+        executeCommand: async () => ({} as any)
+      };
+
+      const handler = new BridgeHandler(mockHost);
+      await assert.rejects(async () => {
+        await handler.handleRawMessage({
+          type: 'startJob',
+          jobType: 'ExecutePlan',
+          planId: '00123'
+        });
+      }, /Host does not support startJob/);
     });
   });
 });

--- a/extensions/vscode/src/test/suite/chat.test.ts
+++ b/extensions/vscode/src/test/suite/chat.test.ts
@@ -1,0 +1,333 @@
+import * as assert from 'assert';
+import { handleChatRequest } from '../../chat/chatParticipant';
+import {
+  IJobRunner,
+  JobListItem,
+  JobResult,
+  JobRunner,
+  JobStatusResult
+} from '../../jobs/jobRunner';
+
+class MockChatResponseStream {
+  public markdownOutput: string[] = [];
+  public progressOutput: string[] = [];
+
+  markdown(val: string): void {
+    this.markdownOutput.push(val);
+  }
+
+  progress(val: string): void {
+    this.progressOutput.push(val);
+  }
+
+  anchor(): void {}
+  button(): void {}
+  filetree(): void {}
+  reference(): void {}
+  push(): void {}
+}
+
+class TestJobRunner implements IJobRunner {
+  public startCreatePlanCalls: Array<{ desc: string; project?: string }> = [];
+  public startExecutePlanCalls: Array<{ planId: string; note?: string }> = [];
+  public startRetryPlanCalls: Array<{ planId: string; changeRequest: string }> = [];
+  public startUpdatePlanCalls: Array<{ planId: string; instructions: string }> = [];
+  public getJobStatusCalls: string[] = [];
+  public listJobsCalls = 0;
+  public listProjectsCalls = 0;
+  public executeCliCalls: string[][] = [];
+
+  async startCreatePlan(desc: string, project?: string): Promise<JobResult> {
+    this.startCreatePlanCalls.push({ desc, project });
+    return { jobId: '00001', status: 'Started', message: 'Created' };
+  }
+
+  async startExecutePlan(planId: string, note?: string): Promise<JobResult> {
+    this.startExecutePlanCalls.push({ planId, note });
+    return { jobId: '00002', status: 'Started', message: 'Executing' };
+  }
+
+  async startRetryPlan(planId: string, changeRequest: string): Promise<JobResult> {
+    this.startRetryPlanCalls.push({ planId, changeRequest });
+    return { jobId: '00003', status: 'Started', message: 'Retrying' };
+  }
+
+  async startUpdatePlan(planId: string, instructions: string): Promise<JobResult> {
+    this.startUpdatePlanCalls.push({ planId, instructions });
+    return { jobId: '00004', status: 'Started', message: 'Updating' };
+  }
+
+  async getJobStatus(jobId: string): Promise<JobStatusResult> {
+    this.getJobStatusCalls.push(jobId);
+    return { id: jobId, status: 'Running', message: 'Implementing changes' };
+  }
+
+  async listJobs(): Promise<JobListItem[]> {
+    this.listJobsCalls++;
+    return [
+      {
+        id: '01864',
+        type: 'ExecutePlan',
+        project: 'ivy-tendril',
+        status: 'Running',
+        message: 'Running build',
+        planId: '00399'
+      }
+    ];
+  }
+
+  async listProjects(): Promise<string[]> {
+    this.listProjectsCalls++;
+    return ['ivy-tendril', 'growth-hack'];
+  }
+
+  async executeCli(args: string[]): Promise<{ stdout: string; stderr: string }> {
+    this.executeCliCalls.push(args);
+    return { stdout: '', stderr: '' };
+  }
+}
+
+const mockServerManager: any = {
+  ensureServerRunning: async () => ({
+    baseUrl: 'http://localhost:5000',
+    port: 5000,
+    pid: 1234,
+    scheme: 'http',
+    heartbeat: new Date()
+  }),
+  getHealthInfo: async () => ({
+    isAlive: true,
+    baseUrl: 'http://localhost:5000',
+    port: 5000,
+    pid: 1234
+  }),
+  tendrilHome: '/mock/tendril'
+};
+
+describe('Tendril Chat Participant Suite', () => {
+  describe('Slash command handling in handleChatRequest', () => {
+    it('should handle /plan with valid prompt', async () => {
+      const runner = new TestJobRunner();
+      const stream = new MockChatResponseStream();
+      const request: any = {
+        command: 'plan',
+        prompt: 'Add dark mode support'
+      };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.startCreatePlanCalls.length, 1);
+      assert.strictEqual(runner.startCreatePlanCalls[0].desc, 'Add dark mode support');
+      assert.strictEqual(runner.startCreatePlanCalls[0].project, 'ivy-tendril');
+      assert.ok(stream.markdownOutput.length > 0);
+      assert.ok(stream.markdownOutput[0].includes('Started **CreatePlan** job'));
+      assert.ok(stream.markdownOutput[0].includes('00001'));
+    });
+
+    it('should prompt for description when /plan prompt is empty', async () => {
+      const runner = new TestJobRunner();
+      const stream = new MockChatResponseStream();
+      const request: any = {
+        command: 'plan',
+        prompt: '   '
+      };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.startCreatePlanCalls.length, 0);
+      assert.ok(stream.markdownOutput[0].includes('Please provide a description'));
+    });
+
+    it('should handle /run with valid planId', async () => {
+      const runner = new TestJobRunner();
+      const stream = new MockChatResponseStream();
+      const request: any = {
+        command: 'run',
+        prompt: '00399'
+      };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.startExecutePlanCalls.length, 1);
+      assert.strictEqual(runner.startExecutePlanCalls[0].planId, '00399');
+      assert.ok(stream.markdownOutput.length > 0);
+      assert.ok(stream.markdownOutput[0].includes('Started **ExecutePlan** job for Plan `00399`'));
+      assert.ok(stream.markdownOutput[0].includes('00002'));
+    });
+
+    it('should prompt for planId when /run prompt is empty', async () => {
+      const runner = new TestJobRunner();
+      const stream = new MockChatResponseStream();
+      const request: any = {
+        command: 'run',
+        prompt: ''
+      };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.startExecutePlanCalls.length, 0);
+      assert.ok(stream.markdownOutput[0].includes('Please specify a plan ID'));
+    });
+
+    it('should handle /status with specific jobId', async () => {
+      const runner = new TestJobRunner();
+      const stream = new MockChatResponseStream();
+      const request: any = {
+        command: 'status',
+        prompt: '01864'
+      };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.getJobStatusCalls.length, 1);
+      assert.strictEqual(runner.getJobStatusCalls[0], '01864');
+      assert.ok(stream.markdownOutput[0].includes('### Job `01864`'));
+      assert.ok(stream.markdownOutput[0].includes('Running'));
+      assert.ok(stream.markdownOutput[0].includes('Implementing changes'));
+    });
+
+    it('should handle /status without prompt and output active jobs table', async () => {
+      const runner = new TestJobRunner();
+      const stream = new MockChatResponseStream();
+      const request: any = {
+        command: 'status',
+        prompt: ''
+      };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.listJobsCalls, 1);
+      assert.ok(stream.markdownOutput[0].includes('### Active Jobs'));
+      assert.ok(stream.markdownOutput[0].includes('01864'));
+      assert.ok(stream.markdownOutput[0].includes('ExecutePlan'));
+    });
+
+    it('should handle /retry with planId and feedback', async () => {
+      const runner = new TestJobRunner();
+      const stream = new MockChatResponseStream();
+      const request: any = {
+        command: 'retry',
+        prompt: '00399 Fix failing tests'
+      };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.startRetryPlanCalls.length, 1);
+      assert.strictEqual(runner.startRetryPlanCalls[0].planId, '00399');
+      assert.strictEqual(runner.startRetryPlanCalls[0].changeRequest, 'Fix failing tests');
+      assert.ok(stream.markdownOutput[0].includes('Started **RetryPlan** job for Plan `00399`'));
+      assert.ok(stream.markdownOutput[0].includes('Fix failing tests'));
+      assert.ok(stream.markdownOutput[0].includes('00003'));
+    });
+
+    it('should prompt when /retry is missing feedback', async () => {
+      const runner = new TestJobRunner();
+      const stream = new MockChatResponseStream();
+      const request: any = {
+        command: 'retry',
+        prompt: '00399'
+      };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.startRetryPlanCalls.length, 0);
+      assert.ok(stream.markdownOutput[0].includes('Please specify both a plan ID and feedback'));
+    });
+
+    it('should output default help markdown for empty or unknown command', async () => {
+      const runner = new TestJobRunner();
+      const stream = new MockChatResponseStream();
+      const request: any = {
+        command: undefined,
+        prompt: 'hello'
+      };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.ok(stream.markdownOutput[0].includes('Hello! I am **Tendril**'));
+      assert.ok(stream.markdownOutput[0].includes('@tendril /plan'));
+      assert.ok(stream.markdownOutput[0].includes('@tendril /run'));
+      assert.ok(stream.markdownOutput[0].includes('@tendril /status'));
+      assert.ok(stream.markdownOutput[0].includes('@tendril /retry'));
+    });
+  });
+
+  describe('CLI command construction matching Tendril conventions', () => {
+    it('should construct exact equals-form arguments for CreatePlan', async () => {
+      const runner = new JobRunner(mockServerManager);
+      let capturedArgs: string[] = [];
+      runner.executeCli = async (args: string[]) => {
+        capturedArgs = args;
+        return { stdout: 'Job started: 01999\n', stderr: '' };
+      };
+
+      const res = await runner.startCreatePlan('Build authentication', 'ivy-tendril');
+      assert.deepStrictEqual(capturedArgs, [
+        'job',
+        'start',
+        'CreatePlan',
+        '--description=Build authentication',
+        '--project=ivy-tendril'
+      ]);
+      assert.strictEqual(res.jobId, '01999');
+      assert.strictEqual(res.status, 'Started');
+    });
+
+    it('should construct exact arguments for ExecutePlan with optional note', async () => {
+      const runner = new JobRunner(mockServerManager);
+      let capturedArgs: string[] = [];
+      runner.executeCli = async (args: string[]) => {
+        capturedArgs = args;
+        return { stdout: 'Job started: 01998\n', stderr: '' };
+      };
+
+      const res = await runner.startExecutePlan('00399', 'Priority fix');
+      assert.deepStrictEqual(capturedArgs, [
+        'job',
+        'start',
+        'ExecutePlan',
+        '00399',
+        '--note=Priority fix'
+      ]);
+      assert.strictEqual(res.jobId, '01998');
+    });
+
+    it('should construct exact equals-form arguments for RetryPlan', async () => {
+      const runner = new JobRunner(mockServerManager);
+      let capturedArgs: string[] = [];
+      runner.executeCli = async (args: string[]) => {
+        capturedArgs = args;
+        return { stdout: 'Job started: 01997\n', stderr: '' };
+      };
+
+      const res = await runner.startRetryPlan('00399', 'Fix format linter');
+      assert.deepStrictEqual(capturedArgs, [
+        'job',
+        'start',
+        'RetryPlan',
+        '00399',
+        '--change-request=Fix format linter'
+      ]);
+      assert.strictEqual(res.jobId, '01997');
+    });
+
+    it('should construct exact equals-form arguments for UpdatePlan', async () => {
+      const runner = new JobRunner(mockServerManager);
+      let capturedArgs: string[] = [];
+      runner.executeCli = async (args: string[]) => {
+        capturedArgs = args;
+        return { stdout: 'Job started: 01996\n', stderr: '' };
+      };
+
+      const res = await runner.startUpdatePlan('00399', 'Update database schema');
+      assert.deepStrictEqual(capturedArgs, [
+        'job',
+        'start',
+        'UpdatePlan',
+        '00399',
+        '--instructions=Update database schema'
+      ]);
+      assert.strictEqual(res.jobId, '01996');
+    });
+  });
+});

--- a/extensions/vscode/src/test/suite/commands.test.ts
+++ b/extensions/vscode/src/test/suite/commands.test.ts
@@ -1,0 +1,196 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { registerPlanCommands } from '../../commands/planCommands';
+import { COMMANDS } from '../../constants';
+import { IJobRunner, JobListItem, JobResult, JobStatusResult } from '../../jobs/jobRunner';
+
+class MockJobRunner implements IJobRunner {
+  public startCreatePlanCalls: Array<{ desc: string; project?: string }> = [];
+  public startExecutePlanCalls: Array<{ planId: string; note?: string }> = [];
+  public startRetryPlanCalls: Array<{ planId: string; changeRequest: string }> = [];
+  public startUpdatePlanCalls: Array<{ planId: string; instructions: string }> = [];
+  public getJobStatusCalls: string[] = [];
+  public jobsList: JobListItem[] = [];
+  public projectsList: string[] = ['ivy-tendril'];
+
+  async startCreatePlan(desc: string, project?: string): Promise<JobResult> {
+    this.startCreatePlanCalls.push({ desc, project });
+    return { jobId: '00101', status: 'Started', message: 'OK' };
+  }
+
+  async startExecutePlan(planId: string, note?: string): Promise<JobResult> {
+    this.startExecutePlanCalls.push({ planId, note });
+    return { jobId: '00102', status: 'Started', message: 'OK' };
+  }
+
+  async startRetryPlan(planId: string, changeRequest: string): Promise<JobResult> {
+    this.startRetryPlanCalls.push({ planId, changeRequest });
+    return { jobId: '00103', status: 'Started', message: 'OK' };
+  }
+
+  async startUpdatePlan(planId: string, instructions: string): Promise<JobResult> {
+    this.startUpdatePlanCalls.push({ planId, instructions });
+    return { jobId: '00104', status: 'Started', message: 'OK' };
+  }
+
+  async getJobStatus(jobId: string): Promise<JobStatusResult> {
+    this.getJobStatusCalls.push(jobId);
+    return { id: jobId, status: 'Running', message: 'All checks passed' };
+  }
+
+  async listJobs(): Promise<JobListItem[]> {
+    return this.jobsList;
+  }
+
+  async listProjects(): Promise<string[]> {
+    return this.projectsList;
+  }
+
+  async executeCli(_args: string[]): Promise<{ stdout: string; stderr: string }> {
+    return { stdout: '', stderr: '' };
+  }
+}
+
+describe('Tendril Plan Commands Suite', () => {
+  let runner: MockJobRunner;
+  let context: any;
+  let infoMessages: string[] = [];
+  let errorMessages: string[] = [];
+  let inputBoxResponses: (string | undefined)[] = [];
+  let quickPickResponse: any = undefined;
+
+  const mockServerManager: any = {
+    ensureServerRunning: async () => ({ baseUrl: 'http://localhost:5000' }),
+    tendrilHome: '/mock/tendril'
+  };
+
+  beforeEach(() => {
+    runner = new MockJobRunner();
+    infoMessages = [];
+    errorMessages = [];
+    inputBoxResponses = [];
+    quickPickResponse = undefined;
+
+    context = {
+      subscriptions: []
+    };
+
+    vscode.window.showInformationMessage = (async (msg: string) => {
+      infoMessages.push(msg);
+      return undefined;
+    }) as any;
+
+    vscode.window.showErrorMessage = (async (msg: string) => {
+      errorMessages.push(msg);
+      return undefined;
+    }) as any;
+
+    vscode.window.showInputBox = (async () => {
+      return inputBoxResponses.shift();
+    }) as any;
+
+    vscode.window.showQuickPick = (async () => {
+      return quickPickResponse;
+    }) as any;
+
+    registerPlanCommands(context, runner, mockServerManager);
+  });
+
+  afterEach(() => {
+    for (const sub of context.subscriptions) {
+      if (sub && typeof sub.dispose === 'function') {
+        sub.dispose();
+      }
+    }
+  });
+
+  it('should dispatch tendril.createPlan with user input', async () => {
+    inputBoxResponses = ['Implement dark mode'];
+
+    await vscode.commands.executeCommand(COMMANDS.createPlan);
+
+    assert.strictEqual(runner.startCreatePlanCalls.length, 1);
+    assert.strictEqual(runner.startCreatePlanCalls[0].desc, 'Implement dark mode');
+    assert.strictEqual(runner.startCreatePlanCalls[0].project, 'ivy-tendril');
+    assert.ok(infoMessages.some(m => m.includes('Started CreatePlan (Job 00101)')));
+  });
+
+  it('should cancel tendril.createPlan when description is empty', async () => {
+    inputBoxResponses = [undefined];
+
+    await vscode.commands.executeCommand(COMMANDS.createPlan);
+
+    assert.strictEqual(runner.startCreatePlanCalls.length, 0);
+  });
+
+  it('should dispatch tendril.executePlan with argument', async () => {
+    await vscode.commands.executeCommand(COMMANDS.executePlan, '00399');
+
+    assert.strictEqual(runner.startExecutePlanCalls.length, 1);
+    assert.strictEqual(runner.startExecutePlanCalls[0].planId, '00399');
+    assert.ok(infoMessages.some(m => m.includes('Started ExecutePlan (Job 00102)')));
+  });
+
+  it('should dispatch tendril.executePlan with prompt when argument is omitted', async () => {
+    inputBoxResponses = ['00400'];
+
+    await vscode.commands.executeCommand(COMMANDS.executePlan);
+
+    assert.strictEqual(runner.startExecutePlanCalls.length, 1);
+    assert.strictEqual(runner.startExecutePlanCalls[0].planId, '00400');
+  });
+
+  it('should cancel tendril.executePlan when planId is not provided', async () => {
+    inputBoxResponses = ['   '];
+
+    await vscode.commands.executeCommand(COMMANDS.executePlan);
+
+    assert.strictEqual(runner.startExecutePlanCalls.length, 0);
+  });
+
+  it('should dispatch tendril.retryPlan with prompts', async () => {
+    inputBoxResponses = ['00399', 'Fix failing unit test'];
+
+    await vscode.commands.executeCommand(COMMANDS.retryPlan);
+
+    assert.strictEqual(runner.startRetryPlanCalls.length, 1);
+    assert.strictEqual(runner.startRetryPlanCalls[0].planId, '00399');
+    assert.strictEqual(runner.startRetryPlanCalls[0].changeRequest, 'Fix failing unit test');
+    assert.ok(infoMessages.some(m => m.includes('Started RetryPlan (Job 00103)')));
+  });
+
+  it('should cancel tendril.retryPlan when feedback is cancelled', async () => {
+    inputBoxResponses = ['00399', undefined];
+
+    await vscode.commands.executeCommand(COMMANDS.retryPlan);
+
+    assert.strictEqual(runner.startRetryPlanCalls.length, 0);
+  });
+
+  it('should dispatch tendril.checkJobStatus with direct jobId', async () => {
+    await vscode.commands.executeCommand(COMMANDS.checkJobStatus, '01864');
+
+    assert.strictEqual(runner.getJobStatusCalls.length, 1);
+    assert.strictEqual(runner.getJobStatusCalls[0], '01864');
+    assert.ok(infoMessages.some(m => m.includes('Job 01864 is Running: All checks passed')));
+  });
+
+  it('should prompt via quick pick when jobs are available for checkJobStatus', async () => {
+    runner.jobsList = [
+      {
+        id: '01864',
+        type: 'ExecutePlan',
+        project: 'ivy-tendril',
+        status: 'Running',
+        message: 'Building'
+      }
+    ];
+    quickPickResponse = { jobId: '01864' };
+
+    await vscode.commands.executeCommand(COMMANDS.checkJobStatus);
+
+    assert.strictEqual(runner.getJobStatusCalls.length, 1);
+    assert.strictEqual(runner.getJobStatusCalls[0], '01864');
+    assert.ok(infoMessages.some(m => m.includes('Job 01864 is Running')));
+  });
+});

--- a/extensions/vscode/src/test/vscodeMock.ts
+++ b/extensions/vscode/src/test/vscodeMock.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 export class MockUri {
   public readonly scheme: string;
   public readonly fsPath: string;
@@ -15,6 +17,10 @@ export class MockUri {
 
   public static parse(val: string): MockUri {
     return new MockUri(val);
+  }
+
+  public static joinPath(base: MockUri, ...pathSegments: string[]): MockUri {
+    return new MockUri(path.join(base.fsPath, ...pathSegments));
   }
 
   public toString(): string {
@@ -144,6 +150,8 @@ export const vscodeMock = {
       return undefined;
     },
     showTextDocument: async () => ({}),
+    showInputBox: async () => undefined,
+    showQuickPick: async () => undefined,
     activeColorTheme: { kind: ColorThemeKind.Dark },
     onDidChangeActiveColorTheme: () => ({ dispose: () => {} }),
     registerTreeDataProvider: () => ({ dispose: () => {} })
@@ -172,5 +180,13 @@ export const vscodeMock = {
       }
       return undefined;
     }
+  },
+  chat: {
+    createChatParticipant: (id: string, handler: unknown) => ({
+      id,
+      requestHandler: handler,
+      iconPath: undefined,
+      dispose: () => {}
+    })
   }
 };


### PR DESCRIPTION
Fixes #2561

# Summary

## Changes

Added VS Code Chat Participant (`@tendril`) with interactive slash commands (`/plan`, `/run`, `/status`, `/retry`) to interact with Tendril autonomous agents. Added Command Palette entries for creating plans, executing plans, checking job status, and retrying plans, backed by a new `JobRunner` service and extended IDE bridge protocol.

## API Changes

- Added VS Code Chat Participant `tendril.chatParticipant` (`@tendril`) with commands `plan`, `run`, `status`, and `retry`.
- Added Command Palette commands:
  - `tendril.createPlan`: "Tendril: Create Plan"
  - `tendril.executePlan`: "Tendril: Execute Plan"
  - `tendril.checkJobStatus`: "Tendril: Check Job Status"
  - `tendril.retryPlan`: "Tendril: Retry Plan"
- Added Bridge Protocol message types:
  - `ExecuteCommandMessage` (`type: 'executeCommand'`, `command: string`, `args?: unknown[]`)
  - `StartJobMessage` (`type: 'startJob'`, `jobType: 'CreatePlan' | 'ExecutePlan' | 'RetryPlan' | 'UpdatePlan'`, `planId?: string`, `description?: string`, `project?: string`, `changeRequest?: string`)
  - `JobStatusUpdateMessage` (`type: 'jobStatus'`, `jobId: string`, `status: string`, `message?: string`, `planId?: string`)
- Added `IJobRunner` and `JobRunner` in `extensions/vscode/src/jobs/jobRunner.ts`.

## Files Modified

- **Chat Participant**: `extensions/vscode/src/chat/chatParticipant.ts`
- **Command Palette Handlers**: `extensions/vscode/src/commands/planCommands.ts`
- **Job Runner**: `extensions/vscode/src/jobs/jobRunner.ts`
- **Bridge Protocol & Handler**: `extensions/vscode/src/bridge/bridgeProtocol.ts`, `extensions/vscode/src/bridge/bridgeHandler.ts`
- **Configuration & Activation**: `extensions/vscode/package.json`, `extensions/vscode/src/constants.ts`, `extensions/vscode/src/extension.ts`
- **Tests**: `extensions/vscode/src/test/vscodeMock.ts`, `extensions/vscode/src/test/suite/bridge.test.ts`, `extensions/vscode/src/test/suite/chat.test.ts`, `extensions/vscode/src/test/suite/commands.test.ts`

## Manual Testing

1. Open VS Code with the Tendril extension loaded.
2. Open the Chat view and type `@tendril` to see the assistant welcome message and list of slash commands.
3. Type `@tendril /plan Add a settings panel` to verify that a CreatePlan job is initiated and progress is streamed into chat.
4. Type `@tendril /status` to view the list of currently active jobs in markdown format.
5. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS) and run `Tendril: Create Plan`, enter a description, and verify that the plan job starts and a confirmation banner is displayed.
6. Run `Tendril: Check Job Status` to select an active job from the QuickPick list and view its current status.

---

## Commits

- c7ef1659 [00399] Register @tendril chat participant with slash commands
- 1e53acc3 [00399] Add Tendril command palette commands for plan execution and status
- 2c2bb8d0 [00399] Support executeCommand and startJob messages in VS Code IDE bridge

---
Created using [Ivy Tendril](https://ivy.app).