### PR TITLE
[00411] Fix PlanChatTests Failure for Empty Chat Persistence

### DIFF
--- a/src/Ivy.Tendril.Test/PlanChatTests.cs
+++ b/src/Ivy.Tendril.Test/PlanChatTests.cs
@@ -55,6 +55,7 @@ public class PlanChatTests
         {
             var session = service.CreateSession("claude", "opus", "#59 Revamp", planFolderName: "00059-revamp");
             Assert.Equal("00059-revamp", session.PlanFolderName);
+            service.AddMessage(session.Id, "user", "Hello");
 
             var reloaded = new ChatHistoryService(new ConfigService(new TendrilSettings(), tempDir)).GetSession(session.Id);
             Assert.NotNull(reloaded);


### PR DESCRIPTION
# Summary

## Changes

Updated `CreateSession_KeepsThePlanItBelongsToAcrossAReload` in `PlanChatTests.cs` to add a user message before asserting reload from disk. This ensures compatibility with the system invariant that 0-message chat sessions are not persisted to disk.

## API Changes

None.

## Files Modified

- Tests:
  - `src/Ivy.Tendril.Test/PlanChatTests.cs`: Added `service.AddMessage(session.Id, "user", "Hello");` in `CreateSession_KeepsThePlanItBelongsToAcrossAReload`.

## Manual Testing

N/A: internal test suite change with no user-facing behavior. Can be verified by running `dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~PlanChatTests"`.

---
- d029b51d Plan 00411: Add message to PlanChatTests session before disk reload

---
Created using [Ivy Tendril](https://ivy.app).
