### PR TITLE
[00406] Debrand Ivy Tendril and Fork Open Factory Distribution

### DIFF
--- a/src/Ivy.Tendril.Test/AppBrandTests.cs
+++ b/src/Ivy.Tendril.Test/AppBrandTests.cs
@@ -1,0 +1,37 @@
+namespace Ivy.Tendril.Test;
+
+public class AppBrandTests
+{
+    [Fact]
+    public void AppBrand_Constants_AreNonEmpty()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.AppName));
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.Distribution));
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.Organization));
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.RepoName));
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.RepoUrl));
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.IssuesUrl));
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.DocsUrl));
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.DiscordUrl));
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.PrSignatureText));
+        Assert.False(string.IsNullOrWhiteSpace(AppBrand.PrSignatureUrl));
+    }
+
+    [Fact]
+    public void AppBrand_Urls_AreWellFormed()
+    {
+        Assert.True(Uri.TryCreate(AppBrand.RepoUrl, UriKind.Absolute, out var repoUri) && (repoUri.Scheme == Uri.UriSchemeHttp || repoUri.Scheme == Uri.UriSchemeHttps));
+        Assert.True(Uri.TryCreate(AppBrand.IssuesUrl, UriKind.Absolute, out var issuesUri) && (issuesUri.Scheme == Uri.UriSchemeHttp || issuesUri.Scheme == Uri.UriSchemeHttps));
+        Assert.True(Uri.TryCreate(AppBrand.DocsUrl, UriKind.Absolute, out var docsUri) && (docsUri.Scheme == Uri.UriSchemeHttp || docsUri.Scheme == Uri.UriSchemeHttps));
+        Assert.True(Uri.TryCreate(AppBrand.DiscordUrl, UriKind.Absolute, out var discordUri) && (discordUri.Scheme == Uri.UriSchemeHttp || discordUri.Scheme == Uri.UriSchemeHttps));
+        Assert.True(Uri.TryCreate(AppBrand.PrSignatureUrl, UriKind.Absolute, out var prSigUri) && (prSigUri.Scheme == Uri.UriSchemeHttp || prSigUri.Scheme == Uri.UriSchemeHttps));
+    }
+
+    [Fact]
+    public void Constants_Urls_MatchAppBrand()
+    {
+        Assert.Equal(AppBrand.DocsUrl, Constants.DocsUrl);
+        Assert.Equal(AppBrand.DiscordUrl, Constants.DiscordUrl);
+        Assert.Equal(AppBrand.IssuesUrl, Constants.IssuesUrl);
+    }
+}

--- a/src/Ivy.Tendril.Test/LocalFileGuardMiddlewareTests.cs
+++ b/src/Ivy.Tendril.Test/LocalFileGuardMiddlewareTests.cs
@@ -25,7 +25,7 @@ public class LocalFileGuardMiddlewareTests
         public Task InstallAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task DeactivateAsync() => Task.CompletedTask;
-        public string? GetShareUrlForPlan(string planId, bool relative = false) => null;
+        public string GetShareUrlForPlan(string planId, bool relative = false) => "";
         public void Dispose() { }
     }
 

--- a/src/Ivy.Tendril.Test/Services/TelemetryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/TelemetryServiceTests.cs
@@ -1,0 +1,24 @@
+using Ivy.Tendril.Services.Telemetry;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class TelemetryServiceTests
+{
+    [Fact]
+    public void CreatePostHogOptions_IncludesDistributionAndSource_MatchingAppBrand()
+    {
+        var options = TelemetryService.CreatePostHogOptions("test-session-id", "1.0.0");
+
+        Assert.NotNull(options);
+        Assert.NotNull(options.SuperProperties);
+
+        Assert.True(options.SuperProperties.ContainsKey("distribution"));
+        Assert.Equal(AppBrand.Distribution, options.SuperProperties["distribution"]);
+
+        Assert.True(options.SuperProperties.ContainsKey("source"));
+        Assert.Equal(AppBrand.Distribution, options.SuperProperties["source"]);
+
+        Assert.True(options.SuperProperties.ContainsKey("app_version"));
+        Assert.Equal("1.0.0", options.SuperProperties["app_version"]);
+    }
+}

