### PR TITLE
[00418] Subscribe to Job Event Streams in Tendril Chat Participant

### DIFF
--- a/extensions/vscode/src/chat/chatParticipant.ts
+++ b/extensions/vscode/src/chat/chatParticipant.ts
@@ -1,8 +1,84 @@
 import * as vscode from 'vscode';
-import { IJobRunner } from '../jobs/jobRunner';
+import { IJobRunner, JobStreamEvent } from '../jobs/jobRunner';
 import { ServerManager } from '../server/serverManager';
 
 export const CHAT_PARTICIPANT_ID = 'tendril.chatParticipant';
+
+export async function streamJobProgress(
+  jobId: string,
+  response: vscode.ChatResponseStream,
+  jobRunner: IJobRunner,
+  token?: vscode.CancellationToken
+): Promise<void> {
+  const startTime = Date.now();
+  let discoveredPlanId: string | undefined;
+
+  const onEvent = (evt: JobStreamEvent) => {
+    if (token?.isCancellationRequested) {
+      return;
+    }
+
+    if (evt.planId || evt.plan_id) {
+      discoveredPlanId = String(evt.planId || evt.plan_id);
+    }
+
+    if (evt.tool_name) {
+      response.progress(`Running tool: ${evt.tool_name}...`);
+    } else if (evt.status_message || evt.message) {
+      response.progress(String(evt.status_message || evt.message));
+    } else if (evt.kind === 'thinking') {
+      response.progress('Thinking...');
+    }
+
+    if (evt.kind === 'text' && evt.text) {
+      response.markdown(evt.text);
+    } else if (evt.content && evt.kind !== 'thinking') {
+      response.markdown(evt.content);
+    } else if (evt.kind === 'tool_call' && evt.tool_name) {
+      response.markdown(`\n> 🔧 \`${evt.tool_name}\`\n\n`);
+    } else if (evt.kind === 'error' || (evt.kind === 'tool_result' && evt.is_error)) {
+      const errMsg = evt.message || evt.output || 'Unknown error';
+      response.markdown(`\n> ⚠️ **Error:** ${errMsg}\n\n`);
+    }
+  };
+
+  const finalStatus = await jobRunner.subscribeJobEvents(jobId, onEvent, token);
+
+  if (token?.isCancellationRequested) {
+    response.markdown(
+      '\n\n*(Stopped following job events. The job continues running in the background.)*'
+    );
+    return;
+  }
+
+  const elapsedSeconds = Math.max(1, Math.round((Date.now() - startTime) / 1000));
+  const planId = finalStatus.planId || discoveredPlanId;
+
+  let nextStep = '';
+  if (finalStatus.status === 'Completed' && planId) {
+    nextStep = `\n- **Next Command:** \`@tendril /run ${planId}\``;
+  } else if (finalStatus.status === 'Failed' && planId) {
+    nextStep = `\n- **Next Command:** \`@tendril /retry ${planId} <feedback>\``;
+  }
+
+  const statusBadge =
+    finalStatus.status === 'Completed'
+      ? 'Completed ✅'
+      : finalStatus.status === 'Failed'
+      ? 'Failed ❌'
+      : finalStatus.status;
+
+  const planInfo = planId ? `\n- **Plan:** \`${planId}\`` : '';
+
+  response.markdown(
+    `\n\n---\n### Job \`${jobId}\` ${statusBadge}\n` +
+      `- **Status:** ${finalStatus.status}\n` +
+      `- **Duration:** ${elapsedSeconds}s` +
+      planInfo +
+      nextStep +
+      '\n'
+  );
+}
 
 export async function handleChatRequest(
   request: vscode.ChatRequest,
@@ -51,6 +127,10 @@ export async function handleChatRequest(
           `- **Description:** ${prompt}\n\n` +
           (res.jobId ? `Use \`@tendril /status ${res.jobId}\` to monitor progress.` : '')
       );
+
+      if (res.jobId) {
+        await streamJobProgress(res.jobId, response, jobRunner, _token);
+      }
       break;
     }
 
@@ -75,6 +155,10 @@ export async function handleChatRequest(
         `${jobHeader}\n\n` +
           (res.jobId ? `Use \`@tendril /status ${res.jobId}\` to monitor execution.` : '')
       );
+
+      if (res.jobId) {
+        await streamJobProgress(res.jobId, response, jobRunner, _token);
+      }
       break;
     }
 
