### PR TITLE
[00415] Auto-Detect Git Root for Ad-Hoc Projects

### DIFF
--- a/src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs
@@ -110,6 +110,64 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
+    public void ResolveGitRoot_WhenDirectoryInsideGitRepo_ReturnsRepoRoot()
+    {
+        var repoDir = Path.Combine(_tempDir, "git-repo");
+        Directory.CreateDirectory(repoDir);
+        var gitDir = Path.Combine(repoDir, ".git");
+        Directory.CreateDirectory(gitDir);
+
+        var subDir = Path.Combine(repoDir, "src", "Nested", "Folder");
+        Directory.CreateDirectory(subDir);
+
+        var resultFromSub = GitHelper.ResolveGitRoot(subDir);
+        Assert.Equal(Path.GetFullPath(repoDir), resultFromSub);
+
+        var resultFromRoot = GitHelper.ResolveGitRoot(repoDir);
+        Assert.Equal(Path.GetFullPath(repoDir), resultFromRoot);
+    }
+
+    [Fact]
+    public void ResolveGitRoot_WhenDirectoryInWorktree_ReturnsWorktreeRoot()
+    {
+        var wtDir = Path.Combine(_tempDir, "worktree-root");
+        Directory.CreateDirectory(wtDir);
+        File.WriteAllText(Path.Combine(wtDir, ".git"), "gitdir: /some/path/.git/worktrees/wt");
+
+        var subDir = Path.Combine(wtDir, "sub", "dir");
+        Directory.CreateDirectory(subDir);
+
+        var result = GitHelper.ResolveGitRoot(subDir);
+        Assert.Equal(Path.GetFullPath(wtDir), result);
+    }
+
+    [Fact]
+    public void ResolveGitRoot_WhenDirectoryOutsideGitRepo_ReturnsNull()
+    {
+        var standaloneDir = Path.Combine(_tempDir, "standalone");
+        Directory.CreateDirectory(standaloneDir);
+
+        var result = GitHelper.ResolveGitRoot(standaloneDir);
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveGitRoot_WhenNullOrWhitespace_ReturnsNull(string? path)
+    {
+        Assert.Null(GitHelper.ResolveGitRoot(path));
+    }
+
+    [Fact]
+    public void ResolveGitRoot_WhenDirectoryDoesNotExist_ReturnsNull()
+    {
+        var nonExistent = Path.Combine(_tempDir, "nonexistent-" + Guid.NewGuid().ToString("N"));
+        Assert.Null(GitHelper.ResolveGitRoot(nonExistent));
+    }
+
+    [Fact]
     public async Task IsValidBranchAsync_InvalidArgs_ReturnsFalse()
     {
         Assert.False(await GitHelper.IsValidBranchAsync("", "main"));

--- a/src/Ivy.Tendril.Test/Helpers/PlanProjectResolverTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PlanProjectResolverTests.cs
@@ -53,6 +53,65 @@ public class PlanProjectResolverTests
     }
 
     [Fact]
+    public void Resolves_AdHoc_Project_To_Git_Root_When_Subfolder_Provided()
+    {
+        var rootDir = Path.Combine(Path.GetTempPath(), $"tendril-test-adhoc-root-{Guid.NewGuid():N}");
+        var gitDir = Path.Combine(rootDir, ".git");
+        var subDir = Path.Combine(rootDir, "src", "MyModule");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(subDir);
+
+        try
+        {
+            var available = new List<ProjectConfig>
+            {
+                ConfiguredProject("OtherProject", @"/repos/other")
+            };
+
+            var resolved = PlanProjectResolver.ResolveProject(subDir, available);
+
+            Assert.Equal(Path.GetFileName(rootDir), resolved.Name);
+            Assert.Single(resolved.Repos);
+            Assert.Equal(Path.GetFullPath(rootDir), resolved.Repos[0].Path);
+            Assert.True(resolved.IsAdHoc);
+            Assert.True(resolved.Meta.TryGetValue("targetPath", out var targetPath));
+            Assert.Equal(Path.GetFullPath(subDir), targetPath?.ToString());
+        }
+        finally
+        {
+            if (Directory.Exists(rootDir))
+                Directory.Delete(rootDir, true);
+        }
+    }
+
+    [Fact]
+    public void Resolves_Configured_Project_When_Subfolder_Belongs_To_Configured_Repo()
+    {
+        var repoDir = Path.Combine(Path.GetTempPath(), $"tendril-test-conf-repo-{Guid.NewGuid():N}");
+        var gitDir = Path.Combine(repoDir, ".git");
+        var subDir = Path.Combine(repoDir, "src", "NestedPackage");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(subDir);
+
+        try
+        {
+            var configured = ConfiguredProject("ExistingProject", repoDir);
+            var available = new List<ProjectConfig> { configured };
+
+            var resolved = PlanProjectResolver.ResolveProject(subDir, available);
+
+            Assert.Same(configured, resolved);
+            Assert.Equal("ExistingProject", resolved.Name);
+            Assert.False(resolved.IsAdHoc);
+        }
+        finally
+        {
+            if (Directory.Exists(repoDir))
+                Directory.Delete(repoDir, true);
+        }
+    }
+
+    [Fact]
     public void Throws_When_Project_Not_Found_And_Path_Does_Not_Exist()
     {
         var available = new List<ProjectConfig>

--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -157,6 +157,51 @@ public static class GitHelper
         }
     }
 
