### PR TITLE
[00390] Show Context Aware Sample Prompts in Chat

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatSamplePromptsTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatSamplePromptsTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ivy.Tendril.Apps.Chat;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Widgets;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Chat;
+
+public class ChatSamplePromptsTests
+{
+    [Fact]
+    public void ForChat_NamesThePlansWaitingForReview()
+    {
+        var plans = new List<PlanFile>
+        {
+            new() { Id = 101, Title = "Add Login", Status = PlanStatus.Review, Updated = DateTime.UtcNow },
+            new() { Id = 102, Title = "Fix Bug", Status = PlanStatus.Review, Updated = DateTime.UtcNow },
+            new() { Id = 103, Title = "Draft Plan", Status = PlanStatus.Draft, Updated = DateTime.UtcNow },
+        };
+
+        var prompts = SamplePrompts.ForChat(plans, new List<JobItem>());
+
+        var reviewPrompt = prompts.FirstOrDefault(p => p.Label.Contains("Review"));
+        Assert.NotNull(reviewPrompt);
+        Assert.Contains("2 plans", reviewPrompt.Label);
+        Assert.Contains("#101", reviewPrompt.Prompt);
+        Assert.Contains("#102", reviewPrompt.Prompt);
+        Assert.DoesNotContain("#103", reviewPrompt.Prompt);
+    }
+
+    [Fact]
+    public void ForChat_NamesTheNewestFailedPlan()
+    {
+        var older = DateTime.UtcNow.AddHours(-2);
+        var newer = DateTime.UtcNow.AddHours(-1);
+        var plans = new List<PlanFile>
+        {
+            new() { Id = 201, Title = "Old Failed", Status = PlanStatus.Failed, Updated = older },
+            new() { Id = 202, Title = "New Failed", Status = PlanStatus.Failed, Updated = newer },
+        };
+
+        var prompts = SamplePrompts.ForChat(plans, new List<JobItem>());
+
+        var failedPrompt = prompts.FirstOrDefault(p => p.Label.Contains("fail"));
+        Assert.NotNull(failedPrompt);
+        Assert.Contains("#202", failedPrompt.Label);
+        Assert.DoesNotContain("#201", failedPrompt.Label);
+        Assert.Contains("New Failed", failedPrompt.Prompt);
+    }
+
+    [Fact]
+    public void ForChat_ReportsRunningJobs()
+    {
+        var jobs = new List<JobItem>
+        {
+            new() { Id = "job1", Status = JobStatus.Running },
+            new() { Id = "job2", Status = JobStatus.Pending },
+        };
+
+        var prompts = SamplePrompts.ForChat(new List<PlanFile>(), jobs);
+
+        var jobPrompt = prompts.FirstOrDefault(p => p.Label.Contains("jobs"));
+        Assert.NotNull(jobPrompt);
+        Assert.Contains("2 jobs", jobPrompt.Prompt);
+    }
+
+    [Fact]
+    public void ForChat_FallsBackWhenThereIsNoLiveContext()
+    {
+        var prompts = SamplePrompts.ForChat(new List<PlanFile>(), new List<JobItem>());
+
+        Assert.Equal(2, prompts.Count);
+        Assert.Contains(prompts, p => p.Label == "What should I work on next?");
+        Assert.Contains(prompts, p => p.Label == "What shipped this week?");
+    }
+
+    [Fact]
+    public void ForChat_CapsTheListAtFourAndIsDeterministic()
+    {
+        var now = DateTime.UtcNow;
+        var plans = new List<PlanFile>
+        {
+            new() { Id = 1, Title = "Review", Status = PlanStatus.Review, Updated = now },
+            new() { Id = 2, Title = "Failed", Status = PlanStatus.Failed, Updated = now },
+            new() { Id = 3, Title = "Blocked", Status = PlanStatus.Blocked, Updated = now },
+            new() { Id = 4, Title = "Partial", Status = PlanStatus.Draft, PartialDelivery = true, Updated = now },
+        };
+        var jobs = new List<JobItem>
+        {
+            new() { Id = "job1", Status = JobStatus.Running },
+        };
+
+        var prompts1 = SamplePrompts.ForChat(plans, jobs);
+        var prompts2 = SamplePrompts.ForChat(plans, jobs);
+
+        Assert.Equal(SamplePrompts.Max, prompts1.Count);
+        Assert.Equal(prompts1.Select(p => p.Label), prompts2.Select(p => p.Label));
+    }
+
+    [Fact]
+    public void ForPlan_NamesTheFailedVerification()
+    {
+        var plan = new PlanFile
+        {
+            Id = 301,
+            Title = "Test Plan",
+            Verifications = new List<PlanVerificationEntry>
+            {
+                new() { Name = "Build", Status = VerificationStatus.Pass },
+                new() { Name = "Test", Status = VerificationStatus.Fail },
+                new() { Name = "Lint", Status = VerificationStatus.Pending },
+            }
+        };
+
+        var prompts = SamplePrompts.ForPlan(plan);
+
+        var failedPrompt = prompts.FirstOrDefault(p => p.Label.Contains("Test"));
+        Assert.NotNull(failedPrompt);
+        Assert.Contains("Test verification failed", failedPrompt.Prompt);
+    }
+
+    [Fact]
+    public void ForPlan_AsksAboutThePullRequestWhenThePlanHasOne()
+    {
+        var plan = new PlanFile
+        {
+            Id = 401,
+            Title = "PR Plan",
+            Prs = new List<string> { "https://github.com/owner/repo/pull/123" }
+        };
+
+        var prompts = SamplePrompts.ForPlan(plan);
+
+        var prPrompt = prompts.FirstOrDefault(p => p.Label.Contains("PR feedback"));
+        Assert.NotNull(prPrompt);
+        Assert.Contains("https://github.com/owner/repo/pull/123", prPrompt.Prompt);
+    }
+
+    [Fact]
+    public void ForPlan_FallsBackForAFreshDraftPlan()
+    {
+        var plan = new PlanFile
+        {
+            Id = 501,
+            Title = "Draft Plan",
+            Status = PlanStatus.Draft,
+            Verifications = new List<PlanVerificationEntry>()
+        };
+
+        var prompts = SamplePrompts.ForPlan(plan);
+
+        Assert.Contains(prompts, p => p.Label == "Tighten the scope");
+        Assert.Contains(prompts, p => p.Label == "Explain the solution");
+    }
+
+    [Fact]
+    public void ForPlan_ProducesNoDuplicateLabels()
+    {
+        var plan = new PlanFile
+        {
+            Id = 601,
+            Title = "Complex Plan",
+            Status = PlanStatus.Draft,
+            Verifications = new List<PlanVerificationEntry>
+            {
+                new() { Name = "Test", Status = VerificationStatus.Fail },
+            }
+        };
+
+        var prompts = SamplePrompts.ForPlan(plan);
+
+        var labels = prompts.Select(p => p.Label).ToList();
+        Assert.Equal(labels.Count, labels.Distinct().Count());
+    }
+}

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs
@@ -149,6 +149,12 @@ class DemoApp : ViewBase
             StreamingText = streaming.Value ? LiveTurn : null,
             Greeting = "Good Evening, Joel!",
             Headline = "What Are We Producing Today?",