@@ -82,7 +166,10 @@ export async function handleChatRequest(
       await serverManager.ensureServerRunning();
 
       if (prompt) {
-        const jobId = prompt.split(/\s+/)[0];
+        const parts = prompt.split(/\s+/);
+        const jobId = parts[0];
+        const noFollow = parts.includes('--no-follow');
+
         response.progress(`Checking status for job ${jobId}...`);
         const status = await jobRunner.getJobStatus(jobId);
         response.markdown(
@@ -90,6 +177,13 @@ export async function handleChatRequest(
             `- **Status:** ${status.status}\n` +
             `- **Message:** ${status.message || 'No status message'}`
         );
+
+        if (
+          !noFollow &&
+          (status.status === 'Running' || status.status === 'Pending' || status.status === 'Queued')
+        ) {
+          await streamJobProgress(jobId, response, jobRunner, _token);
+        }
       } else {
         response.progress('Fetching active jobs...');
         const jobs = await jobRunner.listJobs();
@@ -137,6 +231,10 @@ export async function handleChatRequest(
           `- **Feedback:** ${feedback}\n\n` +
           (res.jobId ? `Use \`@tendril /status ${res.jobId}\` to monitor execution.` : '')
       );
+
+      if (res.jobId) {
+        await streamJobProgress(res.jobId, response, jobRunner, _token);
+      }
       break;
     }
 

--- a/extensions/vscode/src/jobs/jobRunner.ts
+++ b/extensions/vscode/src/jobs/jobRunner.ts
@@ -1,8 +1,23 @@
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import { CONFIG_KEYS } from '../constants';
-import { resolveTendrilHome } from '../server/masterDiscovery';
+import { discoverMaster, resolveTendrilHome } from '../server/masterDiscovery';
 import { ServerManager } from '../server/serverManager';
+
+export interface JobStreamEvent {
+  kind?: string;
+  text?: string;
+  delta?: boolean;
+  content?: string;
+  tool_name?: string;
+  tool_use_id?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  is_error?: boolean;
+  message?: string;
+  status?: string;
+  [key: string]: unknown;
+}
 
 export interface JobResult {
   jobId?: string;
@@ -14,6 +29,7 @@ export interface JobStatusResult {
   id: string;
   status: string;
   message?: string;
+  planId?: string;
 }
 
 export interface JobListItem {
@@ -33,6 +49,11 @@ export interface IJobRunner {
   startRetryPlan(planId: string, changeRequest: string): Promise<JobResult>;
   startUpdatePlan(planId: string, instructions: string): Promise<JobResult>;
   getJobStatus(jobId: string): Promise<JobStatusResult>;
+  subscribeJobEvents(
+    jobId: string,
+    onEvent: (event: JobStreamEvent) => void,
+    cancellationToken?: vscode.CancellationToken
+  ): Promise<JobStatusResult>;
   listJobs(): Promise<JobListItem[]>;
   listProjects(): Promise<string[]>;
   executeCli(args: string[]): Promise<{ stdout: string; stderr: string }>;
@@ -210,6 +231,142 @@ export class JobRunner implements IJobRunner {
       status: 'Unknown',
       message: 'Job status not found'
     };
+  }
+
+  public async subscribeJobEvents(
+    jobId: string,
+    onEvent: (event: JobStreamEvent) => void,
+    cancellationToken?: vscode.CancellationToken
+  ): Promise<JobStatusResult> {
+    let baseUrl: string | undefined;
+    let apiKey: string | undefined;
+
+    if (this.serverManager) {
+      try {
+        const health = await this.serverManager.getHealthInfo();
+        if (health.isAlive && health.baseUrl) {
+          baseUrl = health.baseUrl;
+          const discovery = discoverMaster(this.serverManager.tendrilHome, false);
+          if (discovery.status === 'found') {
+            apiKey = discovery.result.apiKey;
+          }
+        }
+      } catch {
+        // Fall back
+      }
+    }
+
+    if (!baseUrl) {
+      return await this.getJobStatus(jobId);
+    }
+
+    const abortController = new AbortController();
+    let cancellationListener: vscode.Disposable | undefined;
+    if (cancellationToken) {
+      if (cancellationToken.isCancellationRequested) {
+        abortController.abort();
+      } else {
+        cancellationListener = cancellationToken.onCancellationRequested(() => {
+          abortController.abort();
+        });
+      }
+    }
+
+    const url = `${baseUrl.replace(/\/+$/, '')}/api/jobs/${encodeURIComponent(jobId)}/events`;
+    const headers: Record<string, string> = {
+      Accept: 'text/event-stream'
+    };
+    if (apiKey) {
+      headers['x-api-key'] = apiKey;
+    }
+
+    let finalStatus: string | undefined;
+
+    const parseSseMessage = (message: string) => {
+      let eventType = '';
+      const dataLines: string[] = [];
+      for (const line of message.split(/\r?\n/)) {
+        if (line.startsWith(':')) {
+          continue;
+        }
+        if (line.startsWith('event:')) {
+          eventType = line.slice(6).trim();
+        } else if (line.startsWith('data:')) {
+          dataLines.push(line.slice(5).trimStart());
+        }
+      }
+      const dataStr = dataLines.join('\n');
+      if (!dataStr) {
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(dataStr);
+        if (eventType === 'end') {
+          if (parsed.status) {
+            finalStatus = parsed.status;
+          }
+          onEvent({ kind: 'end', status: parsed.status, ...parsed });
+        } else {
+          if (parsed.status && !finalStatus) {
+            finalStatus = parsed.status;
+          }
+          onEvent(parsed);
+        }
+      } catch {
+        onEvent({ text: dataStr, content: dataStr });
+      }
+    };
+
+    try {
+      const res = await fetch(url, {
+        headers,
+        signal: abortController.signal
+      });
+
+      if (!res.ok || !res.body) {
+        return await this.getJobStatus(jobId);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let match;
+        while ((match = buffer.match(/\r?\n\r?\n/)) !== null && match.index !== undefined) {
+          const idx = match.index;
+          const message = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + match[0].length);
+          parseSseMessage(message);
+        }
+      }
+
+      if (buffer.trim().length > 0) {
+        parseSseMessage(buffer);
+      }
+    } catch (err: unknown) {
+      if (cancellationToken?.isCancellationRequested || (err instanceof Error && err.name === 'AbortError')) {
+        return await this.getJobStatus(jobId);
+      }
+      return await this.getJobStatus(jobId);
+    } finally {
+      cancellationListener?.dispose();
+    }
+
+    if (finalStatus) {
+      return {
+        id: jobId,
+        status: finalStatus
+      };
+    }
+
+    return await this.getJobStatus(jobId);
   }
 
   public async listProjects(): Promise<string[]> {

--- a/extensions/vscode/src/test/suite/chat.test.ts
+++ b/extensions/vscode/src/test/suite/chat.test.ts
@@ -1,11 +1,13 @@
 import * as assert from 'assert';
+import * as vscode from 'vscode';
 import { handleChatRequest } from '../../chat/chatParticipant';
 import {
   IJobRunner,
   JobListItem,
   JobResult,
   JobRunner,
-  JobStatusResult
+  JobStatusResult,
+  JobStreamEvent
 } from '../../jobs/jobRunner';
 
 class MockChatResponseStream {
@@ -33,9 +35,23 @@ class TestJobRunner implements IJobRunner {
   public startRetryPlanCalls: Array<{ planId: string; changeRequest: string }> = [];
   public startUpdatePlanCalls: Array<{ planId: string; instructions: string }> = [];
   public getJobStatusCalls: string[] = [];
+  public subscribeJobEventsCalls: Array<{
+    jobId: string;
+    onEvent: (event: JobStreamEvent) => void;
+    token?: any;
+  }> = [];
   public listJobsCalls = 0;
   public listProjectsCalls = 0;
   public executeCliCalls: string[][] = [];
+
+  async subscribeJobEvents(
+    jobId: string,
+    onEvent: (event: JobStreamEvent) => void,
+    cancellationToken?: any
+  ): Promise<JobStatusResult> {
+    this.subscribeJobEventsCalls.push({ jobId, onEvent, token: cancellationToken });
+    return { id: jobId, status: 'Completed' };
+  }
 
   async startCreatePlan(desc: string, project?: string): Promise<JobResult> {
     this.startCreatePlanCalls.push({ desc, project });
@@ -328,6 +344,120 @@ describe('Tendril Chat Participant Suite', () => {
         '--instructions=Update database schema'
       ]);
       assert.strictEqual(res.jobId, '01996');
+    });
+  });
+
+  describe('Live streaming in handleChatRequest', () => {
+    it('should subscribe to jobRunner.subscribeJobEvents on /plan and render streamed output', async () => {
+      const runner = new TestJobRunner();
+      runner.subscribeJobEvents = async (jobId, onEvent) => {
+        runner.subscribeJobEventsCalls.push({ jobId, onEvent });
+        onEvent({ kind: 'text', text: 'Generating plan structure...' });
+        onEvent({ kind: 'tool_call', tool_name: 'git status' });
+        return { id: jobId, status: 'Completed', planId: '00418' };
+      };
+
+      const stream = new MockChatResponseStream();
+      const request: any = { command: 'plan', prompt: 'Add new feature' };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.subscribeJobEventsCalls.length, 1);
+      assert.strictEqual(runner.subscribeJobEventsCalls[0].jobId, '00001');
+      assert.ok(stream.markdownOutput.some(m => m.includes('Generating plan structure...')));
+      assert.ok(stream.markdownOutput.some(m => m.includes('🔧 `git status`')));
+      assert.ok(stream.markdownOutput.some(m => m.includes('Completed ✅')));
+      assert.ok(stream.markdownOutput.some(m => m.includes('@tendril /run 00418')));
+    });
+
+    it('should subscribe to jobRunner.subscribeJobEvents on /run and render streamed output', async () => {
+      const runner = new TestJobRunner();
+      runner.subscribeJobEvents = async (jobId, onEvent) => {
+        runner.subscribeJobEventsCalls.push({ jobId, onEvent });
+        onEvent({ kind: 'text', text: 'Executing plan steps...' });
+        return { id: jobId, status: 'Completed' };
+      };
+
+      const stream = new MockChatResponseStream();
+      const request: any = { command: 'run', prompt: '00418' };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.subscribeJobEventsCalls.length, 1);
+      assert.strictEqual(runner.subscribeJobEventsCalls[0].jobId, '00002');
+      assert.ok(stream.markdownOutput.some(m => m.includes('Executing plan steps...')));
+      assert.ok(stream.markdownOutput.some(m => m.includes('Completed ✅')));
+    });
+
+    it('should subscribe to jobRunner.subscribeJobEvents on /retry and render streamed output', async () => {
+      const runner = new TestJobRunner();
+      runner.subscribeJobEvents = async (jobId, onEvent) => {
+        runner.subscribeJobEventsCalls.push({ jobId, onEvent });
+        onEvent({ kind: 'text', text: 'Retrying plan with feedback...' });
+        return { id: jobId, status: 'Completed' };
+      };
+
+      const stream = new MockChatResponseStream();
+      const request: any = { command: 'retry', prompt: '00418 Fix compile issues' };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.subscribeJobEventsCalls.length, 1);
+      assert.strictEqual(runner.subscribeJobEventsCalls[0].jobId, '00003');
+      assert.ok(stream.markdownOutput.some(m => m.includes('Retrying plan with feedback...')));
+      assert.ok(stream.markdownOutput.some(m => m.includes('Completed ✅')));
+    });
+
+    it('should stream live progress on /status <jobId> when job is running', async () => {
+      const runner = new TestJobRunner();
+      runner.getJobStatus = async (jobId) => ({ id: jobId, status: 'Running', message: 'In progress' });
+      runner.subscribeJobEvents = async (jobId, onEvent) => {
+        runner.subscribeJobEventsCalls.push({ jobId, onEvent });
+        onEvent({ kind: 'text', text: 'Currently compiling...' });
+        return { id: jobId, status: 'Completed' };
+      };
+
+      const stream = new MockChatResponseStream();
+      const request: any = { command: 'status', prompt: '01864' };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.subscribeJobEventsCalls.length, 1);
+      assert.strictEqual(runner.subscribeJobEventsCalls[0].jobId, '01864');
+      assert.ok(stream.markdownOutput.some(m => m.includes('Currently compiling...')));
+    });
+
+    it('should not stream on /status <jobId> --no-follow', async () => {
+      const runner = new TestJobRunner();
+      runner.getJobStatus = async (jobId) => ({ id: jobId, status: 'Running', message: 'In progress' });
+
+      const stream = new MockChatResponseStream();
+      const request: any = { command: 'status', prompt: '01864 --no-follow' };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager);
+
+      assert.strictEqual(runner.subscribeJobEventsCalls.length, 0);
+    });
+
+    it('should handle cancellation gracefully when CancellationToken is cancelled during streaming', async () => {
+      const runner = new TestJobRunner();
+      const cts = new vscode.CancellationTokenSource();
+
+      runner.subscribeJobEvents = async (jobId, _onEvent, _token) => {
+        cts.cancel();
+        return { id: jobId, status: 'Running' };
+      };
+
+      const stream = new MockChatResponseStream();
+      const request: any = { command: 'run', prompt: '00418' };
+
+      await handleChatRequest(request, stream as any, runner, mockServerManager, cts.token);
+
+      assert.ok(
+        stream.markdownOutput.some(m =>
+          m.includes('Stopped following job events')
+        )
+      );
     });
   });
 });

