### PR TITLE
[00420] Prevent Navigating to Closed or Deleted Plans from Chat Jobs Badge

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs
@@ -1,6 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Ivy.Tendril.Apps.Chat;
+using Ivy.Tendril.Apps.Icebox;
+using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Apps.Review;
+using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Widgets;
@@ -110,26 +115,204 @@ public class ChatAppSidebarListTests
     [Fact]
     public void ToJobDto_ResolvesHumanReadablePlanTitle_WhenPlanServiceIsProvided()
     {
-        var metadata = new PlanMetadata(
-            1579, "test-project", "Feature", "Human Readable Plan Title", PlanStatus.Executing,
-            [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
-        var planFile = new PlanFile(metadata, "", "/tmp/01579-TestPlan", "");
-        var planService = new FakePlanReaderService
+        var tempFolder = Path.Combine(Path.GetTempPath(), "01579-TestPlan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempFolder);
+        try
         {
-            Plans = [planFile]
-        };
+            var metadata = new PlanMetadata(
+                1579, "test-project", "Feature", "Human Readable Plan Title", PlanStatus.Executing,
+                [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+            var planFile = new PlanFile(metadata, "", tempFolder, "");
+            var planService = new FakePlanReaderService
+            {
+                Plans = [planFile]
+            };
+            var job = new JobItem
+            {
+                Id = "00151",
+                Type = Constants.JobTypes.ExecutePlan,
+                Status = JobStatus.Running,
+                PlanFile = Path.GetFileName(tempFolder)
+            };
+
+            var dto = ChatApp.ToJobDto(job, planService);
+
+            Assert.Equal("01579", dto.PlanId);
+            Assert.Equal("Human Readable Plan Title", dto.PlanTitle);
+        }
+        finally
+        {
+            if (Directory.Exists(tempFolder)) Directory.Delete(tempFolder);
+        }
+    }
+
+    [Fact]
+    public void ToJobDto_ClearsPlanId_WhenPlanIsCompleted()
+    {
+        var tempFolder = Path.Combine(Path.GetTempPath(), "01580-CompletedPlan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempFolder);
+        try
+        {
+            var metadata = new PlanMetadata(
+                1580, "test-project", "Feature", "Completed Plan Title", PlanStatus.Completed,
+                [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+            var planFile = new PlanFile(metadata, "", tempFolder, "");
+            var planService = new FakePlanReaderService { Plans = [planFile] };
+            var job = new JobItem
+            {
+                Id = "00152",
+                Type = Constants.JobTypes.ExecutePlan,
+                Status = JobStatus.Completed,
+                PlanFile = Path.GetFileName(tempFolder)
+            };
+
+            var dto = ChatApp.ToJobDto(job, planService);
+
+            Assert.Null(dto.PlanId);
+            Assert.Equal("Completed Plan Title", dto.PlanTitle);
+        }
+        finally
+        {
+            if (Directory.Exists(tempFolder)) Directory.Delete(tempFolder);
+        }
+    }
+
+    [Fact]
+    public void ToJobDto_ClearsPlanId_WhenPlanIsSkipped()
+    {
+        var tempFolder = Path.Combine(Path.GetTempPath(), "01581-SkippedPlan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempFolder);
+        try
+        {
+            var metadata = new PlanMetadata(
+                1581, "test-project", "Feature", "Skipped Plan Title", PlanStatus.Skipped,
+                [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+            var planFile = new PlanFile(metadata, "", tempFolder, "");
+            var planService = new FakePlanReaderService { Plans = [planFile] };
+            var job = new JobItem
+            {
+                Id = "00153",
+                Type = Constants.JobTypes.ExecutePlan,
+                Status = JobStatus.Completed,
+                PlanFile = Path.GetFileName(tempFolder)
+            };
+
+            var dto = ChatApp.ToJobDto(job, planService);
+
+            Assert.Null(dto.PlanId);
+            Assert.Equal("Skipped Plan Title", dto.PlanTitle);
+        }
+        finally
+        {
+            if (Directory.Exists(tempFolder)) Directory.Delete(tempFolder);
+        }
+    }
+
+    [Fact]
+    public void ToJobDto_ClearsPlanId_WhenPlanDoesNotExist()
+    {
+        var planService = new FakePlanReaderService { Plans = [] };
         var job = new JobItem
         {
-            Id = "00151",
+            Id = "00154",
             Type = Constants.JobTypes.ExecutePlan,
             Status = JobStatus.Running,
-            PlanFile = "01579-TestPlan"
+            PlanFile = "01582-MissingPlan"
         };
 
         var dto = ChatApp.ToJobDto(job, planService);
 
-        Assert.Equal("01579", dto.PlanId);
-        Assert.Equal("Human Readable Plan Title", dto.PlanTitle);
+        Assert.Null(dto.PlanId);
+        Assert.Equal("MissingPlan", dto.PlanTitle);
+    }
+
+    [Fact]
+    public void ToJobDto_ClearsPlanId_WhenPlanFolderMissingOnDisk()
+    {
+        var nonExistentFolder = Path.Combine(Path.GetTempPath(), "non-existent-" + Guid.NewGuid().ToString("N"));
+        var metadata = new PlanMetadata(
+            1583, "test-project", "Feature", "Missing Folder Plan", PlanStatus.Draft,
+            [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+        var planFile = new PlanFile(metadata, "", nonExistentFolder, "");
+        var planService = new FakePlanReaderService { Plans = [planFile] };
+        var job = new JobItem
+        {
+            Id = "00155",
+            Type = Constants.JobTypes.ExecutePlan,
+            Status = JobStatus.Running,
+            PlanFile = Path.GetFileName(nonExistentFolder)
+        };
+
+        var dto = ChatApp.ToJobDto(job, planService);
+
+        Assert.Null(dto.PlanId);
+        Assert.Equal("Missing Folder Plan", dto.PlanTitle);
+    }
+
+    [Theory]
+    [InlineData(PlanStatus.Draft)]
+    [InlineData(PlanStatus.Review)]
+    [InlineData(PlanStatus.Failed)]
+    public void ToJobDto_RetainsPlanId_WhenPlanIsDraftOrReview(PlanStatus status)
+    {
+        var tempFolder = Path.Combine(Path.GetTempPath(), "01584-ActivePlan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempFolder);
+        try
+        {
+            var metadata = new PlanMetadata(
+                1584, "test-project", "Feature", "Active Plan Title", status,
+                [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+            var planFile = new PlanFile(metadata, "", tempFolder, "");
+            var planService = new FakePlanReaderService { Plans = [planFile] };
+            var job = new JobItem
+            {
+                Id = "00156",
+                Type = Constants.JobTypes.ExecutePlan,
+                Status = JobStatus.Running,
+                PlanFile = Path.GetFileName(tempFolder)
+            };
+
+            var dto = ChatApp.ToJobDto(job, planService);
+
+            Assert.Equal("01584", dto.PlanId);
+            Assert.Equal("Active Plan Title", dto.PlanTitle);
+        }
+        finally
+        {
+            if (Directory.Exists(tempFolder)) Directory.Delete(tempFolder);
+        }
+    }
+
+    [Fact]
+    public void ResolveTarget_ReturnsNull_ForCompletedAndSkippedPlans()
+    {
+        PlanFile CreateTestPlan(PlanStatus status, string folder = "01585-TargetPlan") =>
+            new(new PlanMetadata(1585, "test", "Feature", "Target Plan", status, [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null),
+                "", "/tmp/" + folder, "");
+
+        Assert.Null(PlanSearchDialog.ResolveTarget(CreateTestPlan(PlanStatus.Completed)));
+        Assert.Null(PlanSearchDialog.ResolveTarget(CreateTestPlan(PlanStatus.Skipped)));
+
+        var draftTarget = PlanSearchDialog.ResolveTarget(CreateTestPlan(PlanStatus.Draft));
+        Assert.NotNull(draftTarget);
+        Assert.Equal(typeof(PlansApp), draftTarget.Value.App);
+
+        var blockedTarget = PlanSearchDialog.ResolveTarget(CreateTestPlan(PlanStatus.Blocked));
+        Assert.NotNull(blockedTarget);
+        Assert.Equal(typeof(PlansApp), blockedTarget.Value.App);
+
+        var reviewTarget = PlanSearchDialog.ResolveTarget(CreateTestPlan(PlanStatus.Review));
+        Assert.NotNull(reviewTarget);
+        Assert.Equal(typeof(ReviewApp), reviewTarget.Value.App);
+
+        var failedTarget = PlanSearchDialog.ResolveTarget(CreateTestPlan(PlanStatus.Failed));
+        Assert.NotNull(failedTarget);
+        Assert.Equal(typeof(ReviewApp), failedTarget.Value.App);
+
+        var iceboxTarget = PlanSearchDialog.ResolveTarget(CreateTestPlan(PlanStatus.Icebox));
+        Assert.NotNull(iceboxTarget);
+        Assert.Equal(typeof(IceboxApp), iceboxTarget.Value.App);
+        Assert.Null(iceboxTarget.Value.Args);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatSamplePromptsTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatSamplePromptsTests.cs
@@ -13,11 +13,12 @@ public class ChatSamplePromptsTests
     [Fact]
     public void ForChat_NamesThePlansWaitingForReview()
     {
+        var now = DateTime.UtcNow;
         var plans = new List<PlanFile>
         {
-            new() { Id = 101, Title = "Add Login", Status = PlanStatus.Review, Updated = DateTime.UtcNow },
-            new() { Id = 102, Title = "Fix Bug", Status = PlanStatus.Review, Updated = DateTime.UtcNow },
-            new() { Id = 103, Title = "Draft Plan", Status = PlanStatus.Draft, Updated = DateTime.UtcNow },
+            CreatePlanFile(101, "Add Login", PlanStatus.Review, updated: now),
+            CreatePlanFile(102, "Fix Bug", PlanStatus.Review, updated: now),
+            CreatePlanFile(103, "Draft Plan", PlanStatus.Draft, updated: now),
         };
 
         var prompts = SamplePrompts.ForChat(plans, new List<JobItem>());
@@ -37,8 +38,8 @@ public class ChatSamplePromptsTests
         var newer = DateTime.UtcNow.AddHours(-1);
         var plans = new List<PlanFile>
         {
-            new() { Id = 201, Title = "Old Failed", Status = PlanStatus.Failed, Updated = older },
-            new() { Id = 202, Title = "New Failed", Status = PlanStatus.Failed, Updated = newer },
+            CreatePlanFile(201, "Old Failed", PlanStatus.Failed, updated: older),
+            CreatePlanFile(202, "New Failed", PlanStatus.Failed, updated: newer),
         };
 
         var prompts = SamplePrompts.ForChat(plans, new List<JobItem>());
@@ -82,10 +83,10 @@ public class ChatSamplePromptsTests
         var now = DateTime.UtcNow;
         var plans = new List<PlanFile>
         {
-            new() { Id = 1, Title = "Review", Status = PlanStatus.Review, Updated = now },
-            new() { Id = 2, Title = "Failed", Status = PlanStatus.Failed, Updated = now },
-            new() { Id = 3, Title = "Blocked", Status = PlanStatus.Blocked, Updated = now },
-            new() { Id = 4, Title = "Partial", Status = PlanStatus.Draft, PartialDelivery = true, Updated = now },
+            CreatePlanFile(1, "Review", PlanStatus.Review, updated: now),
+            CreatePlanFile(2, "Failed", PlanStatus.Failed, updated: now),
+            CreatePlanFile(3, "Blocked", PlanStatus.Blocked, updated: now),
+            CreatePlanFile(4, "Partial", PlanStatus.Draft, updated: now, partialDelivery: true),
         };
         var jobs = new List<JobItem>
         {
@@ -102,17 +103,15 @@ public class ChatSamplePromptsTests
     [Fact]
     public void ForPlan_NamesTheFailedVerification()
     {
-        var plan = new PlanFile
-        {
-            Id = 301,
-            Title = "Test Plan",
-            Verifications = new List<PlanVerificationEntry>
+        var plan = CreatePlanFile(
+            301,
+            "Test Plan",
+            verifications: new List<PlanVerificationEntry>
             {
                 new() { Name = "Build", Status = VerificationStatus.Pass },
                 new() { Name = "Test", Status = VerificationStatus.Fail },
                 new() { Name = "Lint", Status = VerificationStatus.Pending },
-            }
-        };
+            });
 
         var prompts = SamplePrompts.ForPlan(plan);
 
@@ -124,12 +123,10 @@ public class ChatSamplePromptsTests
     [Fact]
     public void ForPlan_AsksAboutThePullRequestWhenThePlanHasOne()
     {
-        var plan = new PlanFile
-        {
-            Id = 401,
-            Title = "PR Plan",
-            Prs = new List<string> { "https://github.com/owner/repo/pull/123" }
-        };
+        var plan = CreatePlanFile(
+            401,
+            "PR Plan",
+            prs: new List<string> { "https://github.com/owner/repo/pull/123" });
 
         var prompts = SamplePrompts.ForPlan(plan);
 
@@ -141,13 +138,11 @@ public class ChatSamplePromptsTests
     [Fact]
     public void ForPlan_FallsBackForAFreshDraftPlan()
     {
-        var plan = new PlanFile
-        {
-            Id = 501,
-            Title = "Draft Plan",
-            Status = PlanStatus.Draft,
-            Verifications = new List<PlanVerificationEntry>()
-        };
+        var plan = CreatePlanFile(
+            501,
+            "Draft Plan",
+            status: PlanStatus.Draft,
+            verifications: new List<PlanVerificationEntry>());
 
         var prompts = SamplePrompts.ForPlan(plan);
 
@@ -158,20 +153,35 @@ public class ChatSamplePromptsTests
     [Fact]
     public void ForPlan_ProducesNoDuplicateLabels()
     {
-        var plan = new PlanFile
-        {
-            Id = 601,
-            Title = "Complex Plan",
-            Status = PlanStatus.Draft,
-            Verifications = new List<PlanVerificationEntry>
+        var plan = CreatePlanFile(
+            601,
+            "Complex Plan",
+            status: PlanStatus.Draft,
+            verifications: new List<PlanVerificationEntry>
             {
                 new() { Name = "Test", Status = VerificationStatus.Fail },
-            }
-        };
+            });
 
         var prompts = SamplePrompts.ForPlan(plan);
 
         var labels = prompts.Select(p => p.Label).ToList();
         Assert.Equal(labels.Count, labels.Distinct().Count());
+    }
+
+    private static PlanFile CreatePlanFile(
+        int id,
+        string title,
+        PlanStatus status = PlanStatus.Draft,
+        DateTime? updated = null,
+        bool partialDelivery = false,
+        List<PlanVerificationEntry>? verifications = null,
+        List<string>? prs = null)
+    {
+        var metadata = new PlanMetadata(
+            id, "test-project", "Feature", title, status,
+            [], [], prs ?? [], verifications ?? [], [], [],
+            DateTime.UtcNow, updated ?? DateTime.UtcNow, null, null,
+            PartialDelivery: partialDelivery);
+        return new PlanFile(metadata, "", $"/tmp/{id:D5}-{title}", "");
     }
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -627,6 +627,39 @@ describe("ChatWidget embedded mode", () => {
     expect(handleEvent).not.toHaveBeenCalledWith("OnOpenPlan", expect.anything(), expect.anything());
   });
 
+  it("renders a job item with planTitle but undefined planId as non-clickable without chevron or triggering OnOpenPlan", () => {
+    const handleEvent = vi.fn();
+    const session: ChatSessionDto = {
+      id: "s1",
+      title: "Plan chat",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: "",
+      updatedAt: "",
+      messages: [{ id: "m1", role: "user", content: "hi", timestamp: "" }],
+      spawnedJobs: [
+        { id: "00148", type: "ExecutePlan", status: "Completed", planTitle: "Add login" },
+      ],
+    };
+    render(
+      <ChatWidget
+        id="chat"
+        activeSessionId="s1"
+        sessions={[session]}
+        events={["OnOpenPlan"]}
+        eventHandler={handleEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "View running jobs" }));
+    expect(screen.getByText("Add login")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Add login/ })).not.toBeInTheDocument();
+    expect(document.querySelector(".chat-job-nav-icon")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Add login"));
+    expect(handleEvent).not.toHaveBeenCalledWith("OnOpenPlan", expect.anything(), expect.anything());
+  });
+
   it("shows the new-chat chord in the header button's tooltip", () => {
     vi.useFakeTimers();
     const session: ChatSessionDto = {

--- a/src/Ivy.Tendril/AppShell/Dialogs/PlanSearchDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/PlanSearchDialog.cs
@@ -18,11 +18,12 @@ public class PlanSearchDialog(IState<bool> dialogOpen) : ViewBase
 {
     private const int MaxResults = 15;
 
-    internal static (Type App, object? Args) ResolveTarget(PlanFile plan) => plan.Status switch
+    internal static (Type App, object? Args)? ResolveTarget(PlanFile plan) => plan.Status switch
     {
         PlanStatus.Draft or PlanStatus.Blocked => (typeof(PlansApp), new PlansAppArgs(plan.FolderName)),
+        PlanStatus.Review or PlanStatus.Failed => (typeof(ReviewApp), new ReviewAppArgs(plan.FolderName)),
         PlanStatus.Icebox => (typeof(IceboxApp), null),
-        _ => (typeof(ReviewApp), new ReviewAppArgs(plan.FolderName))
+        _ => null
     };
 
     /// <summary>Badges as the plan's owning sidebar list would show them; other statuses get a status badge.</summary>
@@ -68,8 +69,11 @@ public class PlanSearchDialog(IState<bool> dialogOpen) : ViewBase
                     {
                         if (!resultsByFolder.TryGetValue(folderName, out var plan)) return;
                         dialogOpen.Set(false);
-                        var (app, appArgs) = ResolveTarget(plan);
-                        navigator.Navigate(app, appArgs);
+                        var target = ResolveTarget(plan);
+                        if (target.HasValue)
+                        {
+                            navigator.Navigate(target.Value.App, target.Value.Args);
+                        }
                     });
             }
         }

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -133,8 +133,11 @@ public class AgentApp : ViewBase
                 if (planService == null) return;
                 var plan = ContentView.FindPlan(planService, planId);
                 if (plan == null) return;
-                var (app, appArgs) = PlanSearchDialog.ResolveTarget(plan);
-                navigator.Navigate(app, appArgs);
+                var target = PlanSearchDialog.ResolveTarget(plan);
+                if (target.HasValue)
+                {
+                    navigator.Navigate(target.Value.App, target.Value.Args);
+                }
             });
 
         var deleteDialog = new DeleteSessionDialog(deletingSessionId, session, chatService, null, sessionVersion);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -45,9 +45,14 @@ public class ChatApp : ViewBase
         var resolvedPlanId = string.IsNullOrEmpty(planId) ? null : planId;
 
         var planTitle = job.ReportedPlanTitle;
-        if (string.IsNullOrWhiteSpace(planTitle) && resolvedPlanId != null && planService != null)
+        PlanFile? resolvedPlan = null;
+        if (resolvedPlanId != null && planService != null)
         {
-            planTitle = ContentView.FindPlan(planService, resolvedPlanId)?.Title;
+            resolvedPlan = ContentView.FindPlan(planService, resolvedPlanId);
+            if (string.IsNullOrWhiteSpace(planTitle))
+            {
+                planTitle = resolvedPlan?.Title;
+            }
         }
         if (string.IsNullOrWhiteSpace(planTitle) && !string.IsNullOrEmpty(job.PlanFile))
         {
@@ -58,6 +63,14 @@ public class ChatApp : ViewBase
             planTitle = PlanYamlHelper.ExtractSafeTitleFromFolder(job.TypedArgs.PlanFolder);
         }
         var resolvedPlanTitle = string.IsNullOrWhiteSpace(planTitle) ? null : planTitle;
+
+        if (resolvedPlanId != null && planService != null)
+        {
+            if (resolvedPlan == null || !Directory.Exists(resolvedPlan.FolderPath) || resolvedPlan.Status is PlanStatus.Completed or PlanStatus.Skipped)
+            {
+                resolvedPlanId = null;
+            }
+        }
 
         return new(
             job.Id,
@@ -439,6 +452,10 @@ public class ChatApp : ViewBase
                         {
                             staleIds.Add(id);
                         }
+                    }
+                    else
+                    {
+                        staleIds.Add(id);
                     }
                 }
 

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -264,8 +264,11 @@ public class ContentView(
                 var plan = FindPlan(planService, e.Value);
                 if (plan != null)
                 {
-                    var (app, appArgs) = PlanSearchDialog.ResolveTarget(plan);
-                    navigator.Navigate(app, appArgs);
+                    var target = PlanSearchDialog.ResolveTarget(plan);
+                    if (target.HasValue)
+                    {
+                        navigator.Navigate(target.Value.App, target.Value.Args);
+                    }
                 }
                 return ValueTask.CompletedTask;
             }


### PR DESCRIPTION
# Summary

## Changes

Prevented navigation to closed or deleted plans from the chat jobs badge menu by clearing the plan ID on the job DTO when the target plan is in Completed or Skipped status, missing from the database, or missing from disk. In addition, updated PlanSearchDialog.ResolveTarget to return a nullable target and updated callers to guard against navigating to non-navigable plan states, and ensured deleted jobs are purged from the chat session's tracked spawned jobs list.

## API Changes

- `PlanSearchDialog.ResolveTarget(PlanFile plan)` return type changed from `(Type App, object? Args)` to `(Type App, object? Args)?`.

## Files Modified

- Backend logic:
  - `src/Ivy.Tendril/Apps/Chat/ChatApp.cs`: Checked plan existence, folder path on disk, and non-terminal state before setting `resolvedPlanId` on `ChatJobDto`, and purged deleted jobs where `GetJob` returns null.
  - `src/Ivy.Tendril/AppShell/Dialogs/PlanSearchDialog.cs`: Updated `ResolveTarget` to return null for `Completed` and `Skipped` statuses, and checked `target.HasValue` before navigating.
  - `src/Ivy.Tendril/Apps/Chat/ContentView.cs`: Checked `target.HasValue` before navigating on `OnOpenPlan`.
  - `src/Ivy.Tendril/Apps/Agent/AgentApp.cs`: Checked `target.HasValue` before navigating on `OnOpenPlan`.
- Tests:
  - `src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs`: Added unit tests covering plan ID clearing for completed, skipped, missing, and folder-missing plans, as well as `ResolveTarget` null checks.
  - `src/Ivy.Tendril.Test/Apps/Chat/ChatSamplePromptsTests.cs`: Fixed pre-existing compilation issue with `PlanMetadata` constructor calls.
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Added frontend test verifying non-clickable rendering when `planId` is undefined but `planTitle` is present.

## Manual Testing

1. Launch Tendril and open the Chat application.
2. Select or create a chat session that has spawned background jobs whose associated plans are Completed or Skipped (or delete a plan folder from disk).
3. Click the background jobs badge in the top right corner of the chat header to open the jobs dropdown menu.
4. Observe that for jobs associated with closed or deleted plans, the plan title remains visible for context, but the item is rendered without a navigation chevron and is not clickable.

---
- 03bd2da9 Plan 00420: Prevent navigating to closed or deleted plans from chat jobs badge

---
Created using [Ivy Tendril](https://ivy.app).
