### PR TITLE
[00400] Notify The Master Agent Of Plan Edits Made From The Side Chat

### DIFF
--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -1245,6 +1245,212 @@ public class ChatExecutionServiceJobTrackingTests
         }
     }
 
+    /// <summary>
+    /// A plan edited directly from one chat has to reach the plan's other sessions, or the agent that
+    /// created the plan keeps reasoning from the version it last read (plan 00400, issue #2455).
+    /// </summary>
+    private sealed class PlanEditFanOutHarness : IDisposable
+    {
+        public string TempDir { get; }
+        public ChatHistoryService ChatService { get; }
+        public ChatExecutionService ExecService { get; }
+        public PlanDatabaseService Database { get; }
+
+        public PlanEditFanOutHarness(string? planChatSessionId = null, string planFolder = "00400-PlanEdits")
+        {
+            TempDir = Path.Combine(Path.GetTempPath(), "TendrilPlanEditFanOut_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(TempDir);
+
+            var configService = new ConfigService(new TendrilSettings { CodingAgent = "codex" }, TempDir);
+            ChatService = new ChatHistoryService(configService);
+
+            Database = new PlanDatabaseService(Path.Combine(TempDir, "test.db"), NullLogger<PlanDatabaseService>.Instance);
+            Plan = new PlanFile(
+                new PlanMetadata(400, "Tendril", "NiceToHave", "Notify The Master Agent", PlanStatus.Draft,
+                    [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null,
+                    ChatSessionId: planChatSessionId),
+                "# Notify",
+                Path.Combine(TempDir, planFolder),
+                "state: Draft");
+            Database.UpsertPlan(Plan);
+
+            var agentRunner = TestAgentRunner.Create();
+            ExecService = new ChatExecutionService(
+                configService,
+                ChatService,
+                agentRunner,
+                new ChatSessionNamingService(agentRunner, configService, ChatService, NullLogger<ChatSessionNamingService>.Instance),
+                new JsonEventSerializer(),
+                logger: null,
+                serviceProvider: null,
+                jobService: new FakeChatJobService(),
+                planReaderService: null,
+                database: Database);
+        }
+
+        public PlanFile Plan { get; }
+
+        public List<string> EditEvents(string sessionId) =>
+            ChatService.GetSession(sessionId)?.Messages
+                .Where(m => m.Role == "system" && m.Content.Contains("was edited directly"))
+                .Select(m => m.Content)
+                .ToList() ?? [];
+
+        /// <summary>
+        /// The first event puts the session into an execution, and a system event that arrives during
+        /// one is held back rather than added to the history. Waiting for the execution to drain is
+        /// what makes a second event observable at all.
+        /// </summary>
+        public async Task WaitForIdleAsync(string sessionId) =>
+            await WaitAsync(() => !ExecService.IsGenerating(sessionId), $"session {sessionId} to stop generating");
+
+        public async Task WaitForEventsAsync(string sessionId, int count) =>
+            await WaitAsync(() => EditEvents(sessionId).Count >= count, $"{count} edit event(s) in session {sessionId}");
+
+        private static async Task WaitAsync(Func<bool> condition, string what)
+        {
+            var deadline = DateTime.UtcNow.AddSeconds(20);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (condition()) return;
+                await Task.Delay(25);
+            }
+
+            Assert.Fail($"Timed out waiting for {what}");
+        }
+
+        public void Dispose()
+        {
+            ExecService.Dispose();
+            Database.Dispose();
+            if (Directory.Exists(TempDir))
+            {
+                try { Directory.Delete(TempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task NotifyPlanEdit_ReachesTheSidePanelSessionAndThePlansGeneralChatOnce()
+    {
+        using var harness = new PlanEditFanOutHarness();
+        var general = harness.ChatService.CreateSession("codex", "gpt-5.6-sol");
+        var side = harness.ChatService.CreateSession("codex", "gpt-5.6-sol", planFolderName: harness.Plan.FolderName);
+        harness.Database.UpsertPlan(harness.Plan with
+        {
+            Metadata = harness.Plan.Metadata with { ChatSessionId = general.Id }
+        });
+
+        await harness.ExecService.NotifyPlanEditAsync(
+            harness.Plan.FolderName,
+            "Solution changed (+12/-3 lines)",
+            reason: "the user dropped the CLI flag from scope",
+            revisionFile: "004.md");
+
+        await harness.WaitForEventsAsync(side.Id, 1);
+        await harness.WaitForEventsAsync(general.Id, 1);
+
+        Assert.Single(harness.EditEvents(side.Id));
+        Assert.Single(harness.EditEvents(general.Id));
+
+        var message = harness.EditEvents(side.Id)[0];
+        Assert.Contains("Solution changed (+12/-3 lines)", message);
+        Assert.Contains("the user dropped the CLI flag from scope", message);
+        Assert.Contains("Notify The Master Agent", message);
+    }
+
+    [Fact]
+    public async Task NotifyPlanEdit_DoesNotNotifyTheSessionThatMadeTheEdit()
+    {
+        using var harness = new PlanEditFanOutHarness();
+        var general = harness.ChatService.CreateSession("codex", "gpt-5.6-sol");
+        var side = harness.ChatService.CreateSession("codex", "gpt-5.6-sol", planFolderName: harness.Plan.FolderName);
+        harness.Database.UpsertPlan(harness.Plan with
+        {
+            Metadata = harness.Plan.Metadata with { ChatSessionId = general.Id }
+        });
+
+        await harness.ExecService.NotifyPlanEditAsync(
+            harness.Plan.FolderName,
+            "state set to Review",
+            reason: "ready for review",
+            sourceChatSessionId: side.Id);
+
+        await harness.WaitForEventsAsync(general.Id, 1);
+
+        Assert.Empty(harness.EditEvents(side.Id));
+        Assert.Single(harness.EditEvents(general.Id));
+    }
+
+    /// <summary>
+    /// The CLI reports best-effort and may be retried, so the same revision must not be announced
+    /// twice — while a later revision still has to get through.
+    /// </summary>
+    [Fact]
+    public async Task NotifyPlanEdit_DeduplicatesTheSameRevisionButNotTheNextOne()
+    {
+        using var harness = new PlanEditFanOutHarness();
+        var side = harness.ChatService.CreateSession("codex", "gpt-5.6-sol", planFolderName: harness.Plan.FolderName);
+
+        await harness.ExecService.NotifyPlanEditAsync(harness.Plan.FolderName, "Tests added", revisionFile: "004.md");
+        await harness.WaitForEventsAsync(side.Id, 1);
+        await harness.WaitForIdleAsync(side.Id);
+
+        await harness.ExecService.NotifyPlanEditAsync(harness.Plan.FolderName, "Tests added", revisionFile: "004.md");
+        Assert.Single(harness.EditEvents(side.Id));
+
+        await harness.ExecService.NotifyPlanEditAsync(harness.Plan.FolderName, "Tests changed (+1/-0 lines)", revisionFile: "005.md");
+        await harness.WaitForEventsAsync(side.Id, 2);
+
+        Assert.Equal(2, harness.EditEvents(side.Id).Count);
+    }
+
+    [Fact]
+    public async Task NotifyPlanEdit_WithNoSessionAttachedToThePlan_DoesNothing()
+    {
+        using var harness = new PlanEditFanOutHarness();
+        var unrelated = harness.ChatService.CreateSession("codex", "gpt-5.6-sol", planFolderName: "00099-SomethingElse");
+
+        await harness.ExecService.NotifyPlanEditAsync(harness.Plan.FolderName, "Problem changed (+1/-1 lines)");
+
+        Assert.Empty(harness.EditEvents(unrelated.Id));
+        Assert.False(harness.ExecService.IsGenerating(unrelated.Id));
+    }
+
+    [Fact]
+    public async Task NotifyPlanEdit_WithoutASummary_IsIgnored()
+    {
+        using var harness = new PlanEditFanOutHarness();
+        var side = harness.ChatService.CreateSession("codex", "gpt-5.6-sol", planFolderName: harness.Plan.FolderName);
+
+        await harness.ExecService.NotifyPlanEditAsync(harness.Plan.FolderName, "   ");
+
+        Assert.Empty(harness.EditEvents(side.Id));
+    }
+
+    [Fact]
+    public void BuildPlanEditEvent_SaysWhatChangedAndWhy()
+    {
+        var plan = new PlanFile(
+            new PlanMetadata(400, "Tendril", "NiceToHave", "Notify The Master Agent", PlanStatus.Draft,
+                [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null, ChatSessionId: null),
+            "# Notify", "/tmp/Plans/00400-Notify", "state: Draft");
+
+        var withReason = ChatExecutionService.BuildPlanEditEvent(
+            plan, plan.FolderName, "Solution changed (+2/-0 lines)", "the user dropped the CLI flag.");
+
+        Assert.StartsWith("[System Event] Plan 'Notify The Master Agent' (#00400) was edited directly", withReason);
+        Assert.Contains("Solution changed (+2/-0 lines). Reason: the user dropped the CLI flag.", withReason);
+
+        var withoutReason = ChatExecutionService.BuildPlanEditEvent(plan, plan.FolderName, "Tests added", null);
+        Assert.DoesNotContain("Reason:", withoutReason);
+        Assert.Contains("Tests added.", withoutReason);
+
+        // An unresolvable plan still has to produce a usable event — the folder name is what the CLI sent.
+        var unknown = ChatExecutionService.BuildPlanEditEvent(null, "00400-Notify", "Tests added", null);
+        Assert.Contains("Plan '00400-Notify' was edited directly", unknown);
+    }
+
     private class TestState<T> : IState<T>
     {
         private readonly T _initial;

--- a/src/Ivy.Tendril.Test/Commands/PlanCreateDuplicateCandidatesTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PlanCreateDuplicateCandidatesTests.cs
@@ -224,8 +224,10 @@ public class PlanCreateDuplicateCandidatesTests : IDisposable
         Assert.Contains("DuplicateCandidates:", stderr);
         Assert.Contains($"00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042|{Title00063}|Completed", stderr);
 
-        // The plan must never match itself.
-        Assert.DoesNotContain("00065-DeliverTheBlockedCargoFmtPreCommitHook", stderr);
+        // The plan must never match itself. Scoped to the candidate block, because stderr also carries
+        // the plan-edit report, which names the plan being edited.
+        var candidateBlock = stderr[stderr.IndexOf("DuplicateCandidates:", StringComparison.Ordinal)..];
+        Assert.DoesNotContain("00065-DeliverTheBlockedCargoFmtPreCommitHook", candidateBlock);
     }
 
     [Fact]
@@ -241,7 +243,7 @@ public class PlanCreateDuplicateCandidatesTests : IDisposable
 
         Assert.Equal(0, exit);
         Assert.DoesNotContain("DuplicateCandidates", stderr);
-        Assert.DoesNotContain("warning:", stderr);
+        Assert.DoesNotContain("possible duplicate plan(s) found", stderr);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/PlanChatTests.cs
+++ b/src/Ivy.Tendril.Test/PlanChatTests.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Runtime;
 using Ivy.Tendril.Apps.Chat;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Widgets;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Ivy.Tendril.Test;
@@ -55,6 +58,11 @@ public class PlanChatTests
         {
             var session = service.CreateSession("claude", "opus", "#59 Revamp", planFolderName: "00059-revamp");
             Assert.Equal("00059-revamp", session.PlanFolderName);
+
+            // CreateSession only writes a session that has messages, so the reload below needs one.
+            // An empty plan session surviving a restart is a separate question (see the plan 00400
+            // recommendations); what this asserts is that the plan link is part of what gets persisted.
+            service.AddMessage(session.Id, "user", "Let's talk");
 
             var reloaded = new ChatHistoryService(new ConfigService(new TendrilSettings(), tempDir)).GetSession(session.Id);
             Assert.NotNull(reloaded);
@@ -159,6 +167,7 @@ public class PlanChatTests
     private sealed class RecordingChatExecutionService : IChatExecutionService
     {
         public List<(string SessionId, string Prompt, string? AgentId, string? ModelId)> Sent { get; } = [];
+        public List<(string PlanFolderName, string Summary, string? Reason, string? SourceChatSessionId)> PlanEdits { get; } = [];
 #pragma warning disable CS0067
         public event Action<string>? SessionGeneratingChanged;
         public event Action<string>? StreamUpdated;
@@ -176,6 +185,13 @@ public class PlanChatTests
 
         public Task CancelAsync(string sessionId) => Task.CompletedTask;
         public Task InterruptAsync(string sessionId) => Task.CompletedTask;
+
+        public Task NotifyPlanEditAsync(string planFolderName, string summary, string? reason = null,
+            string? sourceChatSessionId = null, string? revisionFile = null)
+        {
+            PlanEdits.Add((planFolderName, summary, reason, sourceChatSessionId));
+            return Task.CompletedTask;
+        }
 
         public Task ForceSendMessageAsync(string sessionId, string prompt, IReadOnlyList<ChatAttachmentDto>? attachments = null,
             string? agentId = null, string? modelId = null, string? effort = null, CancellationToken ct = default) =>
@@ -214,6 +230,57 @@ public class PlanChatTests
     {
         Assert.Contains("before executing it", PlanChatSessions.DiscussPrompt(CreatePlan(1, "Draft")));
         Assert.Contains("outcome of this plan", PlanChatSessions.DiscussPrompt(CreatePlan(2, "Done", PlanStatus.Review)));
+    }
+
+    /// <summary>
+    /// The side panel's session is found by the plan-edit fan-out only because
+    /// <see cref="PlanChatSessions.CreateForPlan" /> stamps <c>PlanFolderName</c> on it. Nothing else
+    /// links the two, so a session created without it would go quiet without failing anything.
+    /// </summary>
+    [Fact]
+    public async Task PlanEditEvent_ReachesASessionCreatedForThePlan()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilPlanEditEventTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configService = new ConfigService(new TendrilSettings { CodingAgent = "codex" }, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var planService = new FakePlanReaderService();
+            var plan = CreatePlan(59, "Revamp");
+            var agentRunner = TestAgentRunner.Create();
+
+            using var execution = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                new ChatSessionNamingService(agentRunner, configService, chatService,
+                    NullLogger<ChatSessionNamingService>.Instance),
+                new JsonEventSerializer());
+
+            var session = PlanChatSessions.CreateForPlan(chatService, planService, plan, "codex", "gpt-5.6-sol", null);
+            Assert.Equal(plan.FolderName, session.PlanFolderName);
+
+            await execution.NotifyPlanEditAsync(plan.FolderName, "Solution changed (+3/-1 lines)",
+                reason: "narrowed the scope");
+
+            var deadline = DateTime.UtcNow.AddSeconds(20);
+            ChatMessageModel? edit = null;
+            while (DateTime.UtcNow < deadline && edit == null)
+            {
+                edit = chatService.GetSession(session.Id)?.Messages
+                    .FirstOrDefault(m => m.Role == "system" && m.Content.Contains("was edited directly"));
+                if (edit == null) await Task.Delay(25);
+            }
+
+            Assert.NotNull(edit);
+            Assert.Contains("Solution changed (+3/-1 lines)", edit.Content);
+            Assert.Contains("narrowed the scope", edit.Content);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -1512,6 +1512,34 @@ public class PlanCliCommandTests : IDisposable
         }
     }
 
+    /// <summary>
+    ///     Both streams at once, for a command whose result is on stdout and whose warnings are on
+    ///     stderr — a plan edit reports itself to the running instance and must warn without failing.
+    /// </summary>
+    private static (string Out, string Error) CaptureConsole(Action action)
+    {
+        lock (ConsoleLock)
+        {
+            var originalOut = Console.Out;
+            var originalError = Console.Error;
+            var outWriter = new StringWriter();
+            var errorWriter = new StringWriter();
+            Console.SetOut(outWriter);
+            Console.SetError(errorWriter);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalError);
+            }
+
+            return (outWriter.ToString(), errorWriter.ToString());
+        }
+    }
+
     // ==================== PlanAddWorktreeCommand ====================
 
     private CommandApp BuildPlanAddWorktreeApp()
@@ -1813,6 +1841,103 @@ public class PlanCliCommandTests : IDisposable
         var revisionsDir = Path.Combine(folder, "Revisions");
         if (Directory.Exists(revisionsDir))
             Assert.Empty(Directory.GetFiles(revisionsDir));
+    }
+
+    /// <summary>
+    ///     Reporting the edit is best-effort: no Tendril server is running in a test, and the revision
+    ///     is already on disk by the time the report is attempted, so this has to stay a warning on
+    ///     stderr with exit 0 (plan 00400).
+    /// </summary>
+    [Fact]
+    public void PlanWriteRevision_WithReason_StillWritesWhenNoServerIsRunning()
+    {
+        CreatePlanFolder("20303", "WriteRevReason");
+        var file = Path.Combine(_tempDir.Path, "revision-reason.md");
+        File.WriteAllText(file, "## Problem\n\nSomething.\n");
+
+        var app = BuildPlanWriteRevisionApp();
+        var exit = -1;
+        var (_, error) = CaptureConsole(() =>
+            exit = app.Run(["plan", "write-revision", "20303", "--file", file,
+                "--reason", "the user narrowed the scope", "--no-duplicate-check"]));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("could not report the edit to plan 20303-WriteRevReason", error);
+        Assert.DoesNotContain("no --reason given", error);
+
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20303");
+        var revisionPath = Directory.GetFiles(Path.Combine(folder, "Revisions")).Single();
+        Assert.Contains("Something.", File.ReadAllText(revisionPath));
+    }
+
+    /// <summary>
+    ///     An edit with no reason still gets announced, but the agent is told what it left out: the
+    ///     other sessions can see the diff for themselves, and only the editor knows why.
+    /// </summary>
+    [Fact]
+    public void PlanWriteRevision_WithoutReason_WarnsThatTheOtherSessionsWillNotKnowWhy()
+    {
+        CreatePlanFolder("20304", "WriteRevNoReason");
+        var file = Path.Combine(_tempDir.Path, "revision-no-reason.md");
+        File.WriteAllText(file, "## Problem\n\nSomething.\n");
+
+        var app = BuildPlanWriteRevisionApp();
+        var exit = -1;
+        var (_, error) = CaptureConsole(() =>
+            exit = app.Run(["plan", "write-revision", "20304", "--file", file, "--no-duplicate-check"]));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("no --reason given", error);
+    }
+
+    // ==================== PlanSet / PlanSetVerification (--reason) ====================
+
+    private static CommandApp BuildPlanSetApp()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
+
+        var app = new CommandApp(new TypeRegistrar(services));
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("plan", plan =>
+            {
+                plan.AddCommand<PlanSetCommand>("set");
+                plan.AddCommand<PlanSetVerificationCommand>("set-verification");
+            });
+        });
+        return app;
+    }
+
+    [Fact]
+    public void PlanSet_WithReason_AppliesTheFieldAndWarnsWhenNoServerIsRunning()
+    {
+        CreatePlanFolder("20305", "SetWithReason");
+
+        var app = BuildPlanSetApp();
+        var exit = -1;
+        var (_, error) = CaptureConsole(() =>
+            exit = app.Run(["plan", "set", "20305", "state", "Review", "--reason", "execution finished"]));
+
+        Assert.Equal(0, exit);
+        Assert.Equal("Review", ReadPlan("20305").State);
+        Assert.Contains("could not report the edit to plan 20305-SetWithReason", error);
+    }
+
+    [Fact]
+    public void PlanSetVerification_WithReason_AppliesTheStatusAndWarnsWhenNoServerIsRunning()
+    {
+        CreatePlanFolder("20306", "SetVerificationWithReason");
+
+        var app = BuildPlanSetApp();
+        var exit = -1;
+        var (_, error) = CaptureConsole(() =>
+            exit = app.Run(["plan", "set-verification", "20306", "DotnetBuild", "Pass", "--reason", "build is green"]));
+
+        Assert.Equal(0, exit);
+        Assert.Equal(VerificationStatus.Pass, ReadPlan("20306").Verifications.Single().Status);
+        Assert.Contains("could not report the edit to plan 20306-SetVerificationWithReason", error);
     }
 
     // ==================== PlanUpdate (--file / --stdin) ====================

--- a/src/Ivy.Tendril.Test/PlanControllerTests.cs
+++ b/src/Ivy.Tendril.Test/PlanControllerTests.cs
@@ -659,6 +659,49 @@ public class PlanControllerTests : IDisposable
         Assert.Contains("002.md", json);
     }
 