+            SamplePrompts = new List<ChatSamplePromptDto>
+            {
+                new("Review the 3 plans waiting", "3 plans are waiting for review. Summarize what each delivers and tell me which to merge first."),
+                new("What should I work on next?", "Look at my draft plans across all projects and recommend which two to execute next, with reasons."),
+                new("What shipped this week?", "Summarize the plans that reached Completed in the last seven days, grouped by project."),
+            },
             OnSendMessage = e => { client.Toast(e.Value.Prompt, "OnSendMessage").Info(); return ValueTask.CompletedTask; },
             OnCancelStream = _ => { streaming.Set(false); client.Toast("Stream cancelled", "OnCancelStream").Info(); return ValueTask.CompletedTask; },
             OnCreateSession = _ => { activeId.Set(EmptySessionId); client.Toast("New chat", "OnCreateSession").Info(); return ValueTask.CompletedTask; },

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -72,6 +72,10 @@ public record ChatQueuedMessageDto(
     List<ChatAttachmentDto>? Attachments = null
 );
 
+/// <param name="Label">The short chip text, 2 to 6 words.</param>
+/// <param name="Prompt">The complete sentence used when the chip is clicked.</param>
+public record ChatSamplePromptDto(string Label, string Prompt);
+
 public record ChatSendMessageDto(
     string Prompt,
     List<ChatAttachmentDto>? Attachments = null,
@@ -112,6 +116,7 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Prop] public List<ChatJobDto>? RunningJobs { get; init; }
     [Prop] public string? Greeting { get; init; }
     [Prop] public string? Headline { get; init; }
