### PR TITLE
[00411] Show the Agent Turn Completion Time in the Chat

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -38,7 +38,7 @@ public class DeleteSessionDialogTests
         {
             return new ChatMessageModel(Guid.NewGuid().ToString(), role, content, DateTimeOffset.UtcNow, agentId, modelId, rawStream, effort);
         }
-        public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true) => null;
+        public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true, bool markCompleted = false) => null;
         public void FlushSession(string sessionId) { }
         public void SetSessionGenerating(string sessionId, bool isGenerating)
         {

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -385,6 +385,90 @@ public class ChatHistoryServiceTests
     }
 
     [Fact]
+    public void UpdateMessage_WithMarkCompleted_StampsCompletedAtAndPersists()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "sonnet");
+            var initialMsg = service.AddMessage(session.Id, "assistant", "initial content", "claude", "sonnet");
+            Assert.NotNull(initialMsg);
+            Assert.Null(initialMsg.CompletedAt);
+
+            var beforeUpdate = DateTimeOffset.UtcNow;
+            var updatedMsg = service.UpdateMessage(session.Id, initialMsg.Id, "final response", rawStream: "{\"kind\":\"result\"}", markCompleted: true);
+            var afterUpdate = DateTimeOffset.UtcNow;
+
+            Assert.NotNull(updatedMsg);
+            Assert.NotNull(updatedMsg.CompletedAt);
+            Assert.InRange(updatedMsg.CompletedAt.Value, beforeUpdate, afterUpdate);
+
+            // Verify persistence by reloading from disk
+            var configService = new ConfigService(new TendrilSettings(), tempDir);
+            var reloadedService = new ChatHistoryService(configService);
+            var reloadedSession = reloadedService.GetSession(session.Id);
+            Assert.NotNull(reloadedSession);
+            Assert.Single(reloadedSession.Messages);
+            Assert.NotNull(reloadedSession.Messages[0].CompletedAt);
+            Assert.Equal(updatedMsg.CompletedAt, reloadedSession.Messages[0].CompletedAt);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void UpdateMessage_WithoutMarkCompleted_LeavesCompletedAtNull()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "sonnet");
+            var initialMsg = service.AddMessage(session.Id, "assistant", "initial content", "claude", "sonnet");
+            Assert.NotNull(initialMsg);
+            Assert.Null(initialMsg.CompletedAt);
+
+            var updatedMsg = service.UpdateMessage(session.Id, initialMsg.Id, "streaming update", rawStream: "{\"kind\":\"text\",\"delta\":true}", flushImmediately: false, touchUpdatedAt: false);
+            Assert.NotNull(updatedMsg);
+            Assert.Null(updatedMsg.CompletedAt);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void UpdateMessage_StreamingUpdate_DoesNotClearExistingCompletedAt()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "sonnet");
+            var initialMsg = service.AddMessage(session.Id, "assistant", "initial content", "claude", "sonnet");
+            Assert.NotNull(initialMsg);
+
+            var completedMsg = service.UpdateMessage(session.Id, initialMsg.Id, "completed response", rawStream: "{\"kind\":\"result\"}", markCompleted: true);
+            Assert.NotNull(completedMsg);
+            Assert.NotNull(completedMsg.CompletedAt);
+            var originalCompletedAt = completedMsg.CompletedAt;
+
+            var laterMsg = service.UpdateMessage(session.Id, initialMsg.Id, "edit after completion", flushImmediately: false, touchUpdatedAt: false);
+            Assert.NotNull(laterMsg);
+            Assert.NotNull(laterMsg.CompletedAt);
+            Assert.Equal(originalCompletedAt, laterMsg.CompletedAt);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void AddSpawnedJob_And_GetSpawnedJobs_TracksAndPersistsJobIds()
     {
         var (service, tempDir) = CreateTestService();

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs
@@ -82,7 +82,7 @@ class DemoApp : ViewBase
             "2026-09-08T09:12:00Z",
             [
                 new ChatMessageDto("m1", "user", $"Add a dark mode toggle to the vault theme settings page\n\n[Attached Files]:\n- {mockupPath}\n- /tmp/design-notes.md", "9:00 AM", "claude", "fable-5-1"),
-                new ChatMessageDto("m2", "assistant", "Plan 00059 started.", "9:02 AM", "claude", "fable-5-1", FinishedTurn),
+                new ChatMessageDto("m2", "assistant", "Plan 00059 started.", "9:02 AM", "claude", "fable-5-1", FinishedTurn, CompletedAt: "2026-09-08T09:02:41Z"),
                 new ChatMessageDto("m3", "system", "[System Event] Job 00148 (ExecutePlan) for '00059: Add dark mode toggle to vault theme settings' has finished with status: Completed (Completed successfully). Please inspect the outcome, determine whether any action is needed or if any issues occurred, and proactively guide the user on the results and next steps.", "9:11 AM"),
                 new ChatMessageDto("m4", "assistant", CompletedMessage, "9:12 AM", "claude", "fable-5-1"),
                 new ChatMessageDto("m5", "system", "[System Event] Manual approval granted and execution started for plan 'Add keyboard shortcuts to composer' (Job 00151).", "9:13 AM"),

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -13,7 +13,8 @@ public record ChatMessageDto(
     string? AgentId = null,
     string? ModelId = null,
     string? RawStream = null,
-    string? Effort = null
+    string? Effort = null,
+    string? CompletedAt = null
 );
 
 public record ChatJobDto(

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { AssistantTurn, formatDuration, summarizeTurn } from "./AssistantTurn";
+import { AssistantTurn, formatDuration, formatClockTime, summarizeTurn } from "./AssistantTurn";
 import { parseEventWireStream } from "../AgentViewer/parse-events";
 
 const wire = (events: object[]) => events.map((e) => JSON.stringify(e)).join("\n");
@@ -127,5 +127,47 @@ describe("AssistantTurn", () => {
     render(<AssistantTurn stream={stream} live />);
     expect(screen.getByText("1m 22s")).toBeInTheDocument();
     expect(screen.getByText("~1k tokens")).toBeInTheDocument();
+  });
+});
+
+describe("formatClockTime", () => {
+  it("formats valid ISO strings according to viewer locale", () => {
+    const iso = new Date(2026, 8, 12, 9, 5).toISOString();
+    const formatted = formatClockTime(iso);
+    expect(formatted).toBeTruthy();
+    expect(formatted).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("returns empty string for unparseable input", () => {
+    expect(formatClockTime("not-a-date")).toBe("");
+    expect(formatClockTime("")).toBe("");
+  });
+});
+
+describe("AssistantTurn with completedAt", () => {
+  it("shows the formatted completion time in the meta row when completedAt is provided", () => {
+    const stream = wire([
+      { kind: "result", timestamp: "t1", response: "Done.", is_success: true, duration_ms: 2400, usage: { input_tokens: 500, output_tokens: 50, cache_read_tokens: 0, cache_write_tokens: 0, reasoning_tokens: 0, cost_usd: 0.012 } },
+    ]);
+    const completedAt = new Date(2026, 8, 12, 14, 30).toISOString();
+    render(<AssistantTurn stream={stream} completedAt={completedAt} />);
+
+    expect(screen.getByText("2.4s")).toBeInTheDocument();
+    expect(screen.getByText("500 / 50")).toBeInTheDocument();
+    const clockTime = formatClockTime(completedAt);
+    expect(screen.getByText(clockTime)).toBeInTheDocument();
+  });
+
+  it("renders meta row without clock item when completedAt is absent", () => {
+    const stream = wire([
+      { kind: "result", timestamp: "t1", response: "Done.", is_success: true, duration_ms: 2400, usage: { input_tokens: 500, output_tokens: 50, cache_read_tokens: 0, cache_write_tokens: 0, reasoning_tokens: 0, cost_usd: 0.012 } },
+    ]);
+    render(<AssistantTurn stream={stream} />);
+
+    expect(screen.getByText("2.4s")).toBeInTheDocument();
+    expect(screen.getByText("500 / 50")).toBeInTheDocument();
+    const { container } = render(<AssistantTurn stream={stream} />);
+    const metaItems = container.querySelectorAll(".chat-turn-meta-item");
+    expect(metaItems.length).toBe(3);
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { ChevronRight, Coins, LoaderCircle, Timer } from "lucide-react";
+import { ChevronRight, Clock, Coins, LoaderCircle, Timer } from "lucide-react";
 import { parseEventWires, presentEventWires } from "../AgentViewer/parse-events";
 import { deriveStatus } from "../AgentViewer/status";
 import { useHeldStatus } from "../AgentViewer/useHeldStatus";
@@ -89,15 +89,21 @@ export function summarizeTurn(events: PresentationEvent[]): TurnSummary {
 
 export const formatDuration = (ms: number): string => `${(ms / 1000).toFixed(1)}s`;
 
+export const formatClockTime = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: true });
+};
+
 const formatTokens = (count: number): string => count.toLocaleString("en-US");
 
 const formatCost = (cost: number): string => `$${cost.toFixed(cost < 1 ? 3 : 2)}`;
 
-const TurnMeta: React.FC<{ wire: ResultWire }> = ({ wire }) => {
-  const usage = wire.usage;
+const TurnMeta: React.FC<{ wire?: ResultWire; completedAt?: string }> = ({ wire, completedAt }) => {
+  const usage = wire?.usage;
   const items: React.ReactNode[] = [];
 
-  if (wire.duration_ms != null && wire.duration_ms > 0) {
+  if (wire && wire.duration_ms != null && wire.duration_ms > 0) {
     items.push(
       <Tooltip key="duration" content="Duration">
         <span className="chat-turn-meta-item">
@@ -107,7 +113,7 @@ const TurnMeta: React.FC<{ wire: ResultWire }> = ({ wire }) => {
       </Tooltip>,
     );
   }
-  if (usage != null && (usage.input_tokens > 0 || usage.output_tokens > 0)) {
+  if (wire && usage != null && (usage.input_tokens > 0 || usage.output_tokens > 0)) {
     items.push(
       <Tooltip key="tokens" content="Tokens in / out">
         <span className="chat-turn-meta-item">
@@ -117,12 +123,25 @@ const TurnMeta: React.FC<{ wire: ResultWire }> = ({ wire }) => {
       </Tooltip>,
     );
   }
-  if (usage?.cost_usd != null && usage.cost_usd > 0) {
+  if (wire && usage?.cost_usd != null && usage.cost_usd > 0) {
     items.push(
       <Tooltip key="cost" content="Cost">
         <span className="chat-turn-meta-item">{formatCost(usage.cost_usd)}</span>
       </Tooltip>,
     );
+  }
+  if (completedAt) {
+    const formattedTime = formatClockTime(completedAt);
+    if (formattedTime) {
+      items.push(
+        <Tooltip key="completed" content="Completed">
+          <span className="chat-turn-meta-item">
+            <Clock size={14} />
+            {formattedTime}
+          </span>
+        </Tooltip>,
+      );
+    }
   }
 
   if (items.length === 0) return null;
@@ -182,6 +201,8 @@ export interface AssistantTurnProps {
   stream: string;
   /** Still arriving: shows the animated status instead of the finished turn's metrics. */
   live?: boolean;
+  /** ISO 8601 timestamp of when the turn completed. */
+  completedAt?: string;
 }
 
 /**
@@ -189,7 +210,7 @@ export interface AssistantTurnProps {
  * happened, and either the animated status (while streaming) or the duration and token figures
  * of the finished run.
  */
-export const AssistantTurn: React.FC<AssistantTurnProps> = ({ stream, live = false }) => {
+export const AssistantTurn: React.FC<AssistantTurnProps> = ({ stream, live = false, completedAt }) => {
   /* One parse per stream update; the turn, its status and its metrics all derive from it. */
   const wires = useMemo(() => (stream ? parseEventWires(stream) : []), [stream]);
   const events = useMemo(() => presentEventWires(wires), [wires]);
@@ -223,7 +244,7 @@ export const AssistantTurn: React.FC<AssistantTurnProps> = ({ stream, live = fal
           />
         </div>
       )}
-      {!live && turn.result && <TurnMeta wire={turn.result} />}
+      {!live && (turn.result || completedAt) && <TurnMeta wire={turn.result} completedAt={completedAt} />}
     </div>
   );
 };

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -863,7 +863,7 @@ export function ChatWidget({
                     <QuestionsDraftContext.Provider value={draftStoreFor(msg.id)}>
                       <QuestionsSubmitContext.Provider value={submitHandlerFor(msg.id)}>
                         {msg.rawStream ? (
-                          <AssistantTurn stream={msg.rawStream} />
+                          <AssistantTurn stream={msg.rawStream} completedAt={msg.completedAt} />
                         ) : msg.content ? (
                           <div className="chat-markdown-body">
                             <BlockMarkdown content={msg.content} />

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
@@ -11,6 +11,7 @@ export interface ChatMessageDto {
   modelId?: string;
   rawStream?: string;
   effort?: string;
+  completedAt?: string; // ISO 8601, only set once the turn has finished
 }
 
 export interface ChatJobDto {

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -492,7 +492,8 @@ public class ChatApp : ViewBase
                     m.AgentId,
                     m.ModelId,
                     m.RawStream,
-                    m.Effort
+                    m.Effort,
+                    CompletedAt: m.CompletedAt?.ToString("o")
                 )).ToList()
                 : [],
             status,

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -632,7 +632,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                         ? (result.IsSuccess ? collectedText : $"{collectedText}\n\n{failureText}")
                         : (result.IsSuccess ? "Task completed successfully." : failureText);
 
-                _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true);
+                _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true, markCompleted: true);
             }
             catch (OperationCanceledException)
             {
@@ -683,7 +683,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                     ? $"{collectedText}\n\n{abortText}"
                     : abortText;
 
-                _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true);
+                _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true, markCompleted: true);
             }
             catch (Exception ex)
             {
@@ -731,7 +731,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                     ? $"{collectedText}\n\nError executing request: {ex.Message}"
                     : $"Error executing request: {ex.Message}";
 
-                _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true);
+                _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true, markCompleted: true);
             }
             finally
             {

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -677,7 +677,7 @@ public class ChatHistoryService : IChatHistoryService
         return false;
     }
 
-    public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true)
+    public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true, bool markCompleted = false)
     {
         if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(messageId)) return null;
 
@@ -696,7 +696,8 @@ public class ChatHistoryService : IChatHistoryService
             updatedMsg = existingMsg with
             {
                 Content = content,
-                RawStream = rawStream ?? existingMsg.RawStream
+                RawStream = rawStream ?? existingMsg.RawStream,
+                CompletedAt = markCompleted ? DateTimeOffset.UtcNow : existingMsg.CompletedAt
             };
 
             var newMessages = new List<ChatMessageModel>(session.Messages);

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -19,7 +19,8 @@ public record ChatMessageModel(
     string? AgentId = null,
     string? ModelId = null,
     string? RawStream = null,
-    string? Effort = null
+    string? Effort = null,
+    DateTimeOffset? CompletedAt = null
 );
 
 public record ChatSessionModel(
@@ -56,7 +57,7 @@ public interface IChatHistoryService
     void DeleteSession(string id);
     void RenameSession(string id, string newTitle);
     ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null, string? effort = null);
-    ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true);
+    ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true, bool markCompleted = false);
     void FlushSession(string sessionId);
     void SetSessionGenerating(string sessionId, bool isGenerating);
     void ClearAllGeneratingSessions();


### PR DESCRIPTION
Fixes #2587

# Summary

## Changes

Added completion timestamp tracking and display for agent turns in the chat UI. When an agent finishes processing a message, the chat now stamps and displays the completion time in the viewer's locale format (e.g., "9:02 AM") alongside the existing duration and token metrics.

## API Changes

**Backend (C#):**
- `ChatMessageModel`: Added `DateTimeOffset? CompletedAt` field
- `IChatHistoryService.UpdateMessage`: Added `bool markCompleted = false` parameter
- `ChatMessageDto`: Added `string? CompletedAt` field (ISO 8601 format)

**Frontend (TypeScript):**
- `ChatMessageDto` interface: Added `completedAt?: string` field
- `AssistantTurnProps` interface: Added `completedAt?: string` property
- Exported helper: `formatClockTime(iso: string): string`

## Files Modified

**Backend:**
- `src/Ivy.Tendril/Services/IChatHistoryService.cs` - CompletedAt field and markCompleted parameter
- `src/Ivy.Tendril/Services/ChatHistoryService.cs` - Stamping logic
- `src/Ivy.Tendril/Services/ChatExecutionService.cs` - Mark completed at terminal paths
- `src/Ivy.Tendril/Apps/Chat/ChatApp.cs` - DTO serialization
- `src/Ivy.Tendril.Widgets/ChatWidget.cs` - DTO definition

**Frontend:**
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts` - TypeScript interface
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.tsx` - Formatting and rendering
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx` - Prop passing

**Tests:**
- `src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs` - 3 new tests for stamping behavior
- `src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs` - Updated stub signature
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/AssistantTurn.test.tsx` - 2 new test suites

**Samples:**
- `src/Ivy.Tendril.Widgets/.samples/Apps/ChatWidget/DemoApp.cs` - Added sample timestamp

## Manual Testing

1. Run the Tendril desktop app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj`
2. Open the Chat app
3. Send a message to an agent and wait for it to complete
4. Observe the finished turn's meta row (below the response text)
5. Verify the clock icon and completion time appear on the right side of the meta row
6. Verify the time format matches your system locale (e.g., "2:45 PM" in en-US)
7. Open the widget samples app: `dotnet run --project src/Ivy.Tendril.Widgets/.samples/Ivy.Tendril.Widgets.Samples.csproj`
8. Navigate to the ChatWidget demo
9. Verify the finished turn shows a completion timestamp in its meta row

---

## Commits

- 448e676b - Test: CompletedAt behavior in ChatHistoryService
- 85fc5ace - Test: formatClockTime and completion timestamp rendering
- 7e45db37 - Show completion time in AssistantTurn meta row
- f02d7427 - Stamp completion time when agent finishes

---
Created using [Ivy Tendril](https://ivy.app).