+    // --- ReportPlanEdit ---
+
+    /// <summary>
+    /// The CLI posts here after every direct plan edit. It has no chat execution service wired in the
+    /// desktop-less case, and the edit is already on disk by then, so the endpoint must still answer
+    /// 200 rather than making the CLI print a warning about a working system (plan 00400).
+    /// </summary>
+    [Fact]
+    public async Task ReportPlanEdit_WithNoChatExecutionWired_ReturnsOk()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = await controller.ReportPlanEdit("00001",
+            new PlanEditEventRequest("Solution changed (+2/-0 lines)", "narrowed the scope"));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Contains("00001-TestPlan", JsonSerializer.Serialize(ok.Value));
+    }
+
+    [Fact]
+    public async Task ReportPlanEdit_ForUnknownPlan_Returns404()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir.Path, "Plans"));
+        var controller = CreateController();
+
+        var result = await controller.ReportPlanEdit("99999", new PlanEditEventRequest("Tests added"));
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task ReportPlanEdit_WithoutASummary_Returns400()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = await controller.ReportPlanEdit("00001", new PlanEditEventRequest("   "));
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("summary is required", JsonSerializer.Serialize(badRequest.Value));
+    }
+
     // --- AddRelatedPlan ---
 
     [Fact]

--- a/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
+++ b/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
@@ -1,0 +1,163 @@
+using Ivy.Tendril.Helpers;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+/// The one line that a plan-edit system event carries. It is the only thing the plan's other chat
+/// sessions are told about a direct edit, so a summary that says "no section changes" for a real
+/// rewrite — or the reverse — is worse than no event at all (plan 00400).
+/// </summary>
+public class PlanEditSummaryTests
+{
+    /// <summary>
+    /// Normalized so the assertions below hold however git checked this file out — the tests splice
+    /// <c>\n</c> into it directly.
+    /// </summary>
+    private static readonly string Before = """
+        ## Problem
+
+        The master agent never hears about edits made from the side chat.
+
+        ## Solution
+
+        Report the edit to the master.
+
+        ## Tests
+
+        Cover the summary helper.
+        """.ReplaceLineEndings("\n");
+
+    [Fact]
+    public void Describe_WhenSectionAdded_NamesIt()
+    {
+        var after = Before + "\n\n## Notes\n\nAdded late.";
+
+        Assert.Equal("Notes added", PlanEditSummary.Describe(Before, after));
+    }
+
+    [Fact]
+    public void Describe_WhenSectionRemoved_NamesIt()
+    {
+        var after = Before.Replace("\n## Tests\n\nCover the summary helper.", "");
+
+        Assert.Equal("Tests removed", PlanEditSummary.Describe(Before, after));
+    }
+
+    [Fact]
+    public void Describe_WhenBodyChanged_ReportsLineDelta()
+    {
+        var after = Before.Replace(
+            "Report the edit to the master.",
+            "Report the edit to the master.\nFan it out to the attached sessions.\nSay why it changed.");
+
+        Assert.Equal("Solution changed (+2/-0 lines)", PlanEditSummary.Describe(Before, after));
+    }
+
+    [Fact]
+    public void Describe_WhenBodyReplaced_CountsBothDirections()
+    {
+        var after = Before.Replace("Report the edit to the master.", "Post it to the running instance.");
+
+        Assert.Equal("Solution changed (+1/-1 lines)", PlanEditSummary.Describe(Before, after));
+    }
+
+    [Fact]
+    public void Describe_WhenNothingChanged_SaysSo()
+    {
+        Assert.Equal("no section changes", PlanEditSummary.Describe(Before, Before));
+    }
+
+    [Fact]
+    public void Describe_WhenNoPreviousRevision_SaysInitial()
+    {
+        Assert.Equal("initial revision written", PlanEditSummary.Describe(null, Before));
+        Assert.Equal("initial revision written", PlanEditSummary.Describe("", Before));
+        Assert.Equal("initial revision written", PlanEditSummary.Describe("   \n", Before));
+    }
+
+    [Fact]
+    public void Describe_ReportsEveryChangedSectionInDocumentOrder()
+    {
+        var after = Before
+            .Replace("The master agent never hears about edits made from the side chat.", "Rewritten.")
+            .Replace("Cover the summary helper.", "Cover the summary helper.\nAnd the fan-out.")
+            + "\n\n## Notes\n\nLast.";
+
+        Assert.Equal(
+            "Problem changed (+1/-1 lines), Tests changed (+1/-0 lines), Notes added",
+            PlanEditSummary.Describe(Before, after));
+    }
+
+    /// <summary>
+    /// A retitled section with an untouched body is a rename, not a deletion plus an insertion:
+    /// telling the master agent "Solution removed" would read as scope being dropped.
+    /// </summary>
+    [Fact]
+    public void Describe_WhenSectionRenamedWithSameBody_ReportsRename()
+    {
+        var after = Before.Replace("## Solution", "## Proposed Solution");
+
+        Assert.Equal("Proposed Solution renamed from Solution", PlanEditSummary.Describe(Before, after));
+    }
+
+    /// <summary>
+    /// Plans quote markdown, including their own headings. A fenced <c>## Problem</c> is body text.
+    /// </summary>
+    [Fact]
+    public void Describe_IgnoresHeadingsInsideFencedBlocks()
+    {
+        var withFence = """
+            ## Problem
+
+            Write a revision that looks like this:
+
+            ```markdown
+            ## Solution
+
+            Not a section.
+            ```
+
+            ## Tests
+
+            Cover it.
+            """;
+
+        var after = withFence.Replace("Not a section.", "Still not a section.");
+
+        Assert.Equal("Problem changed (+1/-1 lines)", PlanEditSummary.Describe(withFence, after));
+    }
+
+    /// <summary>
+    /// Trailing blank lines are how the revision writer pads a document, not an edit anyone made.
+    /// </summary>
+    [Fact]
+    public void Describe_IgnoresBlankPaddingAroundSections()
+    {
+        Assert.Equal("no section changes", PlanEditSummary.Describe(Before, "\n\n" + Before + "\n\n\n"));
+    }
+
+    /// <summary>
+    /// Line endings differ between a revision written on Windows and one written by an agent on
+    /// Linux, and that difference must not read as every section having been rewritten.
+    /// </summary>
+    [Fact]
+    public void Describe_IgnoresLineEndingStyle()
+    {
+        Assert.Equal("no section changes", PlanEditSummary.Describe(Before, Before.ReplaceLineEndings("\r\n")));
+    }
+
+    [Fact]
+    public void Describe_WhenNeitherRevisionHasSections_SaysNoSectionChanges()
+    {
+        Assert.Equal("no section changes", PlanEditSummary.Describe("Just prose.", "Different prose."));
+    }
+
+    [Fact]
+    public void Fingerprint_IsStableAndDistinguishesSummaries()
+    {
+        Assert.Equal(PlanEditSummary.Fingerprint("Solution changed"), PlanEditSummary.Fingerprint("Solution changed"));
+        Assert.NotEqual(PlanEditSummary.Fingerprint("Solution changed"), PlanEditSummary.Fingerprint("Tests changed"));
+        Assert.Equal(16, PlanEditSummary.Fingerprint("Solution changed").Length);
+    }
+}