--- a/src/Ivy.Tendril/AppBrand.cs
+++ b/src/Ivy.Tendril/AppBrand.cs
@@ -1,0 +1,15 @@
+namespace Ivy.Tendril;
+
+public static class AppBrand
+{
+    public const string AppName = "Ivy Tendril";
+    public const string Distribution = "ivy-tendril";
+    public const string Organization = "Ivy-Interactive";
+    public const string RepoName = "Ivy-Tendril";
+    public const string RepoUrl = "https://github.com/Ivy-Interactive/Ivy-Tendril";
+    public const string IssuesUrl = "https://github.com/Ivy-Interactive/Ivy-Tendril/issues/new";
+    public const string DocsUrl = "https://tendril.ivy.app";
+    public const string DiscordUrl = "https://discord.gg/FHgxkDga3y";
+    public const string PrSignatureText = "Ivy Tendril";
+    public const string PrSignatureUrl = "https://ivy.app";
+}

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -885,7 +885,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
         var versionString = typeof(TendrilAppShell).Assembly.GetName().Version!.ToString(3);
         var sidebarHeader = new ShellSidebarHeader()
-            .Title("Ivy Tendril")
+            .Title(AppBrand.AppName)
             .Version($"v {versionString}")
             .LogoUrl("/tendril/assets/Tendril.svg");
 

--- a/src/Ivy.Tendril/Apps/Onboarding/OnboardingApp.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/OnboardingApp.cs
@@ -108,7 +108,7 @@ public class OnboardingApp : ViewBase
 
         var header = Layout.Horizontal().AlignContent(Align.BottomLeft)
                      | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(15)).Height(Size.Auto())
-                     | Text.H2("Welcome to Ivy Tendril")
+                     | Text.H2($"Welcome to {AppBrand.AppName}")
             ;
 
         return Layout.TopCenter() |

--- a/src/Ivy.Tendril/Commands/RunCommand.cs
+++ b/src/Ivy.Tendril/Commands/RunCommand.cs
@@ -85,7 +85,7 @@ public class RunCommand : AsyncCommand<RunCommand.Settings>
             return 1;
         }
 
-        AnsiConsole.MarkupLine($"[green]Starting Ivy Tendril server on localhost:{server.Args.Port}...[/]");
+        AnsiConsole.MarkupLine($"[green]Starting {AppBrand.AppName} server on localhost:{server.Args.Port}...[/]");
 
         await server.RunAsync();
 

--- a/src/Ivy.Tendril/Commands/VersionCommand.cs
+++ b/src/Ivy.Tendril/Commands/VersionCommand.cs
@@ -16,7 +16,7 @@ public class VersionCommand : AsyncCommand<VersionCommand.Settings>
         var version = assembly.GetName().Version;
         var versionString = version?.ToString(3) ?? "0.0.0";
 
-        AnsiConsole.MarkupLine($"[blue]Ivy Tendril[/] v{versionString}");
+        AnsiConsole.MarkupLine($"[blue]{AppBrand.AppName}[/] v{versionString}");
         return Task.FromResult(0);
     }
 }

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -22,9 +22,9 @@ public static class Constants
     public const int Help = 100;
     public const int Onboarding = 110;
 
-    public const string DocsUrl = "https://tendril.ivy.app";
-    public const string DiscordUrl = "https://discord.gg/FHgxkDga3y";
-    public const string IssuesUrl = "https://github.com/Ivy-Interactive/Ivy-Tendril/issues/new";
+    public const string DocsUrl = AppBrand.DocsUrl;
+    public const string DiscordUrl = AppBrand.DiscordUrl;
+    public const string IssuesUrl = AppBrand.IssuesUrl;
     public const string NewsBaseUrl = "https://cdn.ivy.app/tendril/";
     public const string WindowsInstallCommand = "irm https://cdn.ivy.app/install-tendril.ps1 | iex";
     public const string UnixInstallCommand = "curl -sSf https://cdn.ivy.app/install-tendril.sh | sh";

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -177,7 +177,7 @@ public class Program
         {
             try
             {
-                SetCurrentProcessExplicitAppUserModelID("Ivy Tendril");
+                SetCurrentProcessExplicitAppUserModelID(AppBrand.AppName);
             }
             catch { }
         }
@@ -399,12 +399,12 @@ public class Program
             var versionString = version?.ToString(3) ?? "1.1.12";
 
             var window = new DesktopWindow(server)
-                .Title("Ivy Tendril")
-                .AppId("Ivy Tendril")
+                .Title(AppBrand.AppName)
+                .AppId(AppBrand.AppName)
                 .Size(1800, 1200)
                 .UseDpiScaling(false)
                 .Icon(typeof(Program), iconResource)
-                .AboutName("Ivy Tendril")
+                .AboutName(AppBrand.AppName)
                 .AboutVersion(versionString)
                 .AboutCopyright("© 2026 Ivy Interactive")
                 .AboutWebsite("https://ivy.app")

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -188,7 +188,7 @@ rm -f "$body_file"
   fi
 
   # Construct body with issue link prepended
