### PR TITLE
[00400] Support Folders and Projects Not Added as Tendril Projects

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -67,6 +67,10 @@
       {
         "command": "tendril.restartServer",
         "title": "Tendril: Restart Server"
+      },
+      {
+        "command": "tendril.addCurrentProject",
+        "title": "Tendril: Add Current Project"
       }
     ],
     "menus": {

--- a/extensions/vscode/src/constants.ts
+++ b/extensions/vscode/src/constants.ts
@@ -4,7 +4,8 @@ export const COMMANDS = {
   openWorktree: 'tendril.openWorktree',
   startServer: 'tendril.startServer',
   stopServer: 'tendril.stopServer',
-  restartServer: 'tendril.restartServer'
+  restartServer: 'tendril.restartServer',
+  addCurrentProject: 'tendril.addCurrentProject'
 } as const;
 
 export const VIEWS = {

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { BridgeHandler } from './bridge/bridgeHandler';
 import { COMMANDS, CONFIG_KEYS, VIEWS } from './constants';
 import { ServerManager } from './server/serverManager';
@@ -123,6 +124,78 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     })
   );
 
+  context.subscriptions.push(
+    vscode.commands.registerCommand(COMMANDS.addCurrentProject, async (folderUri?: vscode.Uri) => {
+      try {
+        const folders = vscode.workspace.workspaceFolders;
+        const targetFolder = folderUri
+          ? folders?.find(f => f.uri.toString() === folderUri.toString()) ?? { uri: folderUri, name: path.basename(folderUri.fsPath) }
+          : folders?.[0];
+
+        if (!targetFolder) {
+          vscode.window.showWarningMessage('No workspace folder open to add to Tendril.');
+          return;
+        }
+
+        const folderPath = targetFolder.uri.fsPath;
+        const folderName = path.basename(folderPath) || targetFolder.name;
+
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: `Adding '${folderName}' to Tendril...`,
+            cancellable: false
+          },
+          async () => {
+            await serverManager!.executeCli(['project', 'add', folderName]);
+            await serverManager!.executeCli(['project', 'add-repo', folderName, folderPath]);
+            await serverManager!.executeCli(['job', 'start', 'AddProject', folderName]);
+          }
+        );
+
+        vscode.window.showInformationMessage(`Project '${folderName}' added to Tendril. Setup job started.`);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`Failed to add project to Tendril: ${msg}`);
+      }
+    })
+  );
+
+  const promptedWorkspaces = new Set<string>();
+
+  async function checkAndPromptUnmanagedWorkspace(): Promise<void> {
+    if (!serverManager) {
+      return;
+    }
+
+    try {
+      const status = await serverManager.checkWorkspaceProjectStatus();
+      if (!status.isManaged && status.workspacePath) {
+        if (promptedWorkspaces.has(status.workspacePath)) {
+          return;
+        }
+        promptedWorkspaces.add(status.workspacePath);
+
+        const folderName = path.basename(status.workspacePath);
+        const action = await vscode.window.showInformationMessage(
+          `Workspace folder '${folderName}' is not registered in Tendril. Add it now?`,
+          'Add to Tendril'
+        );
+        if (action === 'Add to Tendril') {
+          await vscode.commands.executeCommand(COMMANDS.addCurrentProject);
+        }
+      }
+    } catch {
+      // Ignore background checking errors
+    }
+  }
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      void checkAndPromptUnmanagedWorkspace();
+    })
+  );
+
   // Background initialization & auto-start check
   void (async () => {
     const health = await serverManager!.getHealthInfo();
@@ -138,6 +211,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         // Logged inside ServerManager output channel
       }
     }
+
+    await checkAndPromptUnmanagedWorkspace();
   })();
 
   // Periodic polling for health status (every 10s)

--- a/extensions/vscode/src/server/masterDiscovery.ts
+++ b/extensions/vscode/src/server/masterDiscovery.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { DiscoveryResult, DiscoveryStatus, MasterFileData, TendrilPlanSummary } from './types';
+import { DiscoveryResult, DiscoveryStatus, MasterFileData, TendrilPlanSummary, TendrilProjectSummary } from './types';
 
 export const HEARTBEAT_TIMEOUT_MS = 90_000;
 
