### PR TITLE
[00395] Always Offer an Other Option on Every Question

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -214,7 +214,6 @@ questions:                    # 1-4 items
     header:      string       # optional, <=12 char chip label
     description: markdown     # optional, context shown under the question
     multiple:    bool         # optional, default false; true = multi-select
-    other:       bool         # optional, default true; user may type a free value
     options:                  # 2-4 items; omit entirely for a pure free-text question
       - title:       string   # required, 1-5 words
         description: markdown # optional

--- a/src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs
@@ -81,7 +81,6 @@ public class QuestionValidationServiceTests
               - id: q1
                 title: Which auth scheme?
                 header: Auth
-                other: false
                 options:
                   - title: JSON Web Tokens
                     value: jwt
@@ -164,20 +163,7 @@ public class QuestionValidationServiceTests
                     value: something-else
             """);
 
-        Assert.Equal($"question 1: option '{title}' duplicates what other: true provides", message);
-    }
-
-    [Fact]
-    public void Validate_RejectsOtherFalseWithNoOptions()
-    {
-        var message = SingleError("""
-            questions:
-              - id: q1
-                title: Which one?
-                other: false
-            """);
-
-        Assert.Equal("question 1: other: false with no options is unanswerable", message);
+        Assert.Equal($"question 1: option '{title}' duplicates the Other option every question offers", message);
     }
 
     [Fact]
@@ -225,25 +211,6 @@ public class QuestionValidationServiceTests
     }
 
     [Fact]
-    public void Validate_RejectsUnmatchedAnswerWhenOtherIsFalse()
-    {
-        var message = SingleError("""
-            questions:
-              - id: q1
-                title: Which one?
-                other: false
-                options:
-                  - title: First
-                    value: first
-                  - title: Second
-                    value: second
-                answer: third
-            """);
-
-        Assert.Equal("question 1: answer 'third' matches no option and other is false", message);
-    }
-
-    [Fact]
     public void Validate_AllowsUnmatchedAnswerWhenOtherIsTrue()
     {
         Assert.Empty(Validate("""