--- a/extensions/vscode/src/test/suite/commands.test.ts
+++ b/extensions/vscode/src/test/suite/commands.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { registerPlanCommands } from '../../commands/planCommands';
 import { COMMANDS } from '../../constants';
-import { IJobRunner, JobListItem, JobResult, JobStatusResult } from '../../jobs/jobRunner';
+import { IJobRunner, JobListItem, JobResult, JobStatusResult, JobStreamEvent } from '../../jobs/jobRunner';
 
 class MockJobRunner implements IJobRunner {
   public startCreatePlanCalls: Array<{ desc: string; project?: string }> = [];
@@ -36,6 +36,14 @@ class MockJobRunner implements IJobRunner {
   async getJobStatus(jobId: string): Promise<JobStatusResult> {
     this.getJobStatusCalls.push(jobId);
     return { id: jobId, status: 'Running', message: 'All checks passed' };
+  }
+
+  async subscribeJobEvents(
+    jobId: string,
+    _onEvent: (event: JobStreamEvent) => void,
+    _cancellationToken?: vscode.CancellationToken
+  ): Promise<JobStatusResult> {
+    return { id: jobId, status: 'Completed' };
   }
 
   async listJobs(): Promise<JobListItem[]> {

--- a/extensions/vscode/src/test/suite/jobs.test.ts
+++ b/extensions/vscode/src/test/suite/jobs.test.ts
@@ -1,0 +1,160 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { JobRunner, JobStreamEvent } from '../../jobs/jobRunner';
+
+describe('JobRunner Suite', () => {
+  describe('subscribeJobEvents', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should parse SSE stream and dispatch onEvent callbacks', async () => {
+      const mockServerManager: any = {
+        tendrilHome: '/mock/tendril',
+        getHealthInfo: async () => ({
+          isAlive: true,
+          baseUrl: 'http://localhost:5000',
+          port: 5000,
+          pid: 1234
+        })
+      };
+
+      const ssePayload = [
+        'data: {"kind":"text","text":"Hello world"}\n\n',
+        'data: {"kind":"tool_call","tool_name":"dotnet build"}\n\n',
+        'event: end\ndata: {"status":"Completed"}\n\n'
+      ].join('');
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(ssePayload));
+          controller.close();
+        }
+      });
+
+      let requestedUrl = '';
+      let requestedHeaders: any = {};
+
+      global.fetch = (async (url: string, init?: any) => {
+        requestedUrl = url;
+        requestedHeaders = init?.headers;
+        return new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' }
+        });
+      }) as any;
+
+      const runner = new JobRunner(mockServerManager);
+      const events: JobStreamEvent[] = [];
+
+      const result = await runner.subscribeJobEvents('00418', (evt) => {
+        events.push(evt);
+      });
+
+      assert.strictEqual(requestedUrl, 'http://localhost:5000/api/jobs/00418/events');
+      assert.strictEqual(requestedHeaders['Accept'], 'text/event-stream');
+      assert.strictEqual(events.length, 3);
+      assert.strictEqual(events[0].kind, 'text');
+      assert.strictEqual(events[0].text, 'Hello world');
+      assert.strictEqual(events[1].kind, 'tool_call');
+      assert.strictEqual(events[1].tool_name, 'dotnet build');
+      assert.strictEqual(events[2].kind, 'end');
+      assert.strictEqual(events[2].status, 'Completed');
+      assert.strictEqual(result.id, '00418');
+      assert.strictEqual(result.status, 'Completed');
+    });
+
+    it('should handle multi-chunk SSE stream delivery', async () => {
+      const mockServerManager: any = {
+        tendrilHome: '/mock/tendril',
+        getHealthInfo: async () => ({
+          isAlive: true,
+          baseUrl: 'http://localhost:5000',
+          port: 5000,
+          pid: 1234
+        })
+      };
+
+      const chunk1 = 'data: {"kind":"text","te';
+      const chunk2 = 'xt":"split payload"}\n\n';
+      const chunk3 = 'event: end\ndata: {"status":"Failed"}\n\n';
+
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new TextEncoder().encode(chunk1));
+          controller.enqueue(new TextEncoder().encode(chunk2));
+          controller.enqueue(new TextEncoder().encode(chunk3));
+          controller.close();
+        }
+      });
+
+      global.fetch = (async () => {
+        return new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' }
+        });
+      }) as any;
+
+      const runner = new JobRunner(mockServerManager);
+      const events: JobStreamEvent[] = [];
+
+      const result = await runner.subscribeJobEvents('00418', (evt) => {
+        events.push(evt);
+      });
+
+      assert.strictEqual(events.length, 2);
+      assert.strictEqual(events[0].text, 'split payload');
+      assert.strictEqual(events[1].status, 'Failed');
+      assert.strictEqual(result.status, 'Failed');
+    });
+
+    it('should abort stream when cancellation token triggers', async () => {
+      const mockServerManager: any = {
+        tendrilHome: '/mock/tendril',
+        getHealthInfo: async () => ({
+          isAlive: true,
+          baseUrl: 'http://localhost:5000',
+          port: 5000,
+          pid: 1234
+        })
+      };
+
+      const cts = new vscode.CancellationTokenSource();
+
+      let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const stream = new ReadableStream({
+        start(controller) {
+          streamController = controller;
+          controller.enqueue(new TextEncoder().encode('data: {"kind":"text","text":"start"}\n\n'));
+        }
+      });
+
+      global.fetch = (async (_url: string, init?: any) => {
+        if (init?.signal) {
+          init.signal.addEventListener('abort', () => {
+            try {
+              streamController?.error(new DOMException('The operation was aborted.', 'AbortError'));
+            } catch {}
+          });
+        }
+        return new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' }
+        });
+      }) as any;
+
+      const runner = new JobRunner(mockServerManager);
+      runner.getJobStatus = async (jobId) => ({ id: jobId, status: 'Running' });
+
+      const promise = runner.subscribeJobEvents('00418', () => {
+        cts.cancel();
+      }, cts.token);
+
+      const result = await promise;
+      assert.strictEqual(result.id, '00418');
+      assert.strictEqual(result.status, 'Running');
+    });
+  });
+});