-  body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}\n\n---\nCreated using [Ivy Tendril](https://ivy.app)."
+  body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}\n\n---\nCreated using [${PrSignatureText:-Ivy Tendril}](${PrSignatureUrl:-https://ivy.app})."
   ```
 - **Draft (custom options):** If custom options exist and `draft` is `true`, add `--draft` to the `gh pr create` command to create the PR in draft mode. If no custom options or `draft` is `false`, create as ready for review (default behavior).
 - **Reviewer (custom options):** If custom options exist and `reviewer` is non-empty, split `PrReviewer` on commas and add one `--reviewer <username>` flag per name to the `gh pr create` command. **Never pass a bare `--reviewer` with no value** — that fails with `flag needs an argument: --reviewer`. Omit the flag entirely when `PrReviewer` is empty.

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -731,6 +731,8 @@ internal class JobLauncher
             values["PrComment"] = pr.Comment;
         if (!string.IsNullOrWhiteSpace(pr.BaseBranch))
             values["PrBaseBranch"] = pr.BaseBranch.Trim();
+        values["PrSignatureText"] = AppBrand.PrSignatureText;
+        values["PrSignatureUrl"] = AppBrand.PrSignatureUrl;
     }
 
     private static Dictionary<string, string> BuildJobContext(JobItem job, Dictionary<string, string> firmwareValues, string programFolder)

--- a/src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs
+++ b/src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs
@@ -33,19 +33,7 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
             var sessionId = Guid.NewGuid().ToString();
             // GeoIP enabled so we can see which countries have active users
             var appVersion = typeof(TelemetryService).Assembly.GetName().Version?.ToString(3) ?? "unknown";
-            _client = new PostHogClient(new PostHogOptions
-            {
-                ProjectToken = "phc_uHeJHFURzThFPnizzGMzLEimLWnRAuqy8DunK8N3oYcd",
-                HostUrl = new Uri("https://eu.i.posthog.com"),
-                SuperProperties = new Dictionary<string, object>
-                {
-                    ["$session_id"] = sessionId,
-                    ["$geoip_disable"] = false,
-                    ["app_version"] = appVersion,
-                    ["os"] = Environment.OSVersion.Platform.ToString(),
-                    ["os_version"] = Environment.OSVersion.VersionString
-                }
-            });
+            _client = new PostHogClient(CreatePostHogOptions(sessionId, appVersion));
             _distinctId = GetOrCreateAnonymousId();
             _logger?.LogDebug("TelemetryService initialized with anonymous ID: {DistinctId}", _distinctId);
         }
@@ -56,6 +44,22 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
             _distinctId = "";
         }
     }
+
+    internal static PostHogOptions CreatePostHogOptions(string sessionId, string appVersion) => new()
+    {
+        ProjectToken = "phc_uHeJHFURzThFPnizzGMzLEimLWnRAuqy8DunK8N3oYcd",
+        HostUrl = new Uri("https://eu.i.posthog.com"),
+        SuperProperties = new Dictionary<string, object>
+        {
+            ["$session_id"] = sessionId,
+            ["$geoip_disable"] = false,
+            ["app_version"] = appVersion,
+            ["distribution"] = AppBrand.Distribution,
+            ["source"] = AppBrand.Distribution,
+            ["os"] = Environment.OSVersion.Platform.ToString(),
+            ["os_version"] = Environment.OSVersion.VersionString
+        }
+    };
 
     public async ValueTask DisposeAsync()
     {
@@ -82,6 +86,8 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
                 personPropertiesToSet: new Dictionary<string, object>
                 {
                     ["app_version"] = appVersion,
+                    ["distribution"] = AppBrand.Distribution,
+                    ["source"] = AppBrand.Distribution,
                     ["os"] = Environment.OSVersion.Platform.ToString(),
                     ["os_version"] = Environment.OSVersion.VersionString
                 },

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -28,7 +28,7 @@ public static class TendrilServer
 #if DEBUG
         server.UseHotReload();
 #endif
-        server.SetMetaTitle("Ivy Tendril");
+        server.SetMetaTitle(AppBrand.AppName);
 
         var configService = new ConfigService(Microsoft.Extensions.Logging.Abstractions.NullLogger<ConfigService>.Instance);
         server.Services.AddSingleton(tendrilArgs);
@@ -159,7 +159,7 @@ public static class TendrilServer
                 Layout.Horizontal(
                     new Image("/tendril/assets/Tendril.svg").Width(Size.Px(32)).Height(Size.Px(32)),
                     Layout.Vertical(
-                        Text.Block("Ivy Tendril").NoWrap(),
+                        Text.Block(AppBrand.AppName).NoWrap(),
                         Text.Muted($"v{versionString}").NoWrap()
                     ).Gap(0)
                 ).Gap(2).Padding(2).AlignContent(Align.Left)


### PR DESCRIPTION
# Summary

## Changes

Extracted brand configuration into a centralized `AppBrand` abstraction and replaced hardcoded distribution identity across shell, UI, and CLI banners. Added distribution and source super properties to PostHog telemetry to segment usage between distributions. Created and initialized the `Ivy-Interactive/Open-Factory` GitHub repository with upstream synchronization and debranded distribution metadata.

## API Changes

- Added `Ivy.Tendril.AppBrand` static configuration class containing distribution and brand constants (`AppName`, `Distribution`, `Organization`, `RepoName`, `RepoUrl`, `IssuesUrl`, `DocsUrl`, `DiscordUrl`, `PrSignatureText`, `PrSignatureUrl`).
- Updated `Ivy.Tendril.Constants` (`DocsUrl`, `DiscordUrl`, `IssuesUrl`) to route through `AppBrand`.
- Added internal `TelemetryService.CreatePostHogOptions(string sessionId, string appVersion)` factory method.

## Files Modified

### Core Application & Branding
- `src/Ivy.Tendril/AppBrand.cs`: Brand abstraction defining constants for distribution name, repository URLs, documentation, and PR signatures.
- `src/Ivy.Tendril/Constants.cs`: Updated documentation, Discord, and issues URLs to reference `AppBrand`.
- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs`: Sidebar header title updated to `AppBrand.AppName`.
- `src/Ivy.Tendril/TendrilServer.cs`: Server HTML meta title and header title updated to `AppBrand.AppName`.
- `src/Ivy.Tendril/Program.cs`: Windows AppUserModelID, DesktopWindow title, AppId, and AboutName updated to `AppBrand.AppName`.
- `src/Ivy.Tendril/Apps/Onboarding/OnboardingApp.cs`: Welcome headline updated to `AppBrand.AppName`.
- `src/Ivy.Tendril/Commands/VersionCommand.cs`: Version CLI banner updated to `AppBrand.AppName`.
- `src/Ivy.Tendril/Commands/RunCommand.cs`: Server startup console banner updated to `AppBrand.AppName`.

### Telemetry & Promptwares
- `src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs`: Injected `distribution` and `source` properties into PostHog super properties and person profiles.
- `src/Ivy.Tendril/Services/Jobs/JobLauncher.cs`: Injected `PrSignatureText` and `PrSignatureUrl` into CreatePr firmware values.
- `src/Ivy.Tendril/Promptwares/CreatePr/Program.md`: Parameterized PR signature footer to support custom distribution identity.

### Tests
- `src/Ivy.Tendril.Test/AppBrandTests.cs`: Unit tests for `AppBrand` constant values, non-empty assertions, and URL formatting.
- `src/Ivy.Tendril.Test/Services/TelemetryServiceTests.cs`: Unit tests verifying PostHog super properties include `distribution` and `source`.
- `src/Ivy.Tendril.Test/LocalFileGuardMiddlewareTests.cs`: Fixed method signature return type nullability for Release build.

## Manual Testing

1. Run the version command:
   ```bash
   dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj -- version
   ```
   Verify the output displays `Ivy Tendril v...` using the configured `AppBrand.AppName`.

2. Run the test suite:
   ```bash
   dotnet test src/Ivy.Tendril/Ivy.Tendril.slnx --filter "FullyQualifiedName~TelemetryPlanUuidTests|FullyQualifiedName~AppBrandTests|FullyQualifiedName~TelemetryServiceTests"
   ```
   Verify all 16 tests pass.

3. Inspect the Open-Factory repository:
   Visit https://github.com/Ivy-Interactive/Open-Factory and verify both `development` and `main` branches are pushed, `.github/workflows/sync-upstream.yml` is present, and `AppBrand.cs` specifies `Open Factory`.

---
### Commits

- 574ffdb7 Add AppBrand abstraction and debrand application shell and CLI (Plan 00406)
- d8bdc895 Add distribution and source properties to TelemetryService (Plan 00406)
- 8f6f70ce Support brandable PR signature in CreatePr and JobLauncher (Plan 00406)
- ac76e295 Add unit tests for AppBrand and TelemetryService distribution (Plan 00406)
- 031b722d Fix nullability error in LocalFileGuardMiddlewareTests (Plan 00406)

---
Created using [Ivy Tendril](https://ivy.app).