@@ -257,6 +224,43 @@ public class QuestionValidationServiceTests
                     value: second
                 answer: something the user typed
             """));
+    }
+
+    [Fact]
+    public void Validate_AllowsTypedAnswerWhenOtherIsFalse()
+    {
+        Assert.Empty(Validate("""
+            questions:
+              - id: q1
+                title: Which one?
+                other: false
+                options:
+                  - title: First
+                    value: first
+                  - title: Second
+                    value: second
+                answer: typed answer
+            """));
+    }
+
+    [Fact]
+    public void Validate_WarnsWhenOtherIsFalse()
+    {
+        var issues = Validate("""
+            questions:
+              - id: q1
+                title: Which one?
+                other: false
+                options:
+                  - title: First
+                    value: first
+                  - title: Second
+                    value: second
+            """);
+
+        var issue = Assert.Single(issues);
+        Assert.Equal(QuestionIssueSeverity.Warning, issue.Severity);
+        Assert.Contains("other: false is no longer honoured", issue.Message);
     }
 
     // ---------------------------------------------------------------- schema bounds
@@ -616,7 +620,11 @@ public class QuestionValidationServiceTests
                 title: Fine?
               - id: q2
                 title: Also fine?
-                other: false
+                options:
+                  - title: First
+                    value: same
+                  - title: Second
+                    value: same
             ```
 
             ```questions
@@ -630,7 +638,7 @@ public class QuestionValidationServiceTests
         var issues = QuestionValidationService.Validate(markdown);
 
         Assert.Equal(2, issues.Count);
-        Assert.Equal("block 1: question 2: other: false with no options is unanswerable", issues[0].Message);
+        Assert.Equal("block 1: question 2: duplicate option value 'same'", issues[0].Message);
         Assert.StartsWith("block 2: question 1: header 'WayTooLongHeader'", issues[1].Message);
         Assert.Equal(1, issues[0].Line);
         Assert.Equal(10, issues[1].Line);
@@ -643,7 +651,11 @@ public class QuestionValidationServiceTests
             questions:
               - id: q1
                 title: Which one?
-                other: false
+                options:
+                  - title: First
+                    value: dup
+                  - title: Second
+                    value: dup
             """));
     }
 

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs
@@ -52,7 +52,6 @@ class DemoApp : ViewBase
         ```questions
         - id: proceed
           title: How should we proceed?
-          other: false
           options:
             - title: Open a PR
               description: Open a new Pull Request against development branch.

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
@@ -294,21 +294,21 @@ class QuestionsApp : ViewBase
                          | (Layout.Horizontal().Gap(2)
                             | new Button("Restore Plan").Outline().OnClick(() =>
                             {
-                              markdown.Set(InitialMarkdown);
-                              annotations.Set(DummyAnnotations);
-                              scrollTo.Set((QuestionScrollTarget?)null);
+                                markdown.Set(InitialMarkdown);
+                                annotations.Set(DummyAnnotations);
+                                scrollTo.Set((QuestionScrollTarget?)null);
                             })
                             | new Button("Clear Answers").OnClick(() =>
                             {
-                              // Every answer in the document, including the two it shipped with. Cleared one
-                              // at a time through the same merge the widget's own events use.
-                              var cleared = markdown.Value;
-                              foreach (var answered in QuestionAnswers.Read(cleared).Where(q => q.HasAnswer))
-                                QuestionAnswers.TryApply(cleared, new QuestionAnswer(answered.Id, null), out cleared);
+                                // Every answer in the document, including the two it shipped with. Cleared one
+                                // at a time through the same merge the widget's own events use.
+                                var cleared = markdown.Value;
+                                foreach (var answered in QuestionAnswers.Read(cleared).Where(q => q.HasAnswer))
+                                    QuestionAnswers.TryApply(cleared, new QuestionAnswer(answered.Id, null), out cleared);
 
-                              markdown.Set(cleared);
+                                markdown.Set(cleared);
                             }));
-          
+
 
         return Layout.Horizontal().Height(Size.Full()).RemoveParentPadding()
                | new DraftMarkdownWidget(markdown.Value)

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
@@ -23,9 +23,9 @@ namespace WidgetSamples.Apps.DraftMarkdown;
 ///     <para>
 ///         Between them the four blocks cover the whole schema: a four-question block under the H1
 ///         (the cap, and the scope-level placement the spec asks for), every shape from the shape
-///         table including multi-select over a fixed set, questions that arrive already answered
-///         with a scalar and with a list, one with no <c>header</c>, an optional question, and a
-///         documentation fence that must never become a picker.
+///         table including multi-select, questions that arrive already answered with a scalar and
+///         with a list, one with no <c>header</c>, an optional question, and a documentation fence
+///         that must never become a picker.
 ///     </para>
 /// </summary>
 [App(title: "Questions", icon: Icons.CircleQuestionMark, group: ["DraftMarkdown"])]
@@ -42,7 +42,6 @@ class QuestionsApp : ViewBase
             description: |
               A block placed directly under the H1, which is where a question about the
               plan's overall scope belongs. Four questions is the cap, and they stack.
-            other: false
             options:
               - title: Dispatch only
                 description: The fan-out and the consumers. No settings UI.
@@ -57,9 +56,8 @@ class QuestionsApp : ViewBase
           - id: target-release
             title: Which release should this land in?
             header: Release
-            description: Answered at the kickoff, so it arrives already filled in — this is
+            description: Answered at the kickoff, so it arrives already filled in, this is
               what a revision looks like after UpdatePlan has folded a decision back in.
-            other: false
             options:
               # Quoted, or YAML reads them as numbers. The renderer coerces either way, but a
               # sample should model the authoring the schema actually asks for.
@@ -72,9 +70,8 @@ class QuestionsApp : ViewBase
           - id: rollout-regions
             title: Which regions ship first?
             multiple: true
-            other: false
-            description: Multi-select over a fixed set — the third shape from the schema's
-              table, and the only one the other blocks below do not cover.
+            description: Multi-select, the third shape from the schema's table, and the only one
+              the other blocks below do not cover.
             options:
               - title: EU
                 value: eu
@@ -108,8 +105,7 @@ class QuestionsApp : ViewBase
           - id: retry-scope
             title: Should the retry budget be per-request or per-session?
             header: Retry scope
-            description: A **fixed** set — one of these three, no free text.
-            other: false
+            description: A question with three options and rich descriptions.
             options:
               - title: Per request
                 description: |

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsEditingApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsEditingApp.cs
@@ -34,7 +34,6 @@ class QuestionsEditingApp : ViewBase
           - id: retry-scope
             title: Should the retry budget be per-request or per-session?
             header: Retry scope
-            other: false
             options:
               - title: Per request
                 value: per-request

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsReviewApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsReviewApp.cs
@@ -39,7 +39,6 @@ class QuestionsReviewApp : ViewBase
             header: Scope
             description: Answered in the kickoff, so the answer shows as the option's title
               rather than the `dispatch` slug the YAML actually carries.
-            other: false
             options:
               - title: Dispatch only
                 description: |
@@ -59,7 +58,6 @@ class QuestionsReviewApp : ViewBase
             header: Regions
             description: A multi-select answer lists every value it carries.
             multiple: true
-            other: false
             options:
               - title: EU
                 value: eu

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/TendrilQuestions/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/TendrilQuestions/DemoApp.cs
@@ -11,7 +11,6 @@ class DemoApp : ViewBase
     private const string SingleSelect = """
         - id: proceed
           title: How should we proceed?
-          other: false
           options:
             - title: Open a PR
               description: Open a new Pull Request against development branch.

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
@@ -388,12 +388,11 @@ describe("DraftMarkdown interactive questions", () => {
     expect(container.querySelector(".tq-question-optional")).toBeNull();
   });
 
-  it("renders no Other row when other is false", () => {
+  it("renders Other row even when other is false", () => {
     const { container } = renderInteractive(SINGLE_NO_OTHER);
 
-    expect(container.querySelector(".tq-option--other")).toBeNull();
-    expect(container.querySelector(".tq-text-input")).toBeNull();
-    expect(container.querySelectorAll(".tq-option")).toHaveLength(2);
+    expect(container.querySelector(".tq-option--other")).not.toBeNull();
+    expect(container.querySelectorAll(".tq-option")).toHaveLength(3);
   });
 
   it("renders a free-text input and no options for a question with no options", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSchema.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSchema.ts
@@ -24,7 +24,7 @@ export interface PlanQuestion {
   description?: string;
   /** True when several options may be selected. Answers are then always a list. */
   multiple: boolean;
-  /** Whether the user may type a value of their own. Defaults to true, per the schema. */
+  /** Retired. Accepted only so revisions written before retirement still deserialize. No behavior depends on it. */
   other: boolean;
   /**
    * Whether the plan is complete without an answer. Worth asking, not worth blocking on — an index
@@ -292,7 +292,7 @@ export function parseQuestions(body: string): ParsedQuestions {
       header: optionalString(entry.header),
       description: optionalString(entry.description),
       multiple: entry.multiple === true,
-      other: entry.other !== false,
+      other: entry.other !== false, // Retired key, kept for back-compat
       optional: entry.optional === true,
       options: readOptions(entry.options),
       answer: entry.answer,

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/QuestionsForm.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/QuestionsForm.tsx
@@ -186,7 +186,8 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
           />
         ))}
 
-        {hasOptions && question.other && (
+        {/* Every question with options offers a typed answer. */}
+        {hasOptions && (
           <div
             className="tq-option tq-option--other"
             data-selected={otherActive}

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/TendrilQuestions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/TendrilQuestions.test.tsx
@@ -76,8 +76,8 @@ describe("TendrilQuestions widget", () => {
     expect(screen.getByText("How should we proceed?")).toBeInTheDocument();
     expect(screen.getByText("Open a new Pull Request against development branch.")).toBeInTheDocument();
     expect(screen.getByText("Recommended")).toBeInTheDocument();
-    expect(screen.getAllByRole("radio")).toHaveLength(2);
-    expect(screen.queryByRole("radio", { name: /^Other$/i })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(3);
+    expect(screen.getByRole("radio", { name: /^Other$/i })).toBeInTheDocument();
   });
 
   it("selects an option on card click and reports it through OnAnswer", () => {

--- a/src/Ivy.Tendril/Models/QuestionModels.cs
+++ b/src/Ivy.Tendril/Models/QuestionModels.cs
@@ -60,7 +60,10 @@ public record PlanQuestion
     /// <summary>True when several options may be selected. Answers are then always a list.</summary>
     public bool Multiple { get; init; }
 
-    /// <summary>Whether the user may type a value of their own. Defaults to true, per the schema.</summary>
+    /// <summary>
+    ///     Retired. Accepted only so revisions written before retirement still deserialize.
+    ///     No behavior depends on it. Every question with options now offers a typed answer.
+    /// </summary>
     public bool Other { get; init; } = true;
 
     /// <summary>

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -321,7 +321,6 @@ questions:
     header: Optional Eyebrow   # optional <=12 char label
     description: Optional explanation of why you're asking
     multiple: false            # true for multi-select, false for single-select
-    other: true                # true if user may type custom text
     options:                   # 2-4 selectable options
       - title: Option Title
         description: Markdown details explaining this option

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -312,7 +312,6 @@ questions:                    # 1-4 items
     header:      string       # optional, <=12 char label shown as an eyebrow above the title
     description: markdown     # optional, block markdown shown under the question
     multiple:    bool         # optional, default false; true = multi-select
-    other:       bool         # optional, default true; user may type a free value
     optional:    bool         # optional, default false; true = answering is not expected
     options:                  # 2-4 items; omit entirely for a pure free-text question
       - title:       string   # required, 1-5 words
@@ -391,19 +390,20 @@ questions:
 Use a `|` block scalar for any description spanning more than one line, so blank lines and
 indentation survive YAML parsing intact. Always quote `title`, `header`, and `description` values when they contain colons (`:`), quotes, or code snippets (e.g. `title: "Option: SQLite"` or `description: "Uses `key: val` syntax"`).
 
-Three shapes fall out of `multiple` / `other` / the presence of `options`:
+A question with options always renders an Other field for a typed answer.
+
+Three shapes fall out of `multiple` and the presence of `options`:
 
 | Shape | How |
 |---|---|
-| Single-select, fixed set | `other: false` plus options |
-| Multi-select, open set | `multiple: true` plus options |
+| Single-select | options |
+| Multi-select | `multiple: true` plus options |
 | Pure free text | no options at all |
 
 ### Answer semantics
 
 - An entry that matches an option's `value` is that option.
-- An entry that matches nothing is the user's own text. Legal when `other` is true, or when there are
-  no options.
+- An entry that matches nothing is the user's own text.
 - `multiple: true` means `answer` is always a list, even with one selection.
 - `answer` absent means not yet answered. UpdatePlan carries the block forward unchanged.
 - There is no third state. `answer` is either absent or a value — **never `null`**. A question that
@@ -438,11 +438,9 @@ revision does not consume a revision number. Fix the reported lines and retry.
 | Every question has a non-empty `id` | `question N: id is required` |
 | `id` unique across the whole revision, blocks included | `question N: duplicate question id '<id>'` |
 | At most one `recommended: true` per question | `question N: more than one option is recommended` |
-| No hand-authored option titled "Other", "Something else", "Custom" | `question N: option '<title>' duplicates what other: true provides` |
-| `other: false` with no options | `question N: other: false with no options is unanswerable` |
+| No hand-authored option titled "Other", "Something else", "Custom" | `question N: option '<title>' duplicates the Other option every question offers` |
 | `answer` is a list iff `multiple: true` | `question N: multiple: true requires a list answer` / `question N: answer must be a scalar when multiple is false` |
 | `value` unique within a question | `question N: duplicate option value '<value>'` |
-| `other: false` and an answer entry matches no option value | `question N: answer '<entry>' matches no option and other is false` |
 | `answer` is present but null | `question N: answer: null is not a state; omit the key, or mark the question optional` |
 
 Schema bounds are enforced too: 1-4 questions, a required `id` and `title`, a `header` of at most 12

--- a/src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs
+++ b/src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs
@@ -190,4 +190,7 @@ public static class QuestionValidationService
 
     private static QuestionIssue Error(int line, string message) =>
         new(QuestionIssueSeverity.Error, line, message);
+
+    private static QuestionIssue Warning(int line, string message) =>
+        new(QuestionIssueSeverity.Warning, line, message);
 }

--- a/src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs
+++ b/src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs
@@ -33,7 +33,7 @@ public static class QuestionValidationService
 {
     private static readonly Regex SlugRegex = new("^[a-z0-9][a-z0-9-]*$", RegexOptions.Compiled);
 
-    /// <summary>Titles that restate what <c>other: true</c> already provides.</summary>
+    /// <summary>Titles that duplicate the Other option every question offers.</summary>
     private static readonly string[] ReservedOptionTitles = ["Other", "Something else", "Custom"];
 
     private const int MaxQuestionsPerBlock = 4;
@@ -113,11 +113,13 @@ public static class QuestionValidationService
         if (question.Header is { } header && header.Length > MaxHeaderLength)
             issues.Add(Error(line, prefix + $"header '{header}' is {header.Length} characters; at most {MaxHeaderLength} are allowed"));
 
+        if (!question.Other)
+            issues.Add(Warning(line, prefix + "other: false is no longer honoured; every question offers a typed answer"));
+
         var options = question.Options;
         if (options is null || options.Count == 0)
         {
-            if (!question.Other)
-                issues.Add(Error(line, prefix + "other: false with no options is unanswerable"));
+            // Pure free text
         }
         else
         {
@@ -143,7 +145,7 @@ public static class QuestionValidationService
             if (string.IsNullOrWhiteSpace(option.Title))
                 issues.Add(Error(line, prefix + "option title is required"));
             else if (ReservedOptionTitles.Contains(option.Title.Trim(), StringComparer.OrdinalIgnoreCase))
-                issues.Add(Error(line, prefix + $"option '{option.Title}' duplicates what other: true provides"));
+                issues.Add(Error(line, prefix + $"option '{option.Title}' duplicates the Other option every question offers"));
 
             if (string.IsNullOrWhiteSpace(option.Value))
                 issues.Add(Error(line, prefix + $"option '{option.Title}' is missing a value"));
@@ -183,15 +185,6 @@ public static class QuestionValidationService
         else if (!question.Multiple && question.AnswerIsList)
         {
             issues.Add(Error(line, prefix + "answer must be a scalar when multiple is false"));
-        }
-
-        if (question.Other || question.Options is not { Count: > 0 } options)
-            return;
-
-        foreach (var entry in question.AnswerValues)
-        {
-            if (!options.Any(o => string.Equals(o.Value, entry, StringComparison.Ordinal)))
-                issues.Add(Error(line, prefix + $"answer '{entry}' matches no option and other is false"));
         }
     }
 


### PR DESCRIPTION
Fixes #2547

# Summary

## Changes

Retired the `other` question field. Every question with options now renders an Other field for typed answers. The field remains parseable for backward compatibility with existing revisions but has no effect on behavior.

## API Changes

**Modified:**
- `PlanQuestion.Other` property - Now ignored; kept only for backward compatibility
- `QuestionValidationService.Validate()` - No longer validates `other: false` constraints; emits warning instead

**Removed validation rules:**
- "other: false with no options is unanswerable"
- "answer matches no option and other is false"

## Files Modified

**Core implementation:**
- src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/QuestionsForm.tsx
- src/Ivy.Tendril/Models/QuestionModels.cs
- src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSchema.ts
- src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs

**Documentation:**
- src/Ivy.Tendril/Prompts/Plans.md
- src/Ivy.Tendril/Prompts/AgentPrompt.md
- src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md

**Samples:**
- src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
- src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsEditingApp.cs
- src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsReviewApp.cs
- src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs
- src/Ivy.Tendril.Widgets/.samples/Apps/TendrilQuestions/DemoApp.cs

**Tests:**
- src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/TendrilQuestions.test.tsx
- src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
- src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs
- src/Ivy.Tendril.Test/QuestionAnswersTests.cs
- src/Ivy.Tendril.Test/RevisionWriterTests.cs

## Manual Testing

1. Launch the Widgets samples app
2. Navigate to the Questions sample
3. Observe that every question block with options now displays an "Other" option at the bottom
4. Click the Other option and verify you can type a custom answer
5. For questions with `other: false` in older revisions, verify the Other option still appears (backward compatibility)
6. Verify that `tendril plan write-revision` emits a warning (not an error) when encountering `other: false`

---

## Commits
- Add Warning helper method for QuestionValidationService (2edec962)
- Fix formatting in QuestionsApp.cs (5144a768)
- Retire the 'other' question field (c78430a4)

---
Created using [Ivy Tendril](https://ivy.app).