@@ -232,4 +232,72 @@ export async function fetchRecentPlans(
   } finally {
     clearTimeout(timer);
   }
+}
+
+export async function fetchProjects(
+  baseUrl: string,
+  apiKey?: string,
+  timeoutMs = 3000
+): Promise<TendrilProjectSummary[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const url = `${baseUrl.replace(/\/+$/, '')}/api/projects`;
+    const headers: Record<string, string> = {
+      Accept: 'application/json'
+    };
+    if (apiKey) {
+      headers['x-api-key'] = apiKey;
+    }
+
+    const res = await fetch(url, { headers, signal: controller.signal });
+    if (!res.ok) {
+      return [];
+    }
+
+    const data = await res.json();
+    if (Array.isArray(data)) {
+      return data.map((item: Record<string, unknown>) => ({
+        name: String(item.name ?? ''),
+        color: item.color ? String(item.color) : undefined,
+        repos: Array.isArray(item.repos) ? item.repos.map((r: unknown) => String(r)) : []
+      }));
+    }
+    return [];
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function normalizeRepoPath(p: string): string {
+  if (!p) return '';
+  return path.normalize(p).replace(/[\\/]+$/, '').toLowerCase();
+}
+
+export function isWorkspaceManaged(
+  workspacePath: string,
+  projects: TendrilProjectSummary[]
+): { isManaged: boolean; projectName?: string } {
+  if (!workspacePath) {
+    return { isManaged: true };
+  }
+
+  const normalizedWs = normalizeRepoPath(workspacePath);
+  for (const project of projects) {
+    for (const repo of project.repos) {
+      const normalizedRepo = normalizeRepoPath(repo);
+      if (
+        normalizedWs === normalizedRepo ||
+        normalizedWs.startsWith(normalizedRepo + path.sep) ||
+        normalizedWs.startsWith(normalizedRepo + '/')
+      ) {
+        return { isManaged: true, projectName: project.name };
+      }
+    }
+  }
+
+  return { isManaged: false };
 }

--- a/extensions/vscode/src/server/serverManager.ts
+++ b/extensions/vscode/src/server/serverManager.ts
@@ -3,11 +3,13 @@ import * as cp from 'child_process';
 import { CONFIG_KEYS } from '../constants';
 import {
   discoverMaster,
+  fetchProjects,
   fetchRecentPlans,
+  isWorkspaceManaged,
   pingServer,
   resolveTendrilHome
 } from './masterDiscovery';
-import { DiscoveryResult, ServerHealthInfo, TendrilPlanSummary } from './types';
+import { DiscoveryResult, ServerHealthInfo, TendrilPlanSummary, TendrilProjectSummary } from './types';
 
 export function buildServerArgs(port = 0): string[] {
   const args = ['--web'];
@@ -78,6 +80,63 @@ export class ServerManager implements vscode.Disposable {
     const discovery = discoverMaster(this.tendrilHome, false);
     const apiKey = discovery.status === 'found' ? discovery.result.apiKey : undefined;
     return fetchRecentPlans(health.baseUrl, limit, apiKey);
+  }
+
+  public async getProjects(): Promise<TendrilProjectSummary[]> {
+    const health = await this.getHealthInfo();
+    if (!health.isAlive || !health.baseUrl) {
+      return [];
+    }
+
+    const discovery = discoverMaster(this.tendrilHome, false);
+    const apiKey = discovery.status === 'found' ? discovery.result.apiKey : undefined;
+    return fetchProjects(health.baseUrl, apiKey);
+  }
+
+  public async checkWorkspaceProjectStatus(): Promise<{
+    isManaged: boolean;
+    projectName?: string;
+    workspacePath?: string;
+  }> {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders || folders.length === 0) {
+      return { isManaged: true };
+    }
+
+    const workspacePath = folders[0].uri.fsPath;
+    const projects = await this.getProjects();
+    const result = isWorkspaceManaged(workspacePath, projects);
+
+    return {
+      isManaged: result.isManaged,
+      projectName: result.projectName,
+      workspacePath
+    };
+  }
+
+  public async executeCli(args: string[]): Promise<string> {
+    const config = vscode.workspace.getConfiguration();
+    const executable = config.get<string>(CONFIG_KEYS.executablePath, 'tendril');
+
+    return new Promise((resolve, reject) => {
+      cp.execFile(
+        executable,
+        args,
+        {
+          env: {
+            ...process.env,
+            TENDRIL_HOME: this.tendrilHome
+          }
+        },
+        (error, stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || stdout || error.message));
+          } else {
+            resolve(stdout);
+          }
+        }
+      );
+    });
   }
 
   public async ensureServerRunning(): Promise<DiscoveryResult> {

--- a/extensions/vscode/src/server/types.ts
+++ b/extensions/vscode/src/server/types.ts
@@ -30,6 +30,12 @@ export interface TendrilPlanSummary {
   level?: string;
 }
 
+export interface TendrilProjectSummary {
+  name: string;
+  color?: string;
+  repos: string[];
+}
+
 export interface ServerHealthInfo {
   isAlive: boolean;
   port?: number;

--- a/extensions/vscode/src/test/suite/unmanagedProject.test.ts
+++ b/extensions/vscode/src/test/suite/unmanagedProject.test.ts
@@ -1,0 +1,108 @@
+import * as assert from 'assert';
+import { fetchProjects, isWorkspaceManaged } from '../../server/masterDiscovery';
+import { TendrilProjectSummary } from '../../server/types';
+
+describe('Unmanaged Project Detection Suite', () => {
+  describe('fetchProjects', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('should parse valid /api/projects response correctly', async () => {
+      const mockProjects = [
+        {
+          name: 'ProjectAlpha',
+          color: 'green',
+          repos: ['/repos/alpha', '/repos/alpha-docs']
+        },
+        {
+          name: 'ProjectBeta',
+          repos: ['/repos/beta']
+        }
+      ];
+
+      globalThis.fetch = (async (url: RequestInfo | URL) => {
+        assert.ok(String(url).includes('/api/projects'));
+        return {
+          ok: true,
+          json: async () => mockProjects
+        } as Response;
+      }) as typeof fetch;
+
+      const result = await fetchProjects('http://localhost:5000');
+      assert.strictEqual(result.length, 2);
+      assert.strictEqual(result[0].name, 'ProjectAlpha');
+      assert.strictEqual(result[0].color, 'green');
+      assert.deepStrictEqual(result[0].repos, ['/repos/alpha', '/repos/alpha-docs']);
+      assert.strictEqual(result[1].name, 'ProjectBeta');
+      assert.strictEqual(result[1].color, undefined);
+      assert.deepStrictEqual(result[1].repos, ['/repos/beta']);
+    });
+
+    it('should return empty array on non-ok HTTP response', async () => {
+      globalThis.fetch = (async () => {
+        return {
+          ok: false,
+          status: 500
+        } as Response;
+      }) as typeof fetch;
+
+      const result = await fetchProjects('http://localhost:5000');
+      assert.deepStrictEqual(result, []);
+    });
+  });
+
+  describe('isWorkspaceManaged', () => {
+    const projects: TendrilProjectSummary[] = [
+      {
+        name: 'Ivy-Tendril',
+        repos: ['/Users/dev/git/ivy-tendril', 'C:\\repos\\Ivy-Tendril']
+      },
+      {
+        name: 'SecondaryProject',
+        repos: ['/Users/dev/git/secondary/']
+      }
+    ];
+
+    it('should match workspace folder with exact match', () => {
+      const status = isWorkspaceManaged('/Users/dev/git/ivy-tendril', projects);
+      assert.strictEqual(status.isManaged, true);
+      assert.strictEqual(status.projectName, 'Ivy-Tendril');
+    });
+
+    it('should match workspace folder handling case insensitivity and normalized separators', () => {
+      // Different casing
+      const caseStatus = isWorkspaceManaged('/users/dev/git/IVY-TENDRIL', projects);
+      assert.strictEqual(caseStatus.isManaged, true);
+      assert.strictEqual(caseStatus.projectName, 'Ivy-Tendril');
+
+      // Trailing slashes
+      const trailingSlashStatus = isWorkspaceManaged('/Users/dev/git/ivy-tendril/', projects);
+      assert.strictEqual(trailingSlashStatus.isManaged, true);
+      assert.strictEqual(trailingSlashStatus.projectName, 'Ivy-Tendril');
+
+      // Windows paths with backslashes
+      const windowsStatus = isWorkspaceManaged('c:\\repos\\ivy-tendril', projects);
+      assert.strictEqual(windowsStatus.isManaged, true);
+      assert.strictEqual(windowsStatus.projectName, 'Ivy-Tendril');
+
+      // Subfolder inside registered repo
+      const subfolderStatus = isWorkspaceManaged('/Users/dev/git/ivy-tendril/src/Ivy.Tendril', projects);
+      assert.strictEqual(subfolderStatus.isManaged, true);
+      assert.strictEqual(subfolderStatus.projectName, 'Ivy-Tendril');
+    });
+
+    it('should detect unmanaged status when workspace folder is not in registered projects list', () => {
+      const unmanaged = isWorkspaceManaged('/Users/dev/git/unknown-new-project', projects);
+      assert.strictEqual(unmanaged.isManaged, false);
+      assert.strictEqual(unmanaged.projectName, undefined);
+    });
+
+    it('should return isManaged true for empty workspace path', () => {
+      const empty = isWorkspaceManaged('', projects);
+      assert.strictEqual(empty.isManaged, true);
+    });
+  });
+});

--- a/src/Ivy.Tendril.Test/Helpers/PlanProjectResolverTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PlanProjectResolverTests.cs
@@ -1,0 +1,73 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+public class PlanProjectResolverTests
+{
+    private static ProjectConfig ConfiguredProject(string name, params string[] repos) =>
+        new()
+        {
+            Name = name,
+            Repos = repos.Select(r => new RepoRef { Path = r }).ToList()
+        };
+
+    [Fact]
+    public void Resolves_Configured_Project_By_Name()
+    {
+        var configured = ConfiguredProject("MyProject", @"/repos/my-project");
+        var available = new List<ProjectConfig> { configured };
+
+        var resolved = PlanProjectResolver.ResolveProject("MyProject", available);
+
+        Assert.Equal("MyProject", resolved.Name);
+        Assert.Single(resolved.Repos);
+        Assert.Equal(@"/repos/my-project", resolved.Repos[0].Path);
+        Assert.False(resolved.IsAdHoc);
+    }
+
+    [Fact]
+    public void Resolves_AdHoc_Project_From_Existing_Directory_Path()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var available = new List<ProjectConfig>
+            {
+                ConfiguredProject("OtherProject", @"/repos/other")
+            };
+
+            var resolved = PlanProjectResolver.ResolveProject(tempDir, available);
+
+            Assert.Equal(Path.GetFileName(tempDir), resolved.Name);
+            Assert.Single(resolved.Repos);
+            Assert.Equal(Path.GetFullPath(tempDir), resolved.Repos[0].Path);
+            Assert.True(resolved.IsAdHoc);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Throws_When_Project_Not_Found_And_Path_Does_Not_Exist()
+    {
+        var available = new List<ProjectConfig>
+        {
+            ConfiguredProject("Alpha", @"/repos/alpha"),
+            ConfiguredProject("Beta", @"/repos/beta")
+        };
+
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), $"non-existent-{Guid.NewGuid():N}");
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            PlanProjectResolver.ResolveProject(nonExistentPath, available));
+
+        Assert.Contains($"Project '{nonExistentPath}' not found", ex.Message);
+        Assert.Contains("Alpha", ex.Message);
+        Assert.Contains("Beta", ex.Message);
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/PlanProjectRepoGuardTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanProjectRepoGuardTests.cs
@@ -60,4 +60,32 @@ public class PlanProjectRepoGuardTests
         Assert.Contains("Other", offendingSegment);
         Assert.DoesNotContain("Ivy-Tendril", offendingSegment);
     }