+    /// <summary>
+    /// Resolves the Git repository root directory for a given path.
+    /// Traverses upward looking for a .git directory or file, falling back to git rev-parse --show-toplevel.
+    /// Returns null if the path does not exist or is not within a Git repository.
+    /// </summary>
+    public static string? ResolveGitRoot(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        if (!Directory.Exists(path))
+            return null;
+
+        try
+        {
+            var dir = new DirectoryInfo(path);
+            while (dir != null)
+            {
+                var gitPath = Path.Combine(dir.FullName, ".git");
+                if (Directory.Exists(gitPath) || File.Exists(gitPath))
+                {
+                    return dir.FullName;
+                }
+
+                dir = dir.Parent;
+            }
+
+            var toplevel = RunGitCapture(path, "rev-parse --show-toplevel", 5000);
+            if (!string.IsNullOrWhiteSpace(toplevel))
+            {
+                var trimmed = toplevel.Trim();
+                if (Directory.Exists(trimmed))
+                {
+                    return Path.GetFullPath(trimmed);
+                }
+            }
+        }
+        catch
+        {
+            // Best effort root resolution
+        }
+
+        return null;
+    }
+
     public static string? ResolveRepoRootFromWorktree(string wtDir)
     {
         var gitFile = Path.Combine(wtDir, ".git");

--- a/src/Ivy.Tendril/Helpers/PlanProjectResolver.cs
+++ b/src/Ivy.Tendril/Helpers/PlanProjectResolver.cs
@@ -23,17 +23,37 @@ public static class PlanProjectResolver
             if (Directory.Exists(projectName))
             {
                 var fullPath = Path.GetFullPath(projectName);
-                var folderName = Path.GetFileName(fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                var gitRoot = GitHelper.ResolveGitRoot(fullPath);
+                var targetRepoPath = gitRoot ?? fullPath;
+
+                if (gitRoot != null)
+                {
+                    var normalizedGitRoot = NormalizeLocalPath(gitRoot);
+                    var matchingProject = available.FirstOrDefault(p =>
+                        p.Repos.Any(r => !string.IsNullOrWhiteSpace(r.Path) &&
+                                         string.Equals(NormalizeLocalPath(r.Path), normalizedGitRoot, StringComparison.OrdinalIgnoreCase)));
+
+                    if (matchingProject != null)
+                    {
+                        return matchingProject;
+                    }
+                }
+
+                var folderName = Path.GetFileName(targetRepoPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
                 if (string.IsNullOrEmpty(folderName))
                 {
-                    folderName = fullPath;
+                    folderName = targetRepoPath;
                 }
 
                 return new ProjectConfig
                 {
                     Name = folderName,
-                    Repos = [new RepoRef { Path = fullPath }],
-                    Meta = new Dictionary<string, object> { ["adhoc"] = true }
+                    Repos = [new RepoRef { Path = targetRepoPath }],
+                    Meta = new Dictionary<string, object>
+                    {
+                        ["adhoc"] = true,
+                        ["targetPath"] = fullPath
+                    }
                 };
             }
 
@@ -44,5 +64,18 @@ public static class PlanProjectResolver
             throw new ArgumentException($"Project '{project.Name}' has no repos configured.");
 
         return project;
+    }
+
+    private static string NormalizeLocalPath(string path)
+    {
+        try
+        {
+            var expanded = Environment.ExpandEnvironmentVariables(path);
+            return Path.GetFullPath(expanded).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+        catch
+        {
+            return path.TrimEnd('/', '\\');
+        }
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added Git repository root detection in `GitHelper.ResolveGitRoot` and integrated it into `PlanProjectResolver.ResolveProject`. When a caller provides a subfolder path within a Git repository, Tendril now automatically resolves the top-level repository root so that repository references, worktree operations, and git commands target the repository root. Furthermore, if the detected Git root corresponds to an already configured project, `PlanProjectResolver` now returns that configured project so the plan inherits all configured verifications, review actions, and settings.

## API Changes

- Added `public static string? ResolveGitRoot(string? path)` to `Ivy.Tendril.Helpers.GitHelper`.

## Files Modified

- `src/Ivy.Tendril/Helpers/GitHelper.cs`: Added `ResolveGitRoot` with upward filesystem traversal checking for `.git` directories and worktree pointer files, falling back to `git rev-parse --show-toplevel`.
- `src/Ivy.Tendril/Helpers/PlanProjectResolver.cs`: Updated `ResolveProject` to resolve Git roots, match configured projects by repo path, and derive ad-hoc project metadata (`targetPath`).
- `src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs`: Added unit tests covering Git repository root resolution across nested subdirectories, worktrees, and non-Git folders.
- `src/Ivy.Tendril.Test/Helpers/PlanProjectResolverTests.cs`: Added unit tests covering Git root resolution for ad-hoc projects and matching configured projects from subfolder paths.

## Manual Testing

1. Open a terminal and run `tendril plan create "Test Subfolder" src/Ivy.Tendril`.
2. Inspect the created plan with `tendril plan get <id>`.
3. Observe that the project is resolved to the configured `ivy-tendril` project (inheriting its verifications) and `repos` points to `/Users/rorychatt/git/ivy-tendril` instead of the subfolder.
4. Run `tendril plan create "Test Outside" /tmp`.
5. Observe that it creates an ad-hoc project whose repository path is `/tmp` (or its resolved Git root if `/tmp` is in a repo).

---

- 40658368 Plan 00415: Auto-detect git root for ad-hoc projects and match configured projects

---
Created using [Ivy Tendril](https://ivy.app).
