### PR TITLE
[00399] Fix Top Spacing of a Pinned Comment in the Plan Chat Panel

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom";
 import { ChatWidget, type ChatSessionDto } from "./ChatWidget";
 import { setupChatWidgetTestEnvironment } from "./ChatWidget.testUtils";
+import { PIN_TOP_PADDING } from "./useThreadScroll";
 
 describe("ChatWidget Running Jobs Badge and Spinner", () => {
   beforeEach(() => {
@@ -648,6 +649,58 @@ describe("ChatWidget embedded mode", () => {
     expect(tooltip).toHaveTextContent("New chat");
     expect(tooltip.querySelector(".tui-kbd")?.textContent).toBe("Ctrl+Alt+A");
     vi.useRealTimers();
+  });
+
+  it("keeps top padding when pinning the first message in embedded mode", () => {
+    const layout = { spacerTop: 60 };
+    Object.defineProperty(HTMLElement.prototype, "offsetTop", {
+      configurable: true,
+      get(this: HTMLElement) {
+        if (this.dataset.messageId) return PIN_TOP_PADDING;
+        if (this.classList.contains("chat-scroll-spacer")) return layout.spacerTop;
+        return 0;
+      },
+    });
+
+    try {
+      const session: ChatSessionDto = {
+        id: "s1",
+        title: "Plan chat",
+        agentId: "claude",
+        modelId: "opus",
+        createdAt: "",
+        updatedAt: "",
+        messages: [],
+      };
+      render(
+        <ChatWidget id="embedded" embedded activeSessionId="s1" sessions={[session]} />,
+      );
+
+      const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
+      const spacer = document.querySelector(".chat-scroll-spacer") as HTMLDivElement;
+      let scrollTop = 0;
+      Object.defineProperty(container, "clientHeight", { value: 400, configurable: true });
+      Object.defineProperty(container, "scrollHeight", {
+        get: () => layout.spacerTop + parseFloat(spacer.style.height || "0"),
+        configurable: true,
+      });
+      Object.defineProperty(container, "scrollTop", {
+        get: () => scrollTop,
+        set: (v: number) => {
+          scrollTop = v;
+        },
+        configurable: true,
+      });
+
+      fireEvent.change(screen.getByPlaceholderText(/Ask/i), { target: { value: "test" } });
+      fireEvent.click(screen.getByRole("button", { name: /Send/i }));
+
+      // When the first message's offsetTop equals PIN_TOP_PADDING, scrolling to position 0
+      // means the padding is visible above the message, not scrolled away.
+      expect(scrollTop).toBe(0);
+    } finally {
+      delete (HTMLElement.prototype as any).offsetTop;
+    }
   });
 });
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -1768,8 +1768,10 @@ button.chat-system-event-plan {
   border-bottom: none;
 }
 
+/* Keep the top padding: the pin scroll clamps at 0, so a pinned first message gets no clearance
+   without it. The value is PIN_TOP_PADDING in useThreadScroll.ts. */
 .chat-widget-root[data-embedded="true"] .chat-thread {
-  padding: 0 var(--tch-embedded-inset);
+  padding: 10px var(--tch-embedded-inset) 0;
 }
 
 .chat-widget-root[data-embedded="true"] .chat-empty-state {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { PIN_TOP_PADDING } from "./useThreadScroll";
+
+describe("chat-widget.css", () => {
+  const css = readFileSync(join(__dirname, "chat-widget.css"), "utf-8");
+
+  describe("embedded thread", () => {
+    it("has top padding matching PIN_TOP_PADDING constant", () => {
+      const embeddedThreadBlock = css.slice(
+        css.indexOf('.chat-widget-root[data-embedded="true"] .chat-thread {'),
+        css.indexOf("}", css.indexOf('.chat-widget-root[data-embedded="true"] .chat-thread {')) + 1
+      );
+
+      expect(embeddedThreadBlock).toContain(`padding: ${PIN_TOP_PADDING}px`);
+    });
+
+    it("does not have zero top padding", () => {
+      const embeddedThreadBlock = css.slice(
+        css.indexOf('.chat-widget-root[data-embedded="true"] .chat-thread {'),
+        css.indexOf("}", css.indexOf('.chat-widget-root[data-embedded="true"] .chat-thread {')) + 1
+      );
+
+      expect(embeddedThreadBlock).not.toMatch(/padding:\s*0\s/);
+    });
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/useThreadScroll.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/useThreadScroll.ts
@@ -1,8 +1,8 @@
 import { useCallback, useLayoutEffect, useRef } from "react";
 
 const SCROLL_THRESHOLD = 50;
-/** Breathing room above a pinned message, matching the thread's top padding. */
-const PIN_TOP_PADDING = 10;
+/** Breathing room above a pinned message. Both the embedded and non-embedded thread supply this value as their top padding. */
+export const PIN_TOP_PADDING = 10;
 
 interface Pin {
   messageId: string;


### PR DESCRIPTION
Fixes #2546

## Problem

Commenting to the agent from a plan's side chat leaves the new comment glued to the top edge of the panel, with no gap between it and the border under the plan header.

The embedded chat panel removes the thread's top padding, so when `useThreadScroll` pins a new message to the top, the clamp at `scrollTop = Math.max(0, offsetTop - PIN_TOP_PADDING)` turns the intended -10px offset into 0, scrolling away all clearance.

## Solution

Restore the thread's 10px top padding in embedded mode by changing the CSS rule from `padding: 0 var(--tch-embedded-inset)` to `padding: 10px var(--tch-embedded-inset) 0`. Export `PIN_TOP_PADDING` from `useThreadScroll.ts` and add a CSS test that asserts the stylesheet's padding value matches the constant, preventing drift.

---

### Commits
- c33bb09: Fix top spacing of pinned comment in embedded chat

---
Created using [Ivy Tendril](https://ivy.app).