--- a/extensions/vscode/src/test/vscodeMock.ts
+++ b/extensions/vscode/src/test/vscodeMock.ts
@@ -106,6 +106,40 @@ export class MockEventEmitter<T = unknown> {
   }
 }
 
+export class MockCancellationToken {
+  public isCancellationRequested = false;
+  private listeners: (() => void)[] = [];
+
+  public onCancellationRequested = (listener: () => void) => {
+    this.listeners.push(listener);
+    return {
+      dispose: () => {
+        const idx = this.listeners.indexOf(listener);
+        if (idx >= 0) {
+          this.listeners.splice(idx, 1);
+        }
+      }
+    };
+  };
+
+  public cancel(): void {
+    this.isCancellationRequested = true;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export class MockCancellationTokenSource {
+  public token = new MockCancellationToken();
+
+  public cancel(): void {
+    this.token.cancel();
+  }
+
+  public dispose(): void {}
+}
+
 const registeredCommands = new Map<string, (...args: unknown[]) => unknown>();
 
 export const vscodeMock = {
@@ -119,6 +153,7 @@ export const vscodeMock = {
   ThemeColor: MockThemeColor,
   TreeItem: MockTreeItem,
   EventEmitter: MockEventEmitter,
+  CancellationTokenSource: MockCancellationTokenSource,
   env: {
     lastOpenedUri: undefined as unknown,
     openExternal: async (uri: unknown) => {
@@ -162,7 +197,8 @@ export const vscodeMock = {
     }),
     openTextDocument: async (filePath: string) => ({ uri: MockUri.file(filePath) }),
     workspaceFolders: [],
-    updateWorkspaceFolders: () => true
+    updateWorkspaceFolders: () => true,
+    onDidChangeWorkspaceFolders: () => ({ dispose: () => {} })
   },
   commands: {
     registerCommand: (command: string, callback: (...args: unknown[]) => unknown) => {

--- a/src/Ivy.Tendril.Test/JobControllerTests.cs
+++ b/src/Ivy.Tendril.Test/JobControllerTests.cs
@@ -1,0 +1,149 @@
+using System.Text;
+using Ivy.Tendril.Controllers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Jobs;
+using Ivy.Tendril.Test.TestHelpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ivy.Tendril.Test;
+
+public class JobControllerTests
+{
+    [Fact]
+    public async Task GetJobEvents_ReplaysExistingOutputLines()
+    {
+        var job = new JobItem
+        {
+            Id = "00001",
+            Status = JobStatus.Completed
+        };
+        job.OutputLines.Enqueue("{\"kind\":\"text\",\"text\":\"hello\"}");
+        job.OutputLines.Enqueue("{\"kind\":\"text\",\"text\":\"world\"}");
+
+        var jobService = new StubJobService();
+        jobService.Jobs[job.Id] = job;
+
+        var controller = CreateController(jobService);
+        var bodyStream = new MemoryStream();
+        controller.ControllerContext.HttpContext.Response.Body = bodyStream;
+
+        await controller.GetJobEvents("00001", CancellationToken.None);
+
+        Assert.Equal("text/event-stream", controller.Response.ContentType);
+        Assert.Equal("no-cache", controller.Response.Headers["Cache-Control"].ToString());
+
+        bodyStream.Position = 0;
+        using var reader = new StreamReader(bodyStream, Encoding.UTF8);
+        var content = await reader.ReadToEndAsync();
+
+        Assert.Contains("data: {\"kind\":\"text\",\"text\":\"hello\"}\n\n", content);
+        Assert.Contains("data: {\"kind\":\"text\",\"text\":\"world\"}\n\n", content);
+        Assert.Contains("event: end\ndata: {\"status\":\"Completed\"}\n\n", content);
+    }
+
+    [Fact]
+    public async Task GetJobEvents_StreamsLiveEvents()
+    {
+        var job = new JobItem
+        {
+            Id = "00002",
+            Status = JobStatus.Running
+        };
+
+        var jobService = new StubJobService();
+        jobService.Jobs[job.Id] = job;
+
+        var controller = CreateController(jobService);
+        var bodyStream = new MemoryStream();
+        controller.ControllerContext.HttpContext.Response.Body = bodyStream;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var streamTask = controller.GetJobEvents("00002", cts.Token);
+
+        // Push live output
+        job.EnqueueSystemOutput("live message from agent");
+
+        // Complete the job
+        job.Status = JobStatus.Completed;
+        job.DisposeResources();
+        jobService.NotifyJobFinished(job);
+
+        await streamTask;
+
+        bodyStream.Position = 0;
+        using var reader = new StreamReader(bodyStream, Encoding.UTF8);
+        var content = await reader.ReadToEndAsync();
+
+        Assert.Contains("live message from agent", content);
+        Assert.Contains("event: end\ndata: {\"status\":\"Completed\"}\n\n", content);
+    }
+
+    [Fact]
+    public async Task GetJobEvents_ReturnsNotFoundForUnknownJob()
+    {
+        var jobService = new StubJobService();
+        var controller = CreateController(jobService);
+        var bodyStream = new MemoryStream();
+        controller.ControllerContext.HttpContext.Response.Body = bodyStream;
+
+        await controller.GetJobEvents("nonexistent-999", CancellationToken.None);
+
+        Assert.Equal(404, controller.Response.StatusCode);
+    }
+
+    private static JobController CreateController(IJobService jobService)
+    {
+        var controller = new JobController(jobService, new StubConfigService());
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        return controller;
+    }
+
+    private class StubJobService : IJobService
+    {
+        public Dictionary<string, JobItem> Jobs { get; } = new();
+
+        public event Action<JobItem>? JobFinished;
+
+        public void NotifyJobFinished(JobItem job)
+        {
+            JobFinished?.Invoke(job);
+        }
+
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null)
+        {
+            var id = $"job-{Jobs.Count + 1}";
+            Jobs[id] = new JobItem { Id = id };
+            return id;
+        }
+
+        public void ForceStartJob(string id) { }
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
+        public void StopJob(string id) { }
+        public int StopAllJobs() => 0;
+        public void DeleteJob(string id) { }
+        public void ClearCompletedJobs() { }
+        public void ClearFailedJobs() { }
+        public void ClearAllJobs() { }
+        public int StopQueuedJobs() => 0;
+        public List<JobItem> GetJobs() => Jobs.Values.ToList();
+        public List<JobItem> GetJobsForPlan(string planFile) => [];
+        public JobItem? GetJob(string id) => Jobs.GetValueOrDefault(id);
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
+        public void SetChatSessionId(string id, string chatSessionId) { }
+        public bool ReportJobFailure(string id, string message) => false;
+        public bool IsInboxFileTracked(string filePath) => false;
+        public void Dispose() { }
+
+#pragma warning disable CS0067
+        public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
+        public event Action<JobNotification>? NotificationReady;
+#pragma warning restore CS0067
+    }
+}

--- a/src/Ivy.Tendril/Controllers/JobController.cs
+++ b/src/Ivy.Tendril/Controllers/JobController.cs
@@ -1,6 +1,7 @@
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Ivy.Tendril.Controllers;
@@ -10,6 +11,101 @@ namespace Ivy.Tendril.Controllers;
 public class JobController(IJobService jobService, IConfigService configService) : ControllerBase
 {
     private static string NormalizeJobId(string jobId) => Helpers.JobId.Normalize(jobId);
+
+    [HttpGet("{jobId}/events")]
+    public async Task GetJobEvents(string jobId, CancellationToken cancellationToken)
+    {
+        var id = NormalizeJobId(jobId);
+        var job = jobService.GetJob(id);
+        if (job == null)
+        {
+            Response.StatusCode = StatusCodes.Status404NotFound;
+            await Response.WriteAsJsonAsync(new { error = "Job not found" }, cancellationToken);
+            return;
+        }
+
+        Response.ContentType = "text/event-stream";
+        Response.Headers["Cache-Control"] = "no-cache";
+        Response.Headers["Connection"] = "keep-alive";
+        Response.Headers["X-Accel-Buffering"] = "no";
+
+        try
+        {
+            foreach (var line in job.OutputLines)
+            {
+                if (cancellationToken.IsCancellationRequested) return;
+                await WriteSseLineAsync(Response, line, cancellationToken);
+            }
+
+            if (IsTerminal(job.Status))
+            {
+                await WriteSseEndAsync(Response, job.Status.ToString(), cancellationToken);
+                return;
+            }
+
+            var channel = System.Threading.Channels.Channel.CreateUnbounded<string>();
+
+            void OnJobFinished(JobItem finishedJob)
+            {
+                if (finishedJob.Id == job.Id)
+                {
+                    channel.Writer.TryComplete();
+                }
+            }
+
+            jobService.JobFinished += OnJobFinished;
+
+            using var subscription = job.OutputObservable.Subscribe(
+                onNext: line => channel.Writer.TryWrite(line),
+                onError: ex => channel.Writer.TryComplete(ex),
+                onCompleted: () => channel.Writer.TryComplete());
+
+            try
+            {
+                if (IsTerminal(job.Status))
+                {
+                    channel.Writer.TryComplete();
+                }
+
+                while (await channel.Reader.WaitToReadAsync(cancellationToken))
+                {
+                    while (channel.Reader.TryRead(out var line))
+                    {
+                        await WriteSseLineAsync(Response, line, cancellationToken);
+                    }
+                }
+
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await WriteSseEndAsync(Response, job.Status.ToString(), cancellationToken);
+                }
+            }
+            finally
+            {
+                jobService.JobFinished -= OnJobFinished;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected gracefully
+        }
+    }
+
+    private static bool IsTerminal(JobStatus status) =>
+        status is JobStatus.Completed or JobStatus.Failed or JobStatus.Stopped or JobStatus.Timeout;
+
+    private static async Task WriteSseLineAsync(HttpResponse response, string line, CancellationToken cancellationToken)
+    {
+        var cleanLine = line.TrimEnd('\r', '\n');
+        await response.WriteAsync($"data: {cleanLine}\n\n", cancellationToken);
+        await response.Body.FlushAsync(cancellationToken);
+    }
+
+    private static async Task WriteSseEndAsync(HttpResponse response, string status, CancellationToken cancellationToken)
+    {
+        await response.WriteAsync($"event: end\ndata: {{\"status\":\"{status}\"}}\n\n", cancellationToken);
+        await response.Body.FlushAsync(cancellationToken);
+    }
 
     [HttpPost]
     public IActionResult StartJob([FromBody] JobArgsBase args)


### PR DESCRIPTION
# Plan 00418: Subscribe to Job Event Streams in Tendril Chat Participant

## Executive Summary
Implemented live Server-Sent Events (SSE) streaming for job execution progress, bridging the Tendril ASP.NET Core backend with the `@tendril` VS Code chat participant. Developers triggering `/plan`, `/run`, `/retry`, or `/status` now observe real-time progress updates, tool activity, assistant text deltas, and terminal status cards directly within their VS Code chat session.

## Key Changes

### 1. Tendril Server (`Ivy.Tendril`)
- **SSE Streaming Endpoint**: Added `[HttpGet("{jobId}/events")]` to `JobController.cs`.
- **Buffered Replay**: Immediately flushes existing output lines from `job.OutputLines` for subscribers that connect after job initiation.
- **Live Event Observation**: Subscribes to `job.OutputObservable` and serializes incoming events as SSE chunks (`data: <json>\n\n`).
- **Terminal Event & Disconnect Safety**: Emits an `event: end` message when jobs reach terminal states (`Completed`, `Failed`, `Stopped`), and gracefully handles cancellation tokens via `HttpContext.RequestAborted`.

### 2. VS Code Extension (`extensions/vscode`)
- **Event Streaming in JobRunner**: Defined the `JobStreamEvent` interface and implemented `subscribeJobEvents` in `jobRunner.ts` to consume and parse the SSE event stream with cancellation support.
- **Live Progress in Chat Participant**: Added `streamJobProgress` in `chatParticipant.ts`. Renders live progress spinner updates, tool execution badges, text deltas, and completion summaries.
- **Command Integration**: Integrated live progress streaming into `/plan`, `/run`, `/retry`, and `/status` chat commands.

### 3. Test Coverage & Verification
- **Backend Unit Tests**: Added unit tests in `src/Ivy.Tendril.Test/JobControllerTests.cs` verifying replay buffer, live SSE streaming, and 404 responses for unknown jobs.
- **VS Code Extension Tests**: Added unit tests in `extensions/vscode/src/test/suite/jobs.test.ts` and `extensions/vscode/src/test/suite/chat.test.ts` covering SSE parsing, chunking, chat command integration, and cancellation handling.
- **Verifications**:
  - `DotnetFormat`: Pass
  - `DotnetBuild`: Pass (clean build with `--warnaserror`)
  - `DotnetTest`: Pass (all backend and frontend test suites pass)
  - `CheckResult`: Pass (all plan objectives fully implemented)

---
## Commits
- 515fd892 Plan 00418: Stream live job progress in Tendril chat participant with tests
- 123b878d Plan 00418: Add JobStreamEvent and subscribeJobEvents to VS Code JobRunner with tests
- f7d41756 Plan 00418: Add SSE streaming endpoint for job event streams and unit tests

---
Created using [Ivy Tendril](https://ivy.app).