--- a/src/Ivy.Tendril/Commands/PlanSetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetCommand.cs
@@ -28,6 +28,14 @@ public class PlanSetSettings : CommandSettings
     [CommandOption("--allow-failed-verifications")]
     public bool AllowFailedVerifications { get; init; }
 
+    [Description("Why this edit was made — reported to the plan's other chat sessions")]
+    [CommandOption("--reason")]
+    public string? Reason { get; set; }
+
+    [Description("Chat session making the edit, so it is not notified about its own change")]
+    [CommandOption("--chat-session")]
+    public string? ChatSessionId { get; set; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         var required = CliValidation.Combine(
@@ -104,6 +112,13 @@ public class PlanSetCommand : Command<PlanSetSettings>
             plan.Updated = DateTime.UtcNow;
 
         PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        // A field change is a plan edit too, and the side chat makes them: announce it like a revision.
+        PlanEditEventReporter.Report(
+            PathHelper.GetFileNameCrossPlatform(planFolder),
+            $"{settings.Field} set to {settings.Value}",
+            settings.Reason,
+            settings.ChatSessionId);
 
         Console.WriteLine($"Set {settings.Field} = {settings.Value}");
         return 0;

--- a/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
@@ -20,6 +20,14 @@ public class PlanSetVerificationSettings : CommandSettings
     [CommandArgument(2, "<status>")]
     public string Status { get; set; } = "";
 
+    [Description("Why this edit was made — reported to the plan's other chat sessions")]
+    [CommandOption("--reason")]
+    public string? Reason { get; set; }
+
+    [Description("Chat session making the edit, so it is not notified about its own change")]
+    [CommandOption("--chat-session")]
+    public string? ChatSessionId { get; set; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         return CliValidation.Combine(
@@ -65,6 +73,13 @@ public class PlanSetVerificationCommand : Command<PlanSetVerificationSettings>
         plan.Updated = DateTime.UtcNow;
 
         PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        // A verification change is a plan edit too, and the side chat makes them.
+        PlanEditEventReporter.Report(
+            PathHelper.GetFileNameCrossPlatform(planFolder),
+            $"verification {settings.Name} set to {status}",
+            settings.Reason,
+            settings.ChatSessionId);
 
         Console.WriteLine($"Set verification {settings.Name} = {settings.Status}");
         return 0;

--- a/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
@@ -28,6 +28,14 @@ public class PlanWriteRevisionSettings : CommandSettings
     [CommandOption("--no-question-check")]
     public bool NoQuestionCheck { get; set; }
 
+    [Description("Why this edit was made — reported to the plan's other chat sessions")]
+    [CommandOption("--reason")]
+    public string? Reason { get; set; }
+
+    [Description("Chat session making the edit, so it is not notified about its own change")]
+    [CommandOption("--chat-session")]
+    public string? ChatSessionId { get; set; }
+
     public int SourceCount => CliValidation.CountSources(Stdin, FilePath, "");
 
     public override Spectre.Console.ValidationResult Validate()
@@ -68,10 +76,54 @@ public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>
 
         WarnAboutQuestionBlocks(questionWarnings);
 
+        ReportPlanEdit(planFolder, filePath, settings);
+
         if (!settings.NoDuplicateCheck)
             WarnAboutDuplicateCandidates(planFolder);
 
         return 0;
+    }
+
+    /// <summary>
+    ///     Tells the plan's other chat sessions what this revision changed and why. Runs after the
+    ///     write, so a master that is down or restarting costs a warning rather than the revision.
+    /// </summary>
+    private static void ReportPlanEdit(string planFolder, string filePath, PlanWriteRevisionSettings settings)
+    {
+        try
+        {
+            PlanEditEventReporter.WarnAboutMissingReason(settings.Reason);
+
+            PlanEditEventReporter.Report(
+                PathHelper.GetFileNameCrossPlatform(planFolder),
+                PlanEditSummary.Describe(ReadPreviousRevision(filePath), File.ReadAllText(filePath)),
+                settings.Reason,
+                settings.ChatSessionId,
+                Path.GetFileName(filePath));
+        }
+        catch (Exception ex)
+        {
+            // Advisory only, like the warnings around it: the revision is already on disk.
+            Console.Error.WriteLine($"Warning: could not describe the plan edit: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    ///     The <c>NNN.md</c> below the revision just written, or null when this was the first one.
+    ///     Numbering follows <see cref="RevisionWriter.NextRevisionNumber" />, so the predecessor of
+    ///     <c>004.md</c> is <c>003.md</c>.
+    /// </summary>
+    private static string? ReadPreviousRevision(string filePath)
+    {
+        if (!int.TryParse(Path.GetFileNameWithoutExtension(filePath), out var number) || number <= 1)
+            return null;
+
+        var directory = Path.GetDirectoryName(filePath);
+        if (string.IsNullOrEmpty(directory))
+            return null;
+
+        var previous = Path.Combine(directory, $"{number - 1:D3}.md");
+        return File.Exists(previous) ? File.ReadAllText(previous) : null;
     }
 
     /// <summary>

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -97,12 +97,19 @@ public class PlanController : ControllerBase
     private readonly IPlanWatcherService _planWatcher;
     private readonly IConfigService _configService;
     private readonly IGithubService _githubService;
+    private readonly IChatExecutionService? _chatExecution;
 
-    public PlanController(IPlanWatcherService planWatcher, IConfigService configService, IGithubService githubService)
+    /// <param name="chatExecution">
+    ///     Optional so <c>PlanControllerTests</c> can construct the controller directly; the real
+    ///     container always resolves the singleton registered in <c>AddTendrilServices</c>.
+    /// </param>
+    public PlanController(IPlanWatcherService planWatcher, IConfigService configService, IGithubService githubService,
+        IChatExecutionService? chatExecution = null)
     {
         _planWatcher = planWatcher;
         _configService = configService;
         _githubService = githubService;
+        _chatExecution = chatExecution;
     }
 
     private IActionResult ModifyPlanEndpoint(
@@ -491,6 +498,41 @@ public class PlanController : ControllerBase
         }
     }
 
+    /// <summary>
+    ///     Announces a direct plan edit — one made without a job, typically by an agent running
+    ///     <c>tendril plan write-revision</c> in a side chat — to the plan's other chat sessions.
+    ///     <para>
+    ///         Advisory, so a plan with no session attached is still a 200: the caller has already
+    ///         written the edit, and there is nothing for it to do about an audience of nobody.
+    ///     </para>
+    /// </summary>
+    [HttpPost("{planId}/events")]
+    public async Task<IActionResult> ReportPlanEdit(string planId, [FromBody] PlanEditEventRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var folderName = PathHelper.GetFileNameCrossPlatform(planFolder);
+
+            if (string.IsNullOrWhiteSpace(request.Summary))
+                return BadRequest(new { error = "summary is required" });
+
+            if (_chatExecution != null)
+                await _chatExecution.NotifyPlanEditAsync(
+                    folderName, request.Summary, request.Reason, request.SourceChatSessionId, request.RevisionFile);
+
+            return Ok(new { message = $"Reported edit to plan {folderName}" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
     [HttpPost("{planId}/related-plans")]
     public IActionResult AddRelatedPlan(string planId, [FromBody] AddRelatedPlanRequest request)
     {
@@ -703,6 +745,11 @@ public record CreatePlanDirectRequest(
     List<string>? RelatedPlans = null,
     List<string>? DependsOn = null);
 public record WriteRevisionRequest(string Content);
+public record PlanEditEventRequest(
+    string Summary,
+    string? Reason = null,
+    string? SourceChatSessionId = null,
+    string? RevisionFile = null);
 public record AddRelatedPlanRequest(string RelatedPlan);
 public record RemoveRelatedPlanRequest(string RelatedPlan);
 public record AddDependsOnRequest(string DependsOn);

--- a/src/Ivy.Tendril/Helpers/PlanEditEventReporter.cs
+++ b/src/Ivy.Tendril/Helpers/PlanEditEventReporter.cs
@@ -1,0 +1,81 @@
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Reports a direct plan edit from a CLI process into the running Tendril instance, which fans it
+///     out to the chat sessions attached to the plan.
+///     <para>
+///         Best-effort by design, exactly like <see cref="MasterClient.TryPutJson" /> behind
+///         <c>tendril job status</c>: an edit is already on disk by the time this runs, so a missing or
+///         restarted master must produce a <c>Warning:</c> line and nothing else. Never a non-zero
+///         exit, never a throw.
+///     </para>
+/// </summary>
+public static class PlanEditEventReporter
+{
+    /// <summary>
+    ///     Posts the edit to <c>api/plans/{planId}/events</c>.
+    /// </summary>
+    /// <param name="planId">Plan id or folder name — the endpoint resolves either.</param>
+    /// <param name="summary">What changed, e.g. <c>Solution changed (+12/-3 lines)</c>.</param>
+    /// <param name="reason">Why the edit was made, when the caller passed <c>--reason</c>.</param>
+    /// <param name="sourceChatSessionId">
+    ///     The chat session making the edit, so it is not notified about its own change. Defaults to
+    ///     <see cref="ResolveSourceChatSession" />.
+    /// </param>
+    /// <param name="revisionFile">
+    ///     The revision file written, e.g. <c>004.md</c>. Used to deduplicate a retried report.
+    /// </param>
+    /// <returns>True when the master accepted the event.</returns>
+    public static bool Report(
+        string planId,
+        string summary,
+        string? reason = null,
+        string? sourceChatSessionId = null,
+        string? revisionFile = null,
+        CancellationToken cancellationToken = default)
+    {
+        var (ok, error) = MasterClient.TryPostJson(
+            $"api/plans/{planId}/events",
+            new
+            {
+                summary,
+                reason,
+                sourceChatSessionId = ResolveSourceChatSession(sourceChatSessionId),
+                revisionFile
+            },
+            cancellationToken);
+
+        if (!ok)
+            Console.Error.WriteLine($"Warning: could not report the edit to plan {planId}: {error}");
+
+        return ok;
+    }
+
+    /// <summary>
+    ///     Falls back to <c>TENDRIL_CHAT_SESSION_ID</c> when <c>--chat-session</c> was not passed, the
+    ///     same convention as <see cref="Commands.JobStartCommand" />. A chat-launched agent inherits
+    ///     that variable (see <c>ChatExecutionService</c>), so the session that made the edit is left
+    ///     out of the fan-out even when the agent forgets the option. Job and promptware processes do
+    ///     not set it, so their edits still reach every attached session.
+    /// </summary>
+    internal static string? ResolveSourceChatSession(string? sourceChatSessionId)
+    {
+        return !string.IsNullOrWhiteSpace(sourceChatSessionId)
+            ? sourceChatSessionId
+            : Environment.GetEnvironmentVariable("TENDRIL_CHAT_SESSION_ID");
+    }
+
+    /// <summary>
+    ///     Names <c>--reason</c> when a direct edit arrives without one. Advisory: the event is still
+    ///     reported, because an edit nobody can explain still beats an edit nobody hears about.
+    /// </summary>
+    public static void WarnAboutMissingReason(string? reason)
+    {
+        if (!string.IsNullOrWhiteSpace(reason))
+            return;
+
+        Console.Error.WriteLine(
+            "warning: no --reason given for this plan edit. Pass --reason \"<why you changed it>\" so the " +
+            "plan's other chat sessions are told why, not just what.");
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PlanEditSummary.cs
+++ b/src/Ivy.Tendril/Helpers/PlanEditSummary.cs
@@ -1,0 +1,200 @@
+using System.Text;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Describes what one revision changed relative to the one before it, in a single line short
+///     enough to carry inside a chat system event ("Solution changed (+12/-3 lines), Tests added").
+///     <para>
+///         Pure over two strings on purpose: the plan-edit event is reported from a CLI process that
+///         has already written the revision, so the description must be derivable from the two
+///         markdown bodies alone, with no plans directory and no services to mock.
+///     </para>
+/// </summary>
+public static class PlanEditSummary
+{
+    private const string NoPreviousRevision = "initial revision written";
+    private const string NoSectionChanges = "no section changes";
+
+    /// <summary>The <c>##</c> sections of one revision, in document order.</summary>
+    private sealed class Sections
+    {
+        private readonly Dictionary<string, List<string>> _bodies = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Section names in the order they appear in the document.</summary>
+        public List<string> Names { get; } = [];
+
+        public List<string> this[string name] => _bodies[name];
+
+        public bool Contains(string name) => _bodies.ContainsKey(name);
+
+        public void Add(string name, List<string> body)
+        {
+            if (_bodies.TryAdd(name, body))
+                Names.Add(name);
+            else
+                _bodies[name] = body;
+        }
+    }
+
+    /// <summary>
+    ///     One line naming the <c>##</c> sections that were added, removed, renamed or changed
+    ///     between <paramref name="previousRevision" /> and <paramref name="newRevision" />.
+    /// </summary>
+    /// <param name="previousRevision">
+    ///     The revision written before this one, or null/empty when this is the plan's first.
+    /// </param>
+    public static string Describe(string? previousRevision, string newRevision)
+    {
+        if (string.IsNullOrWhiteSpace(previousRevision))
+            return NoPreviousRevision;
+
+        var before = ReadSections(previousRevision);
+        var after = ReadSections(newRevision ?? string.Empty);
+
+        var added = after.Names.Where(name => !before.Contains(name)).ToList();
+        var removed = before.Names.Where(name => !after.Contains(name)).ToList();
+        var renames = MatchRenames(before, after, added, removed);
+
+        var clauses = new List<string>();
+
+        foreach (var name in after.Names)
+        {
+            if (renames.TryGetValue(name, out var oldName))
+            {
+                clauses.Add($"{name} renamed from {oldName}");
+                continue;
+            }
+
+            if (added.Contains(name, StringComparer.OrdinalIgnoreCase))
+            {
+                clauses.Add($"{name} added");
+                continue;
+            }
+
+            var (plus, minus) = CountLineDelta(before[name], after[name]);
+            if (plus > 0 || minus > 0)
+                clauses.Add($"{name} changed (+{plus}/-{minus} lines)");
+        }
+
+        foreach (var name in removed)
+            clauses.Add($"{name} removed");
+
+        return clauses.Count > 0 ? string.Join(", ", clauses) : NoSectionChanges;
+    }
+
+    /// <summary>
+    ///     Splits a revision into its <c>##</c> sections. A heading inside a fenced code block is body
+    ///     text, not a section — plans quote markdown, and this document is itself an example.
+    /// </summary>
+    private static Sections ReadSections(string markdown)
+    {
+        var sections = new Sections();
+        var current = new List<string>();
+        string? currentName = null;
+        string? fence = null;
+
+        foreach (var rawLine in markdown.ReplaceLineEndings("\n").Split('\n'))
+        {
+            var line = rawLine.TrimEnd();
+            var trimmed = line.TrimStart();
+
+            if (fence != null)
+            {
+                if (trimmed.StartsWith(fence, StringComparison.Ordinal))
+                    fence = null;
+            }
+            else if (trimmed.StartsWith("```", StringComparison.Ordinal) ||
+                     trimmed.StartsWith("~~~", StringComparison.Ordinal))
+            {
+                fence = new string(trimmed[0], trimmed.TakeWhile(c => c == trimmed[0]).Count());
+            }
+            else if (trimmed.StartsWith("## ", StringComparison.Ordinal))
+            {
+                if (currentName != null)
+                    sections.Add(currentName, current);
+
+                currentName = trimmed[3..].Trim();
+                current = [];
+                continue;
+            }
+
+            if (currentName != null)
+                current.Add(line);
+        }
+
+        if (currentName != null)
+            sections.Add(currentName, current);
+
+        return sections;
+    }
+
+    /// <summary>
+    ///     Pairs a removed section with an added one whose body is unchanged: that is a rename rather
+    ///     than a deletion plus an insertion. Returns new name to old name, and strikes both out of
+    ///     <paramref name="added" /> and <paramref name="removed" />.
+    /// </summary>
+    private static Dictionary<string, string> MatchRenames(
+        Sections before,
+        Sections after,
+        List<string> added,
+        List<string> removed)
+    {
+        var renames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var newName in added.ToList())
+        {
+            var oldName = removed.FirstOrDefault(candidate => SameBody(before[candidate], after[newName]));
+            if (oldName == null) continue;
+
+            renames[newName] = oldName;
+            added.Remove(newName);
+            removed.Remove(oldName);
+        }
+
+        return renames;
+    }
+
+    private static bool SameBody(List<string> before, List<string> after) =>
+        Normalize(before).SequenceEqual(Normalize(after), StringComparer.Ordinal);
+
+    /// <summary>Body lines with the blank padding around a section dropped, so it never counts.</summary>
+    private static List<string> Normalize(List<string> lines) =>
+        lines.SkipWhile(string.IsNullOrWhiteSpace)
+            .Reverse()
+            .SkipWhile(string.IsNullOrWhiteSpace)
+            .Reverse()
+            .ToList();
+
+    /// <summary>
+    ///     How many lines a section gained and lost, counted as a multiset difference so a block that
+    ///     only moved does not read as a rewrite. Blank padding is ignored.
+    /// </summary>
+    private static (int Plus, int Minus) CountLineDelta(List<string> before, List<string> after)
+    {
+        var remaining = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var line in Normalize(before))
+            remaining[line] = remaining.GetValueOrDefault(line) + 1;
+
+        var plus = 0;
+        foreach (var line in Normalize(after))
+        {
+            if (remaining.TryGetValue(line, out var count) && count > 0)
+                remaining[line] = count - 1;
+            else
+                plus++;
+        }
+
+        return (plus, remaining.Values.Sum());
+    }
+
+    /// <summary>
+    ///     A short stable key for a summary, for deduplicating an edit event that carries no revision
+    ///     file name. Not a security boundary — only equality of two summaries matters.
+    /// </summary>
+    public static string Fingerprint(string text)
+    {
+        var hash = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(text ?? string.Empty));
+        return Convert.ToHexString(hash, 0, 8);
+    }
+}

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -157,7 +157,7 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `tendril plan list` | List plans (supports filters) |
 | `tendril plan create <title>` | Low-level create of the plan folder/yaml — **edit-only primitive, not for creating a plan from a chat request** (start a `CreatePlan` job instead) |
 | `tendril plan update <plan-id>` | Update plan from a file or stdin (--file/--stdin) |
-| `tendril plan set <plan-id> <field> <value>` | Set a plan field |
+| `tendril plan set <plan-id> <field> <value>` | Set a plan field (takes `--reason`, see below) |
 | `tendril plan get <plan-id> [field]` | Get plan data |
 | `tendril plan validate <plan-id>` | Validate plan health |
 | `tendril plan doctor` | Check all plans health |
@@ -169,10 +169,25 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `tendril plan remove-related-plan <plan-id> <folder>` | Remove related plan |
 | `tendril plan add-depends-on <plan-id> <folder>` | Add dependency |
 | `tendril plan remove-depends-on <plan-id> <folder>` | Remove dependency |
-| `tendril plan write-revision <plan-id>` | Write revision from a file or stdin (--file/--stdin) — **only to edit an existing plan; never to create a new plan** (start a `CreatePlan` job instead) |
+| `tendril plan write-revision <plan-id>` | Write revision from a file or stdin (--file/--stdin) — **only to edit an existing plan; never to create a new plan** (start a `CreatePlan` job instead). Takes `--reason`, see below |
 | `tendril plan get-revision <plan-id> [--number <n>]` | Print revision content (latest by default, or a specific numbered revision) |
 | `tendril plan cleanup <plan-id>` | Remove worktrees |
-| `tendril plan set-verification <plan-id> <name> <status>` | Set verification status |
+| `tendril plan set-verification <plan-id> <name> <status>` | Set verification status (takes `--reason`, see below) |
+
+#### Say Why You Edited A Plan
+
+A plan can have more than one chat session open on it — the panel beside the plan and the general
+chat. When you edit a plan directly with `write-revision`, `set` or `set-verification`, the other
+sessions are told what changed, as a `[System Event]` in their history. Pass `--reason` so they are
+told *why* as well:
+
+```bash
+tendril plan write-revision 00123 --stdin --reason "user asked to drop the CLI flag from scope"
+```
+
+Without it the other agents see the diff and have to guess the intent, and you get a warning on
+stderr. `--chat-session <id>` names the session making the edit so it is not notified about its own
+change; inside a chat this defaults to `TENDRIL_CHAT_SESSION_ID`, so you rarely need to pass it.
 
 ### Plan Recommendation Commands
 

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -38,6 +38,7 @@ public sealed class ChatExecutionService : IChatExecutionService
     private readonly IPlanDatabaseService? _database;
 
     private readonly ConcurrentDictionary<string, byte> _notifiedJobCompletions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, byte> _notifiedPlanEdits = new(StringComparer.OrdinalIgnoreCase);
     private bool _jobServiceSubscribed;
     private readonly object _jobSubLock = new();
 
@@ -116,7 +117,9 @@ public sealed class ChatExecutionService : IChatExecutionService
             sb.AppendLine($"- Execute the plan: `tendril job start ExecutePlan {folder} --chat-session {sessionId}`");
         }
         sb.AppendLine("Questions that only need an answer, and small edits the user asks you to make directly to the plan's revision, do not need a job.");
-        sb.AppendLine("Job completions are reported back into this chat as system events.");
+        sb.AppendLine("Job completions and direct plan edits are both reported back into this chat as system events.");
+        sb.AppendLine($"So when you edit the plan directly, say why: `tendril plan write-revision {folder} --stdin --reason \"<why you changed it>\" --chat-session {sessionId}`.");
+        sb.AppendLine($"The same two options work on `tendril plan set` and `tendril plan set-verification`. `--reason` is what the plan's other chat sessions are told; `--chat-session {sessionId}` keeps the event from coming back to you.");
         return sb.ToString().TrimEnd();
     }
 
@@ -972,6 +975,113 @@ public sealed class ChatExecutionService : IChatExecutionService
             "Please inspect the outcome, determine whether any action is needed or if any issues occurred, and proactively guide the user on the results and next steps.";
 
         _ = SendMessageAsync(targetSessionId, eventMessage, role: "system");
+    }
+
+    public async Task NotifyPlanEditAsync(
+        string planFolderName,
+        string summary,
+        string? reason = null,
+        string? sourceChatSessionId = null,
+        string? revisionFile = null)
+    {
+        if (string.IsNullOrWhiteSpace(planFolderName) || string.IsNullOrWhiteSpace(summary)) return;
+
+        var plan = ResolvePlanByFolderName(planFolderName);
+        var message = BuildPlanEditEvent(plan, planFolderName, summary, reason);
+
+        // A retried post must not notify twice, so key on the revision the edit produced. An edit that
+        // wrote no revision (plan set, set-verification) is keyed on the summary itself instead.
+        var editKey = !string.IsNullOrWhiteSpace(revisionFile)
+            ? revisionFile.Trim()
+            : PlanEditSummary.Fingerprint($"{summary}|{reason}");
+
+        foreach (var sessionId in ResolvePlanEditRecipients(planFolderName, plan, sourceChatSessionId))
+        {
+            if (!_notifiedPlanEdits.TryAdd($"{sessionId}:{planFolderName}:{editKey}", 0)) continue;
+
+            await SendMessageAsync(sessionId, message, role: "system");
+        }
+    }
+
+    /// <summary>
+    ///     The sessions that learn about an edit to a plan: the plan's own side-panel sessions, plus
+    ///     the general chat recorded in the plan's <c>chatSessionId</c> — usually the conversation the
+    ///     plan was created from, which is the one at risk of acting on a stale reading of it. The
+    ///     editing session itself is left out, and the list is deduplicated because those two sets
+    ///     overlap once a plan adopts its own session.
+    /// </summary>
+    private List<string> ResolvePlanEditRecipients(string planFolderName, PlanFile? plan, string? sourceChatSessionId)
+    {
+        var candidates = _chatService.GetSessions()
+            .Where(s => string.Equals(s.PlanFolderName, planFolderName, StringComparison.OrdinalIgnoreCase))
+            .Select(s => s.Id)
+            .ToList();
+
+        if (!string.IsNullOrEmpty(plan?.ChatSessionId))
+            candidates.Add(plan.ChatSessionId);
+
+        var recipients = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var sessionId in candidates)
+        {
+            if (string.IsNullOrEmpty(sessionId)) continue;
+            if (string.Equals(sessionId, sourceChatSessionId, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!seen.Add(sessionId)) continue;
+            if (_chatService.GetSession(sessionId) == null) continue;
+
+            recipients.Add(sessionId);
+        }
+
+        return recipients;
+    }
+
+    /// <summary>
+    ///     The system event announcing a plan edit, shaped like the job-completion and
+    ///     manual-execution events: what happened, then what the agent is expected to do about it.
+    /// </summary>
+    internal static string BuildPlanEditEvent(PlanFile? plan, string planFolderName, string summary, string? reason)
+    {
+        var name = plan != null ? $"'{plan.Title}' (#{plan.Id:D5})" : $"'{planFolderName}'";
+        var reasonClause = string.IsNullOrWhiteSpace(reason)
+            ? string.Empty
+            : $" Reason: {reason.Trim().TrimEnd('.')}.";
+
+        return $"[System Event] Plan {name} was edited directly from the plan chat: " +
+            $"{summary.Trim().TrimEnd('.')}.{reasonClause} " +
+            "Check whether this changes your understanding of the plan, and tell the user if anything needs follow-up.";
+    }
+
+    /// <summary>
+    ///     Resolves a plan from its folder name, falling back to the database the way
+    ///     <see cref="OnJobFinished" /> does — the plans directory is not always readable from the
+    ///     process handling the event.
+    /// </summary>
+    private PlanFile? ResolvePlanByFolderName(string folderName)
+    {
+        var planReader = ResolvedPlanReaderService;
+        if (planReader != null)
+        {
+            try
+            {
+                var plan = planReader.GetPlanByFolder(Path.Combine(planReader.PlansDirectory, folderName));
+                if (plan != null) return plan;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to read plan {FolderName} while reporting a plan edit", folderName);
+            }
+        }
+
+        try
+        {
+            return ResolvedDatabase?.GetPlanByFolder(folderName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to look up plan {FolderName} in the database while reporting a plan edit", folderName);
+            return null;
+        }
     }
 
     private void FlushExecution(string sessionId, ActiveChatExecution exec, string? fallbackMessage = null)

--- a/src/Ivy.Tendril/Services/IChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/IChatExecutionService.cs
@@ -24,6 +24,28 @@ public interface IChatExecutionService : IDisposable
         CancellationToken ct = default);
     Task CancelAsync(string sessionId);
     Task InterruptAsync(string sessionId);
+
+    /// <summary>
+    ///     Announces a direct edit to a plan — one made without a job, from a chat or the CLI — to
+    ///     every chat session attached to that plan, so a session that spawned the plan and still
+    ///     believes it knows what the plan says learns otherwise.
+    /// </summary>
+    /// <param name="planFolderName">Folder name of the edited plan, e.g. <c>00123-AddRetries</c>.</param>
+    /// <param name="summary">What changed, e.g. <c>Solution changed (+12/-3 lines)</c>.</param>
+    /// <param name="reason">Why it changed. The event omits the clause when this is absent.</param>
+    /// <param name="sourceChatSessionId">
+    ///     The session that made the edit, which is excluded from the fan-out.
+    /// </param>
+    /// <param name="revisionFile">
+    ///     The revision file written, e.g. <c>004.md</c>. Deduplicates a retried report; a summary
+    ///     fingerprint stands in when the edit wrote no revision.
+    /// </param>
+    Task NotifyPlanEditAsync(
+        string planFolderName,
+        string summary,
+        string? reason = null,
+        string? sourceChatSessionId = null,
+        string? revisionFile = null);
     Task ForceSendMessageAsync(
         string sessionId,
         string prompt,


### PR DESCRIPTION
Fixes #2455

# Notify The Master Agent Of Plan Edits Made From The Side Chat

Closes issue [#2455](https://github.com/ivy-interactive/ivy-tendril/issues/2455) (@rorychatt). A plan
edited directly from the side-panel chat now announces itself to the plan's *other* chat sessions —
what changed and why — instead of leaving the conversation that created the plan reasoning from a
version that no longer exists.

## Changes

**The event.** `ChatExecutionService.NotifyPlanEditAsync` sends a `[System Event]` to every chat
session attached to a plan: the side-panel sessions (`ChatSessionModel.PlanFolderName == FolderName`)
plus the general chat in `plan.ChatSessionId`, deduplicated, minus the session that made the edit. It
goes through the existing `SendMessageAsync(..., role: "system")` path, so an event that arrives while
a session is mid-execution queues into `_pendingSystemEvents` rather than the user's prompt queue.
A concurrent dictionary keyed on session + revision file (or a hash of the summary, for edits that
write no revision) means a retried report is announced once.

The text mirrors the two events that already exist:

```
[System Event] Plan 'Notify The Master Agent' (#00400) was edited directly from the plan chat:
Solution changed (+12/-3 lines). Reason: the user dropped the CLI flag from scope. Check whether this
changes your understanding of the plan, and tell the user if anything needs follow-up.
```

**What changed, in one line.** `PlanEditSummary.Describe(previous, next)` is pure over two revision
bodies. It diffs the `##` sections and reports what was added, removed or renamed plus a per-section
line delta — `Problem changed (+1/-1 lines), Tests added`. A retitled section with an untouched body
reads as a rename, not a deletion plus an insertion, because "Solution removed" would look like scope
being dropped. Headings inside fenced blocks are body text, since plans quote markdown. Line deltas
are a multiset difference, so a moved block does not read as a rewrite.

**Getting it there from a CLI process.** `PlanEditEventReporter` posts to
`POST api/plans/{planId}/events` with `MasterClient.TryPostJson`. Best-effort by design, like
`tendril job status`: the edit is already on disk by the time the report runs, so a missing or
restarting master produces a `Warning:` on stderr and nothing else — never a non-zero exit.

**Saying why.** `plan write-revision`, `plan set` and `plan set-verification` take
`--reason "<why you changed it>"` and `--chat-session <id>`. `write-revision` warns when `--reason` is
missing, because the other sessions can read the diff for themselves and only the editor knows the
intent. `--chat-session` falls back to `TENDRIL_CHAT_SESSION_ID`, which chat-launched agents already
inherit, so an agent that forgets the flag still cannot be notified about its own edit.

**Telling the agents.** `AgentPrompt.md` gains a "Say Why You Edited A Plan" section, and
`BuildAttachedPlanSection` now says that direct edits — not just job completions — come back as system
events, with the `--reason` form spelled out.

## API Changes

| Kind | Change |
|------|--------|
| HTTP | **New** `POST api/plans/{planId}/events`, body `{ summary, reason?, sourceChatSessionId?, revisionFile? }`. 200 when accepted (including when no session is listening), 404 for an unknown plan, 400 with no summary. |
| Interface | **New member** `IChatExecutionService.NotifyPlanEditAsync(planFolderName, summary, reason?, sourceChatSessionId?, revisionFile?)`. Breaking for any external implementer; the one in-repo test double was updated. |
| Constructor | `PlanController` gains a 4th parameter `IChatExecutionService? chatExecution = null`. Optional, so existing direct construction still compiles. |
| CLI | `tendril plan write-revision`, `plan set`, `plan set-verification` gain `--reason` and `--chat-session`. Both optional; no promptware needed changing. |
| Public helpers | **New** `PlanEditSummary.Describe` / `.Fingerprint`, **new** `PlanEditEventReporter.Report` / `.WarnAboutMissingReason`. |

No plan.yaml schema change, no database migration, no frontend change.

## Files Modified

**New**

- `src/Ivy.Tendril/Helpers/PlanEditSummary.cs` — the section diff.
- `src/Ivy.Tendril/Helpers/PlanEditEventReporter.cs` — best-effort report from a CLI process.
- `src/Ivy.Tendril.Test/PlanEditSummaryTests.cs` — 13 cases.

**Changed**

- `src/Ivy.Tendril/Services/IChatExecutionService.cs`, `Services/ChatExecutionService.cs` — the
  fan-out, its dedupe, plan resolution by folder name, and the attached-plan prompt.
- `src/Ivy.Tendril/Controllers/PlanController.cs` — the endpoint and its request record.
- `src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs`, `PlanSetCommand.cs`,
  `PlanSetVerificationCommand.cs` — `--reason` / `--chat-session` and the report call.
- `src/Ivy.Tendril/Prompts/AgentPrompt.md` — the new contract for interactive agents.
- `src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs`, `PlanChatTests.cs`,
  `PlanControllerTests.cs`, `PlanCliCommandTests.cs`,
  `Commands/PlanCreateDuplicateCandidatesTests.cs` — coverage, the new interface member on the test
  double, and two stderr assertions narrowed to the duplicate warning they were about.

## Manual Testing

Everything below needs a running Tendril instance, which the automated tests deliberately do not have
(the installed `tendril` on this machine is the pre-change build, so the reporter's success path is
covered only by the endpoint and fan-out being tested directly).

1. Open a plan in the Drafts page, use the side-panel chat to make a small edit to the plan, and
   confirm the general chat that created the plan receives a `[System Event]` naming the changed
   sections and the reason — and that the side panel itself does not.
2. Ask the side chat to change the plan's state (`plan set`) and confirm the same.
3. Run `tendril plan write-revision <id> --file rev.md` from a terminal with the app running, and
   confirm the event reaches both sessions and names `initial revision written` or the section delta.
4. Stop the app and repeat step 3: the revision must still be written, exit code 0, with a single
   `Warning: could not report the edit to plan ...` line on stderr.
5. While the side chat is generating, trigger an edit from elsewhere and confirm the event is
   delivered after the current turn finishes rather than interleaved into the prompt queue.

## Known Consequence Worth A Look

`plan set-verification` is called several times per promptware run, so an ExecutePlan job on a plan
with an attached chat will now drop one system event per verification into that chat, each waking the
agent. The plan asked for these commands to be wired ("Those are plan edits too, and the side chat
uses them") and explicitly left promptwares unmodified, so this is implemented as specified — but the
noise is real and is filed in `recommendations.md`.

---

## Commits

- Report direct plan edits from the CLI with --reason, for plan 00400 (5fa17368)
- Accept plan-edit events over the master API, for plan 00400 (5f153cd5)
- Fan a plan edit out to the plan's other chat sessions, for plan 00400 (1f0aeca7)
- Describe what a plan revision changed, for plan 00400 (b40c206f)

---
Created using [Ivy Tendril](https://ivy.app).
