### PR TITLE
[00428] Support Monorepo Subprojects in Plan Project Resolver

### DIFF
--- a/src/Ivy.Tendril.Test/Helpers/PlanProjectResolverTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PlanProjectResolverTests.cs
@@ -129,4 +129,219 @@ public class PlanProjectResolverTests
         Assert.Contains("Alpha", ex.Message);
         Assert.Contains("Beta", ex.Message);
     }
+
+    [Fact]
+    public void Resolves_Correct_Monorepo_Project_When_Multiple_Projects_Share_Git_Root_By_Repo_Subfolder()
+    {
+        var repoDir = Path.Combine(Path.GetTempPath(), $"tendril-test-monorepo-repo-{Guid.NewGuid():N}");
+        var gitDir = Path.Combine(repoDir, ".git");
+        var subDirA = Path.Combine(repoDir, "apps", "frontend");
+        var subDirB = Path.Combine(repoDir, "apps", "backend");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(subDirA);
+        Directory.CreateDirectory(subDirB);
+
+        try
+        {
+            var projectA = ConfiguredProject("ProjectFrontend", subDirA);
+            var projectB = ConfiguredProject("ProjectBackend", subDirB);
+            var available = new List<ProjectConfig> { projectA, projectB };
+
+            var resolved = PlanProjectResolver.ResolveProject(subDirB, available);
+
+            Assert.Same(projectB, resolved);
+            Assert.Equal("ProjectBackend", resolved.Name);
+            Assert.False(resolved.IsAdHoc);
+        }
+        finally
+        {
+            if (Directory.Exists(repoDir))
+                Directory.Delete(repoDir, true);
+        }
+    }
+
+    [Fact]
+    public void Resolves_Correct_Monorepo_Project_Using_ProjectConfig_Subdirectory()
+    {
+        var repoDir = Path.Combine(Path.GetTempPath(), $"tendril-test-monorepo-sub-{Guid.NewGuid():N}");
+        var gitDir = Path.Combine(repoDir, ".git");
+        var subDirA = Path.Combine(repoDir, "apps", "frontend");
+        var subDirASrc = Path.Combine(subDirA, "src");
+        var subDirB = Path.Combine(repoDir, "apps", "backend");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(subDirASrc);
+        Directory.CreateDirectory(subDirB);
+
+        try
+        {
+            var projectA = new ProjectConfig
+            {
+                Name = "ProjectFrontend",
+                Subdirectory = "apps/frontend",
+                Repos = [new RepoRef { Path = repoDir }]
+            };
+            var projectB = new ProjectConfig
+            {
+                Name = "ProjectBackend",
+                Subdirectory = "apps/backend",
+                Repos = [new RepoRef { Path = repoDir }]
+            };
+            var available = new List<ProjectConfig> { projectA, projectB };
+
+            var resolved = PlanProjectResolver.ResolveProject(subDirASrc, available);
+
+            Assert.Same(projectA, resolved);
+            Assert.Equal("ProjectFrontend", resolved.Name);
+            Assert.False(resolved.IsAdHoc);
+        }
+        finally
+        {
+            if (Directory.Exists(repoDir))
+                Directory.Delete(repoDir, true);
+        }
+    }
+
+    [Fact]
+    public void Resolves_Most_Specific_Subdirectory_When_Nested()
+    {
+        var repoDir = Path.Combine(Path.GetTempPath(), $"tendril-test-monorepo-nested-{Guid.NewGuid():N}");
+        var gitDir = Path.Combine(repoDir, ".git");
+        var appsDir = Path.Combine(repoDir, "apps");
+        var frontendDir = Path.Combine(appsDir, "frontend");
+        var srcDir = Path.Combine(frontendDir, "src");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(srcDir);
+
+        try
+        {
+            var projectApps = new ProjectConfig
+            {
+                Name = "ProjectApps",
+                Subdirectory = "apps",
+                Repos = [new RepoRef { Path = repoDir }]
+            };
+            var projectFrontend = new ProjectConfig
+            {
+                Name = "ProjectFrontend",
+                Subdirectory = "apps/frontend",
+                Repos = [new RepoRef { Path = repoDir }]
+            };
+            var available = new List<ProjectConfig> { projectApps, projectFrontend };
+
+            var resolved = PlanProjectResolver.ResolveProject(srcDir, available);
+
+            Assert.Same(projectFrontend, resolved);
+            Assert.Equal("ProjectFrontend", resolved.Name);
+            Assert.False(resolved.IsAdHoc);
+        }
+        finally
+        {
+            if (Directory.Exists(repoDir))
+                Directory.Delete(repoDir, true);
+        }
+    }
+
+    [Fact]
+    public void Resolves_Root_Project_When_Subfolder_Does_Not_Match_Specific_Subprojects()
+    {
+        var repoDir = Path.Combine(Path.GetTempPath(), $"tendril-test-monorepo-root-{Guid.NewGuid():N}");
+        var gitDir = Path.Combine(repoDir, ".git");
+        var frontendDir = Path.Combine(repoDir, "apps", "frontend");
+        var toolsScriptsDir = Path.Combine(repoDir, "tools", "scripts");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(frontendDir);
+        Directory.CreateDirectory(toolsScriptsDir);
+
+        try
+        {
+            var projectRoot = new ProjectConfig
+            {
+                Name = "MonorepoRoot",
+                Repos = [new RepoRef { Path = repoDir }]
+            };
+            var projectFrontend = new ProjectConfig
+            {
+                Name = "ProjectFrontend",
+                Subdirectory = "apps/frontend",
+                Repos = [new RepoRef { Path = repoDir }]
+            };
+            var available = new List<ProjectConfig> { projectFrontend, projectRoot };
+
+            var resolved = PlanProjectResolver.ResolveProject(toolsScriptsDir, available);
+
+            Assert.Same(projectRoot, resolved);
+            Assert.Equal("MonorepoRoot", resolved.Name);
+            Assert.False(resolved.IsAdHoc);
+        }
+        finally
+        {
+            if (Directory.Exists(repoDir))
+                Directory.Delete(repoDir, true);
+        }
+    }
+
+    [Fact]
+    public void Does_Not_Match_Subdirectory_When_Prefix_Is_Partial_Directory_Name()
+    {
+        var repoDir = Path.Combine(Path.GetTempPath(), $"tendril-test-monorepo-prefix-{Guid.NewGuid():N}");
+        var gitDir = Path.Combine(repoDir, ".git");
+        var frontendDir = Path.Combine(repoDir, "apps", "frontend");
+        var frontendExtraDir = Path.Combine(repoDir, "apps", "frontend-extra");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(frontendDir);
+        Directory.CreateDirectory(frontendExtraDir);
+
+        try
+        {
+            var projectFrontend = new ProjectConfig
+            {
+                Name = "ProjectFrontend",
+                Subdirectory = "apps/frontend",
+                Repos = [new RepoRef { Path = repoDir }]
+            };
+            var available = new List<ProjectConfig> { projectFrontend };
+
+            // Single candidate whose subdirectory conflicts with target path: falls through to ad-hoc
+            var resolved = PlanProjectResolver.ResolveProject(frontendExtraDir, available);
+
+            Assert.True(resolved.IsAdHoc);
+            Assert.Equal(Path.GetFileName(repoDir), resolved.Name);
+        }
+        finally
+        {
+            if (Directory.Exists(repoDir))
+                Directory.Delete(repoDir, true);
+        }
+    }
+
+    [Fact]
+    public void Resolves_Using_RepoRef_Subdirectory()
+    {
+        var repoDir = Path.Combine(Path.GetTempPath(), $"tendril-test-reporef-sub-{Guid.NewGuid():N}");
+        var gitDir = Path.Combine(repoDir, ".git");
+        var adminDir = Path.Combine(repoDir, "apps", "admin");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(adminDir);
+
+        try
+        {
+            var projectAdmin = new ProjectConfig
+            {
+                Name = "ProjectAdmin",
+                Repos = [new RepoRef { Path = repoDir, Subdirectory = "apps/admin" }]
+            };
+            var available = new List<ProjectConfig> { projectAdmin };
+
+            var resolved = PlanProjectResolver.ResolveProject(adminDir, available);
+
+            Assert.Same(projectAdmin, resolved);
+            Assert.Equal("ProjectAdmin", resolved.Name);
+            Assert.False(resolved.IsAdHoc);
+        }
+        finally
+        {
+            if (Directory.Exists(repoDir))
+                Directory.Delete(repoDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Helpers/PlanProjectResolver.cs
+++ b/src/Ivy.Tendril/Helpers/PlanProjectResolver.cs
@@ -29,13 +29,63 @@ public static class PlanProjectResolver
                 if (gitRoot != null)
                 {
                     var normalizedGitRoot = NormalizeLocalPath(gitRoot);
-                    var matchingProject = available.FirstOrDefault(p =>
-                        p.Repos.Any(r => !string.IsNullOrWhiteSpace(r.Path) &&
-                                         string.Equals(NormalizeLocalPath(r.Path), normalizedGitRoot, StringComparison.OrdinalIgnoreCase)));
+                    var normalizedFullPath = NormalizeLocalPath(fullPath);
 
-                    if (matchingProject != null)
+                    var candidateProjects = available.Where(p =>
+                        p.Repos.Any(r => RepoBelongsToGitRoot(r, normalizedGitRoot))).ToList();
+
+                    if (candidateProjects.Count == 1)
                     {
-                        return matchingProject;
+                        var singleCandidate = candidateProjects[0];
+                        var subdirs = GetProjectSubdirectories(singleCandidate, normalizedGitRoot);
+                        if (subdirs.Count > 0)
+                        {
+                            if (subdirs.Any(s => IsSameOrSubdirectory(normalizedFullPath, s)))
+                            {
+                                return singleCandidate;
+                            }
+                            // Subdirectories conflict with fullPath: fall through to ad-hoc project creation
+                        }
+                        else
+                        {
+                            return singleCandidate;
+                        }
+                    }
+                    else if (candidateProjects.Count > 1)
+                    {
+                        var matchingWithLength = candidateProjects
+                            .Select(p =>
+                            {
+                                var subdirs = GetProjectSubdirectories(p, normalizedGitRoot);
+                                var matching = subdirs.Where(s => IsSameOrSubdirectory(normalizedFullPath, s)).ToList();
+                                return new
+                                {
+                                    Project = p,
+                                    Subdirs = subdirs,
+                                    MaxMatchLength = matching.Count > 0 ? matching.Max(s => s.Length) : -1
+                                };
+                            })
+                            .ToList();
+
+                        var bestMatch = matchingWithLength
+                            .Where(x => x.MaxMatchLength >= 0)
+                            .OrderByDescending(x => x.MaxMatchLength)
+                            .FirstOrDefault();
+
+                        if (bestMatch != null)
+                        {
+                            return bestMatch.Project;
+                        }
+
+                        var rootProject = matchingWithLength
+                            .FirstOrDefault(x => x.Subdirs.Count == 0);
+
+                        if (rootProject != null)
+                        {
+                            return rootProject.Project;
+                        }
+
+                        return candidateProjects[0];
                     }
                 }
 
@@ -66,16 +116,136 @@ public static class PlanProjectResolver
         return project;
     }
 
-    private static string NormalizeLocalPath(string path)
+    private static bool RepoBelongsToGitRoot(RepoRef repo, string normalizedGitRoot)
+    {
+        if (string.IsNullOrWhiteSpace(repo.Path))
+            return false;
+
+        var normalizedRepoPath = NormalizeLocalPath(repo.Path);
+        if (string.Equals(normalizedRepoPath, normalizedGitRoot, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (IsSubdirectory(normalizedRepoPath, normalizedGitRoot))
+            return true;
+
+        if (!Path.IsPathRooted(repo.Path))
+        {
+            var combined = NormalizeLocalPath(Path.Combine(normalizedGitRoot, repo.Path));
+            if (IsSubdirectory(combined, normalizedGitRoot))
+                return true;
+        }
+
+        try
+        {
+            var resolvedRoot = GitHelper.ResolveGitRoot(repo.Path);
+            if (resolvedRoot != null && string.Equals(NormalizeLocalPath(resolvedRoot), normalizedGitRoot, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        catch
+        {
+            // Ignore any errors if path does not exist
+        }
+
+        return false;
+    }
+
+    private static List<string> GetProjectSubdirectories(ProjectConfig project, string normalizedGitRoot)
+    {
+        var subdirs = new List<string>();
+
+        void AddSubdir(string? sub)
+        {
+            if (string.IsNullOrWhiteSpace(sub)) return;
+
+            string normalized;
+            if (Path.IsPathRooted(sub))
+            {
+                normalized = NormalizeLocalPath(sub);
+            }
+            else
+            {
+                normalized = NormalizeLocalPath(Path.Combine(normalizedGitRoot, sub));
+            }
+
+            if (!subdirs.Any(s => string.Equals(s, normalized, StringComparison.OrdinalIgnoreCase)))
+            {
+                subdirs.Add(normalized);
+            }
+        }
+
+        AddSubdir(project.Subdirectory);
+
+        var metaSub = project.GetMeta("subdirectory") ?? project.GetMeta("subfolder");
+        AddSubdir(metaSub);
+
+        foreach (var repo in project.Repos)
+        {
+            if (!RepoBelongsToGitRoot(repo, normalizedGitRoot))
+                continue;
+
+            AddSubdir(repo.Subdirectory);
+
+            var normRepoPath = NormalizeLocalPath(repo.Path);
+            if (IsSubdirectory(normRepoPath, normalizedGitRoot))
+            {
+                AddSubdir(normRepoPath);
+            }
+            else if (!Path.IsPathRooted(repo.Path))
+            {
+                var combined = NormalizeLocalPath(Path.Combine(normalizedGitRoot, repo.Path));
+                if (IsSubdirectory(combined, normalizedGitRoot))
+                {
+                    AddSubdir(combined);
+                }
+            }
+        }
+
+        return subdirs;
+    }
+
+    public static bool IsSameOrSubdirectory(string path, string parent)
+    {
+        var normalizedPath = NormalizeLocalPath(path);
+        var normalizedParent = NormalizeLocalPath(parent);
+
+        if (string.Equals(normalizedPath, normalizedParent, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return IsSubdirectory(normalizedPath, normalizedParent);
+    }
+
+    public static bool IsSubdirectory(string path, string parent)
+    {
+        var normalizedPath = NormalizeLocalPath(path);
+        var normalizedParent = NormalizeLocalPath(parent);
+
+        if (string.Equals(normalizedPath, normalizedParent, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var parentWithSeparator = normalizedParent.EndsWith(Path.DirectorySeparatorChar) || normalizedParent.EndsWith(Path.AltDirectorySeparatorChar)
+            ? normalizedParent
+            : normalizedParent + Path.DirectorySeparatorChar;
+
+        return normalizedPath.StartsWith(parentWithSeparator, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string NormalizeLocalPath(string path)
     {
         try
         {
             var expanded = Environment.ExpandEnvironmentVariables(path);
-            return Path.GetFullPath(expanded).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var full = Path.GetFullPath(expanded);
+            var trimmed = full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return string.IsNullOrEmpty(trimmed) ? full : trimmed;
         }
         catch
         {
-            return path.TrimEnd('/', '\\');
+            var trimmed = path.TrimEnd('/', '\\');
+            return string.IsNullOrEmpty(trimmed) ? path : trimmed;
         }
     }
 }

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -20,6 +20,7 @@ public record RepoRef
 {
     public string Path { get; set; } = "";
     public string? BaseBranch { get; set; }
+    public string? Subdirectory { get; set; }
 }
 
 public record ProjectMcpServerRef
@@ -85,6 +86,7 @@ public record ProjectEnvFileConfig
 public record ProjectConfig
 {
     public string Name { get; set; } = "";
+    public string? Subdirectory { get; set; }
     public string Color { get; set; } = "";
     public Dictionary<string, object> Meta { get; set; } = new();
     public List<RepoRef> Repos { get; set; } = new();


### PR DESCRIPTION
# Summary

## Changes

Implemented monorepo subproject and subdirectory resolution in `PlanProjectResolver`. Added optional `Subdirectory` properties to `ProjectConfig` and `RepoRef` so projects in shared repositories can target specific subfolders and resolve by longest prefix match.

## API Changes

- `Ivy.Tendril.Services.ProjectConfig`: Added `public string? Subdirectory { get; set; }`
- `Ivy.Tendril.Services.RepoRef`: Added `public string? Subdirectory { get; set; }`
- `Ivy.Tendril.Helpers.PlanProjectResolver`: Added `public static bool IsSameOrSubdirectory(string path, string parent)`, `public static bool IsSubdirectory(string path, string parent)`, and updated `NormalizeLocalPath` to public.

## Files Modified

- Configuration & Models:
  - `src/Ivy.Tendril/Services/ConfigService.cs`: Added `Subdirectory` properties to `RepoRef` and `ProjectConfig`.
- Project Resolution:
  - `src/Ivy.Tendril/Helpers/PlanProjectResolver.cs`: Updated project resolution to handle monorepo Git roots, collect subdirectories from configs and repos, rank by longest matching prefix, and perform clean directory boundary checks.
- Tests:
  - `src/Ivy.Tendril.Test/Helpers/PlanProjectResolverTests.cs`: Added unit tests covering multiple projects sharing a Git root by repo subfolder, `ProjectConfig.Subdirectory` matching, nested subdirectory ranking, root project fallback, partial directory name prefix protection, and `RepoRef.Subdirectory` resolution.

## Manual Testing

N/A: internal engine change for project resolution in CLI/services, verified through comprehensive unit tests in `PlanProjectResolverTests`.

---

## Commits

- 59a07d8c Support monorepo subprojects in PlanProjectResolver (Plan 00428)

---
Created using [Ivy Tendril](https://ivy.app).