+
+    [Fact]
+    public void Allows_Repo_When_Project_Is_AdHoc()
+    {
+        var project = new ProjectConfig
+        {
+            Name = "AdHocProj",
+            Repos = [new RepoRef { Path = @"/some/path" }],
+            Meta = new Dictionary<string, object> { ["adhoc"] = true }
+        };
+
+        // No throw even for unrelated repo path.
+        PlanProjectRepoGuard.EnsureReposBelongToProject([@"/other/unrelated/repo"], project);
+    }
+
+    [Fact]
+    public void Allows_Unmanaged_Workspace_Path()
+    {
+        var project = new ProjectConfig
+        {
+            Name = "UnmanagedWorkspace",
+            Repos = [new RepoRef { Path = @"/unmanaged/workspace" }],
+            Meta = new Dictionary<string, object> { ["adhoc"] = true }
+        };
+
+        // No throw for unmanaged workspace path.
+        PlanProjectRepoGuard.EnsureReposBelongToProject([@"/unmanaged/workspace/subfolder"], project);
+    }
 }

--- a/src/Ivy.Tendril/Controllers/ProjectController.cs
+++ b/src/Ivy.Tendril/Controllers/ProjectController.cs
@@ -1,0 +1,21 @@
+using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ivy.Tendril.Controllers;
+
+[ApiController]
+[Route("api/projects")]
+public class ProjectController(IConfigService configService) : ControllerBase
+{
+    [HttpGet]
+    public IActionResult GetProjects()
+    {
+        var projects = configService.Projects.Select(p => new
+        {
+            name = p.Name,
+            color = p.Color,
+            repos = p.RepoPaths
+        });
+        return Ok(projects);
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PlanProjectResolver.cs
+++ b/src/Ivy.Tendril/Helpers/PlanProjectResolver.cs
@@ -19,7 +19,26 @@ public static class PlanProjectResolver
             p.Name.Equals(projectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
+        {
+            if (Directory.Exists(projectName))
+            {
+                var fullPath = Path.GetFullPath(projectName);
+                var folderName = Path.GetFileName(fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                if (string.IsNullOrEmpty(folderName))
+                {
+                    folderName = fullPath;
+                }
+
+                return new ProjectConfig
+                {
+                    Name = folderName,
+                    Repos = [new RepoRef { Path = fullPath }],
+                    Meta = new Dictionary<string, object> { ["adhoc"] = true }
+                };
+            }
+
             throw new ArgumentException($"Project '{projectName}' not found. Available: {namesList}");
+        }
 
         if (project.Repos.Count == 0)
             throw new ArgumentException($"Project '{project.Name}' has no repos configured.");

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -116,6 +116,9 @@ public record ProjectConfig
     [YamlIgnore]
     public List<string> RepoPaths => Repos.Select(r => r.Path).ToList();
 
+    [YamlIgnore]
+    public bool IsAdHoc => Meta.TryGetValue("adhoc", out var v) && (v is true || string.Equals(v?.ToString(), "true", StringComparison.OrdinalIgnoreCase));
+
     public string? GetMeta(string key)
     {
         return Meta.TryGetValue(key, out var v) ? v?.ToString() : null;

--- a/src/Ivy.Tendril/Services/Plans/PlanProjectRepoGuard.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanProjectRepoGuard.cs
@@ -18,6 +18,9 @@ public static class PlanProjectRepoGuard
     /// </summary>
     public static void EnsureReposBelongToProject(IEnumerable<string> repoPaths, ProjectConfig project)
     {
+        if (project.IsAdHoc)
+            return;
+
         var allowed = AllowedRepoNames(project);
 
         // Fail open: a project with no repos configured gives nothing to validate against.


### PR DESCRIPTION
Fixes #2564

# Summary

## Changes

Added end-to-end support for unmanaged workspace folders and external directories in Tendril. Tendril core now exposes a registered project listing endpoint and supports ad-hoc project resolution directly from local directory paths, while the VS Code extension detects unmanaged workspaces and provides interactive onboarding into Tendril.

## API Changes

- `[Route("api/projects")] ProjectController`: New HTTP controller exposing `[HttpGet]` to list registered projects with their names, colors, and repository paths.
- `ProjectConfig.IsAdHoc`: New boolean property indicating whether a project was created ad-hoc for an unmanaged directory.
- `PlanProjectResolver.ResolveProject`: Now accepts local directory paths when a project name is not registered, generating an ad-hoc project configuration.
- `COMMANDS.addCurrentProject` (`tendril.addCurrentProject`): New VS Code extension command to add the current workspace folder and start project setup.
- `fetchProjects` and `isWorkspaceManaged` functions added in VS Code extension master discovery module.
- `ServerManager.getProjects()`, `ServerManager.checkWorkspaceProjectStatus()`, and `ServerManager.executeCli()` added to the extension server manager.

## Files Modified

**Backend & Core:**
- `src/Ivy.Tendril/Controllers/ProjectController.cs`: Controller for registered project queries.
- `src/Ivy.Tendril/Services/ConfigService.cs`: Added `IsAdHoc` property on `ProjectConfig`.
- `src/Ivy.Tendril/Helpers/PlanProjectResolver.cs`: Added fallback resolution for existing local directories.
- `src/Ivy.Tendril/Services/Plans/PlanProjectRepoGuard.cs`: Added exemption for ad-hoc projects from strict repo membership checks.
- `src/Ivy.Tendril.Test/Helpers/PlanProjectResolverTests.cs`: Unit tests for project resolution and ad-hoc fallback.
- `src/Ivy.Tendril.Test/Services/PlanProjectRepoGuardTests.cs`: Unit tests for ad-hoc repository guard behavior.

**VS Code Extension:**
- `extensions/vscode/src/server/types.ts`: Added `TendrilProjectSummary` interface.
- `extensions/vscode/src/server/masterDiscovery.ts`: Added `fetchProjects` and `isWorkspaceManaged`.
- `extensions/vscode/src/server/serverManager.ts`: Added project status checks and CLI invocation helper.
- `extensions/vscode/src/constants.ts`: Registered `addCurrentProject` command.
- `extensions/vscode/package.json`: Contributed command definition.
- `extensions/vscode/src/extension.ts`: Added active workspace detection and prompt with onboarding flow.
- `extensions/vscode/src/test/suite/unmanagedProject.test.ts`: Test suite for unmanaged workspace detection and API parsing.

## Manual Testing

1. **Verify Project Listing Endpoint:**
   - Launch the Tendril web server: `tendril --web` (or start via VS Code extension).
   - In a browser or via `curl`, query `http://localhost:<port>/api/projects`.
   - Observe JSON array containing registered projects with their repository paths and colors.

2. **Verify Unmanaged Workspace Prompt in VS Code:**
   - Open a folder in VS Code that is not registered in Tendril (for example, `/tmp/my-test-app`).
   - Observe notification: "Workspace folder 'my-test-app' is not registered in Tendril. Add it now?".
   - Click "Add to Tendril" and verify project addition and setup job initiation.

3. **Verify Ad-Hoc Plan Creation with Directory Path:**
   - Run `tendril plan create "Test Plan" "/path/to/any/folder"`.
   - Observe plan creation completes successfully without throwing "Project not found".

---
- 1f45e5ad Plan 00400: Detect unmanaged workspaces and support onboarding in VS Code extension
- c8935338 Plan 00400: Add project listing API and ad-hoc project fallback mode in Tendril core

---
Created using [Ivy Tendril](https://ivy.app).