+    [Prop] public List<ChatSamplePromptDto> SamplePrompts { get; init; } = new();
 
     /// <summary>Hosted inside another page (the plan chat panel): no title bar, a tighter composer.</summary>
     [Prop] public bool Embedded { get; init; }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.samplePrompts.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.samplePrompts.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ChatWidget } from "./ChatWidget";
+import { setupChatWidgetTestEnvironment } from "./ChatWidget.test";
+import type { ChatSamplePromptDto, ChatSessionDto } from "./types";
+
+describe("ChatWidget - Sample Prompts", () => {
+  beforeEach(() => {
+    setupChatWidgetTestEnvironment();
+  });
+
+  it("renders one button per sample prompt in the empty state", () => {
+    const samplePrompts: ChatSamplePromptDto[] = [
+      { label: "Review plans", prompt: "Review all the plans waiting for review." },
+      { label: "What's next?", prompt: "What should I work on next?" },
+    ];
+
+    render(
+      <ChatWidget
+        id="test-widget"
+        headline="Test Headline"
+        samplePrompts={samplePrompts}
+        sessions={[]}
+      />
+    );
+
+    const buttons = screen.getAllByRole("button");
+    const promptButtons = buttons.filter((btn) => btn.className.includes("chat-sample-prompt"));
+
+    expect(promptButtons).toHaveLength(2);
+    expect(screen.getByText("Review plans")).toBeInTheDocument();
+    expect(screen.getByText("What's next?")).toBeInTheDocument();
+  });
+
+  it("clicking a chip fills the textarea without sending", async () => {
+    const user = userEvent.setup();
+    const samplePrompts: ChatSamplePromptDto[] = [
+      { label: "Review plans", prompt: "Review all the plans waiting for review." },
+    ];
+
+    const { container } = render(
+      <ChatWidget
+        id="test-widget"
+        headline="Test Headline"
+        samplePrompts={samplePrompts}
+        sessions={[]}
+      />
+    );
+
+    const promptButton = screen.getByText("Review plans");
+    await user.click(promptButton);
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).toHaveValue("Review all the plans waiting for review.");
+  });
+
+  it("renders no container when samplePrompts is empty", () => {
+    const { container } = render(
+      <ChatWidget id="test-widget" headline="Test Headline" sessions={[]} />
+    );
+
+    const promptsContainer = container.querySelector(".chat-sample-prompts");
+    expect(promptsContainer).not.toBeInTheDocument();
+  });
+
+  it("renders no chips once the session has messages", () => {
+    const samplePrompts: ChatSamplePromptDto[] = [
+      { label: "Review plans", prompt: "Review all the plans waiting for review." },
+    ];
+
+    const sessions: ChatSessionDto[] = [
+      {
+        id: "session1",
+        title: "Test Session",
+        agentId: "claude",
+        modelId: "opus",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        messages: [
+          {
+            id: "msg1",
+            role: "user",
+            content: "Hello",
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      },
+    ];
+
+    const { container } = render(
+      <ChatWidget
+        id="test-widget"
+        headline="Test Headline"
+        samplePrompts={samplePrompts}
+        sessions={sessions}
+        activeSessionId="session1"
+      />
+    );
+
+    const promptsContainer = container.querySelector(".chat-sample-prompts");
+    expect(promptsContainer).not.toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.samplePrompts.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.samplePrompts.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { ChatWidget } from "./ChatWidget";
-import { setupChatWidgetTestEnvironment } from "./ChatWidget.test";
+import { setupChatWidgetTestEnvironment } from "./ChatWidget.testUtils";
 import type { ChatSamplePromptDto, ChatSessionDto } from "./types";
 
 describe("ChatWidget - Sample Prompts", () => {
@@ -33,8 +32,7 @@ describe("ChatWidget - Sample Prompts", () => {
     expect(screen.getByText("What's next?")).toBeInTheDocument();
   });
 
-  it("clicking a chip fills the textarea without sending", async () => {
-    const user = userEvent.setup();
+  it("clicking a chip fills the textarea without sending", () => {
     const samplePrompts: ChatSamplePromptDto[] = [
       { label: "Review plans", prompt: "Review all the plans waiting for review." },
     ];
@@ -49,7 +47,7 @@ describe("ChatWidget - Sample Prompts", () => {
     );
 
     const promptButton = screen.getByText("Review plans");
-    await user.click(promptButton);
+    fireEvent.click(promptButton);
 
     const textarea = container.querySelector("textarea");
     expect(textarea).toHaveValue("Review all the plans waiting for review.");

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -150,6 +150,7 @@ export function ChatWidget({
   runningJobs = [],
   greeting,
   headline = "What Are We Producing Today?",
+  samplePrompts = [],
   embedded = false,
   events = [],
   eventHandler,
@@ -499,6 +500,11 @@ export function ChatWidget({
     emit("OnCancelStream");
   };
 
+  const applySamplePrompt = (prompt: string) => {
+    setPromptText(prompt);
+    textareaRef.current?.focus();
+  };
+
   const handleSendQueuedNow = (queueId: string) => {
     const item = queuedMessages.find((q) => q.id === queueId);
     if (!item) return;
@@ -780,6 +786,21 @@ export function ChatWidget({
             <div className="chat-empty-state">
               {greeting && <div className="chat-empty-greeting">{greeting}</div>}
               <div className="chat-empty-headline">{headline}</div>
+              {samplePrompts.length > 0 && (
+                <div className="chat-sample-prompts">
+                  {samplePrompts.map((sp) => (
+                    <button
+                      key={sp.label}
+                      type="button"
+                      className="chat-sample-prompt"
+                      title={sp.prompt}
+                      onClick={() => applySamplePrompt(sp.prompt)}
+                    >
+                      {sp.label}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
           )}
           <div ref={spacerRef} className="chat-scroll-spacer" aria-hidden="true" />

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -497,6 +497,30 @@ button.chat-jobs-dropdown-item:hover .chat-job-nav-icon {
   color: var(--tch-fg);
 }
 
+.chat-sample-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.chat-sample-prompt {
+  padding: 8px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--tch-border);
+  background: var(--tch-bg);
+  color: var(--tch-fg);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.chat-sample-prompt:hover {
+  background: var(--tch-bg-hover);
+  border-color: var(--tch-fg-faint);
+}
+
 .chat-message-row {
   display: flex;
   width: 100%;
@@ -1793,6 +1817,11 @@ button.chat-system-event-plan {
   font-size: 20px;
   font-weight: 500;
   line-height: 26px;
+}
+
+.chat-widget-root[data-embedded="true"] .chat-sample-prompts {
+  flex-wrap: nowrap;
+  overflow-x: auto;
 }
 
 .chat-widget-root[data-embedded="true"] .chat-footer {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
@@ -82,6 +82,11 @@ export interface ChatQueuedMessageDto {
   attachments?: ChatAttachmentDto[];
 }
 
+export interface ChatSamplePromptDto {
+  label: string;
+  prompt: string;
+}
+
 export interface ChatWidgetProps {
   id: string;
   activeSessionId?: string | null;
@@ -104,6 +109,7 @@ export interface ChatWidgetProps {
   /** Shown above the headline while the conversation is empty, e.g. "Good Morning, Joel!". */
   greeting?: string;
   headline?: string;
+  samplePrompts?: ChatSamplePromptDto[];
   /** Hosted inside another page (the plan chat panel): no title bar, a tighter composer. */
   embedded?: boolean;
   events?: string[];

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -351,6 +351,13 @@ public class ChatApp : ViewBase
             },
             id => deletingSessionId.Set(id)));
 
+        var runningChatJobs = jobService?.GetJobs()
+            .Where(j => j.Status is JobStatus.Running or JobStatus.Pending or JobStatus.Queued)
+            .ToList() ?? new List<JobItem>();
+        var samplePrompts = SamplePrompts.ForChat(
+            planService?.GetPlans() ?? new List<PlanFile>(),
+            runningChatJobs);
+
         var content = new ContentView(
             activeSession,
             activeSessionId,
@@ -373,7 +380,8 @@ public class ChatApp : ViewBase
             SendMessage,
             SelectSession,
             StartNewChat,
-            sharedDeletingSessionId: deletingSessionId
+            sharedDeletingSessionId: deletingSessionId,
+            samplePrompts: samplePrompts
         );
 
         return new Fragment(content, searchDialog);

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -38,7 +38,8 @@ public class ContentView(
     Action<string> selectSession,
     Action startNewChat,
     bool embedded = false,
-    IState<string?>? sharedDeletingSessionId = null) : ViewBase
+    IState<string?>? sharedDeletingSessionId = null,
+    List<ChatSamplePromptDto>? samplePrompts = null) : ViewBase
 {
     internal IState<string> SelectedAgentState => selectedAgent;
     internal IState<string> SelectedModelState => selectedModel;
@@ -122,6 +123,7 @@ public class ContentView(
             RunningJobs = runningJobs,
             Greeting = greeting,
             Headline = headline,
+            SamplePrompts = samplePrompts ?? new(),
             Embedded = embedded,
 
             OnSelectSession = e =>

--- a/src/Ivy.Tendril/Apps/Chat/SamplePrompts.cs
+++ b/src/Ivy.Tendril/Apps/Chat/SamplePrompts.cs
@@ -1,0 +1,200 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Widgets;
+
+namespace Ivy.Tendril.Apps.Chat;
+
+internal static class SamplePrompts
+{
+    public const int Max = 4;
+
+    public static List<ChatSamplePromptDto> ForChat(
+        IReadOnlyList<PlanFile> plans,
+        IReadOnlyList<JobItem> runningJobs)
+    {
+        var prompts = new List<ChatSamplePromptDto>();
+        var labels = new HashSet<string>();
+
+        // Rule: any plan in Review
+        var reviewPlans = plans.Where(p => p.Status == PlanStatus.Review).ToList();
+        if (reviewPlans.Count > 0)
+        {
+            var label = $"Review the {reviewPlans.Count} plans waiting";
+            if (labels.Add(label))
+            {
+                var planList = string.Join(", ", reviewPlans.Select(p => $"#{p.Id} {p.Title}"));
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    $"{reviewPlans.Count} plans are waiting for review: {planList}. Summarize what each delivers and tell me which to merge first."));
+            }
+        }
+
+        // Rule: any plan Failed, newest by Updated
+        var failedPlan = plans
+            .Where(p => p.Status == PlanStatus.Failed)
+            .OrderByDescending(p => p.Updated)
+            .FirstOrDefault();
+        if (failedPlan != null)
+        {
+            var label = $"Why did #{failedPlan.Id} fail?";
+            if (labels.Add(label))
+            {
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    $"Plan #{failedPlan.Id} {failedPlan.Title} failed. Read its logs and verification reports and explain what went wrong."));
+            }
+        }
+
+        // Rule: any plan Blocked, newest
+        var blockedPlan = plans
+            .Where(p => p.Status == PlanStatus.Blocked)
+            .OrderByDescending(p => p.Updated)
+            .FirstOrDefault();
+        if (blockedPlan != null)
+        {
+            var label = $"What is blocking #{blockedPlan.Id}?";
+            if (labels.Add(label))
+            {
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    $"Plan #{blockedPlan.Id} {blockedPlan.Title} is blocked. List the plans it depends on and what each one still needs."));
+            }
+        }
+
+        // Rule: runningJobs not empty
+        if (runningJobs.Count > 0)
+        {
+            var label = "What are my jobs doing?";
+            if (labels.Add(label))
+            {
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    $"{runningJobs.Count} jobs are running. Summarize what each one is working on."));
+            }
+        }
+
+        // Rule: any plan with PartialDelivery, newest
+        var partialPlan = plans
+            .Where(p => p.PartialDelivery)
+            .OrderByDescending(p => p.Updated)
+            .FirstOrDefault();
+        if (partialPlan != null)
+        {
+            var label = $"What did #{partialPlan.Id} skip?";
+            if (labels.Add(label))
+            {
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    $"Plan #{partialPlan.Id} {partialPlan.Title} completed over a failed verification. Tell me what it did not deliver."));
+            }
+        }
+
+        // Fallbacks
+        var fallback1 = "What should I work on next?";
+        if (labels.Add(fallback1))
+        {
+            prompts.Add(new ChatSamplePromptDto(
+                fallback1,
+                "Look at my draft plans across all projects and recommend which two to execute next, with reasons."));
+        }
+
+        var fallback2 = "What shipped this week?";
+        if (labels.Add(fallback2))
+        {
+            prompts.Add(new ChatSamplePromptDto(
+                fallback2,
+                "Summarize the plans that reached Completed in the last seven days, grouped by project."));
+        }
+
+        return prompts.Take(Max).ToList();
+    }
+
+    public static List<ChatSamplePromptDto> ForPlan(PlanFile plan)
+    {
+        var prompts = new List<ChatSamplePromptDto>();
+        var labels = new HashSet<string>();
+
+        // Rule: a verification is Fail, first in list order
+        var failedVerification = plan.Verifications
+            .FirstOrDefault(v => v.Status == VerificationStatus.Fail);
+        if (failedVerification != null)
+        {
+            var label = $"Why did {failedVerification.Name} fail?";
+            if (labels.Add(label))
+            {
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    $"The {failedVerification.Name} verification failed for this plan. Read its report in Verification/{failedVerification.Name}.md and explain the failure and how to fix it."));
+            }
+        }
+
+        // Rule: plan.PartialDelivery
+        if (plan.PartialDelivery)
+        {
+            var label = "What is missing?";
+            if (labels.Add(label))
+            {
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    "This plan completed over a failed verification. Tell me what it did not deliver."));
+            }
+        }
+
+        // Rule: plan.Prs not empty
+        if (plan.Prs.Count > 0)
+        {
+            var label = "Summarize the PR feedback";
+            if (labels.Add(label))
+            {
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    $"Read the review comments on {plan.Prs[0]} and list the changes they ask for."));
+            }
+        }
+
+        // Rule: plan.Status is Blocked
+        if (plan.Status == PlanStatus.Blocked)
+        {
+            var label = "What is blocking this?";
+            if (labels.Add(label))
+            {
+                var deps = string.Join(", ", plan.DependsOn);
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    $"This plan is blocked on {deps}. Tell me what each dependency still needs."));
+            }
+        }
+
+        // Rule: plan.Status is Draft
+        if (plan.Status == PlanStatus.Draft)
+        {
+            var label = "Tighten the scope";
+            if (labels.Add(label))
+            {
+                prompts.Add(new ChatSamplePromptDto(
+                    label,
+                    "Read the latest revision of this plan and point out anything out of scope or under specified."));
+            }
+        }
+
+        // Fallbacks
+        var fallback1 = "Explain the solution";
+        if (labels.Add(fallback1))
+        {
+            prompts.Add(new ChatSamplePromptDto(
+                fallback1,
+                "Explain the Solution section of this plan in plain terms, and list every file it will touch."));
+        }
+
+        var fallback2 = "What could go wrong?";
+        if (labels.Add(fallback2))
+        {
+            prompts.Add(new ChatSamplePromptDto(
+                fallback2,
+                "What are the riskiest parts of this plan, and what should I check in review?"));
+        }
+
+        return prompts.Take(Max).ToList();
+    }
+}

--- a/src/Ivy.Tendril/Apps/Views/PlanChatView.cs
+++ b/src/Ivy.Tendril/Apps/Views/PlanChatView.cs
@@ -130,6 +130,8 @@ public class PlanChatView(PlanFile plan) : ViewBase
             streamVersion.Set(v => v + 1);
         }
 
+        var samplePrompts = SamplePrompts.ForPlan(plan);
+
         return new Chat.ContentView(
             session,
             activeSessionId,
@@ -152,7 +154,8 @@ public class PlanChatView(PlanFile plan) : ViewBase
             SendMessage,
             id => activeSessionId.Set(id),
             startNewChat: () => { },
-            embedded: true);
+            embedded: true,
+            samplePrompts: samplePrompts);
 
         string DefaultAgent(ChatSessionModel? sess) =>
             sess?.AgentId ?? configService.Settings.CodingAgent ?? "claude";


### PR DESCRIPTION
Fixes #2510

# Summary

## Changes

Added context-aware sample prompts to the chat widget empty state. When a chat session has no messages, the widget now displays up to 4 clickable prompt chips that suggest relevant questions based on plan status, running jobs, and other system state. Clicking a chip fills the composer without sending, allowing the user to edit before submitting.

## API Changes

- `ChatSamplePromptDto(Label, Prompt)` - New DTO for sample prompt chips
- `ChatWidget.SamplePrompts` - New prop accepting `List<ChatSamplePromptDto>`
- `SamplePrompts.ForChat(plans, jobs)` - Static method generating prompts for standalone Chat app
- `SamplePrompts.ForPlan(plan)` - Static method generating prompts for plan chat panel
- `ContentView` constructor - New optional `samplePrompts` parameter

## Files Modified

**Backend:**
- `src/Ivy.Tendril.Widgets/ChatWidget.cs` - Added DTO and prop
- `src/Ivy.Tendril/Apps/Chat/SamplePrompts.cs` - New builder class
- `src/Ivy.Tendril/Apps/Chat/ContentView.cs` - Added parameter
- `src/Ivy.Tendril/Apps/Chat/ChatApp.cs` - Wired ForChat
- `src/Ivy.Tendril/Apps/Views/PlanChatView.cs` - Wired ForPlan

**Frontend:**
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts` - Added interface
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx` - Rendering and handler
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css` - Chip styling

**Demo:**
- `src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs` - Example prompts

**Tests:**
- `src/Ivy.Tendril.Test/Apps/Chat/ChatSamplePromptsTests.cs` - New backend tests
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.samplePrompts.test.tsx` - New frontend tests

## Manual Testing

1. **Standalone Chat app**: Launch Tendril and open the Chat app. The empty state should show sample prompts like "Review the N plans waiting" or "What should I work on next?" based on your plan state. Click a chip to fill the composer with the prompt text.

2. **Plan chat panel**: Open a plan and click its Chat tab. The empty state should show plan-specific prompts like "Why did X fail?" (if a verification failed) or "Explain the solution". Click a chip to pre-fill the prompt.

3. **Embedded mode**: Verify the plan panel's chips display in a single horizontal scrollable row, not wrapping to multiple lines.

4. **Demo app**: Run the ChatWidget sample app to see the feature in isolation with three hardcoded prompts.
---

## Commits

- `b555891a` Add ChatSamplePromptDto and backend builder
- `cf9df621` Add frontend sample prompts rendering
- `ca12fd8c` Wire sample prompts in chat hosts
- `d8e4a24f` Add sample prompts to ChatWidget demo
- `70d46060` Add tests for sample prompts
- `4befb95c` Fix frontend test imports and remove unused dependencies

---
Created using [Ivy Tendril](https://ivy.app).