### PR TITLE
[00407] Add Open Chat Action for Selected Inbox Issues

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/InboxChatPromptTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/InboxChatPromptTests.cs
@@ -1,0 +1,137 @@
+using Ivy.Tendril.Apps.Inbox;
+using Ivy.Tendril.Services.Git;
+
+namespace Ivy.Tendril.Test.Apps;
+
+public class InboxChatPromptTests
+{
+    private static GitHubIssue Issue(
+        int number = 4766,
+        string title = "Inbox needs an Open Chat action",
+        string? body = "The action bar only fires issues off as plans.",
+        string[]? labels = null,
+        string[]? assignees = null,
+        string? repository = "owner/repo",
+        string? url = "https://github.com/owner/repo/issues/4766") =>
+        new(number, title, body, labels ?? ["bug"], assignees ?? ["octocat"], repository, url);
+
+    [Fact]
+    public void Build_SingleIssue_RendersHeadingUrlLabelsAssigneesAndBody()
+    {
+        var prompt = InboxChatPrompt.Build([Issue()]);
+
+        Assert.Contains("## owner/repo#4766: Inbox needs an Open Chat action", prompt);
+        Assert.Contains("URL: https://github.com/owner/repo/issues/4766", prompt);
+        Assert.Contains("Labels: bug", prompt);
+        Assert.Contains("Assignees: octocat", prompt);
+        Assert.Contains("The action bar only fires issues off as plans.", prompt);
+    }
+
+    [Fact]
+    public void Build_LeadLine_PluralizesAndKeepsListOrder()
+    {
+        var single = InboxChatPrompt.Build([Issue(number: 1)]);
+        Assert.StartsWith("Let's discuss 1 GitHub issue I selected in the Tendril Inbox.", single);
+
+        var many = InboxChatPrompt.Build([Issue(number: 3), Issue(number: 1), Issue(number: 2)]);
+        Assert.StartsWith("Let's discuss 3 GitHub issues I selected in the Tendril Inbox.", many);
+
+        var first = many.IndexOf("#3:", StringComparison.Ordinal);
+        var second = many.IndexOf("#1:", StringComparison.Ordinal);
+        var third = many.IndexOf("#2:", StringComparison.Ordinal);
+        Assert.True(first < second && second < third, "Issues should be rendered in list order");
+    }
+
+    [Fact]
+    public void Build_DerivesUrlFromRepositoryWhenUrlIsNull()
+    {
+        var prompt = InboxChatPrompt.Build([Issue(number: 12, repository: "acme/widgets", url: null)]);
+
+        Assert.Contains("URL: https://github.com/acme/widgets/issues/12", prompt);
+    }
+
+    [Fact]
+    public void Build_OmitsUrlLineWhenUrlAndRepositoryAreNull()
+    {
+        var prompt = InboxChatPrompt.Build([Issue(number: 12, repository: null, url: null)]);
+
+        Assert.Contains("## #12: Inbox needs an Open Chat action", prompt);
+        Assert.DoesNotContain("URL:", prompt);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Build_EmptyBody_RendersNoDescriptionPlaceholder(string? body)
+    {
+        var prompt = InboxChatPrompt.Build([Issue(body: body)]);
+
+        Assert.Contains("No description provided.", prompt);
+    }
+
+    [Fact]
+    public void Build_TruncatesLongBodyToBodyPreviewLength()
+    {
+        var longBody = new string('a', 600);
+        var prompt = InboxChatPrompt.Build([Issue(body: longBody)]);
+
+        Assert.Contains(InboxApp.TruncateBody(longBody, InboxChatPrompt.BodyPreviewLength), prompt);
+        Assert.DoesNotContain(longBody, prompt);
+        Assert.Contains(new string('a', InboxChatPrompt.BodyPreviewLength) + "…", prompt);
+    }
+
+    [Fact]
+    public void Build_OmitsLabelsAndAssigneesWhenEmptyOrWhitespace()
+    {
+        var empty = InboxChatPrompt.Build([Issue(labels: [], assignees: [])]);
+        Assert.DoesNotContain("Labels:", empty);
+        Assert.DoesNotContain("Assignees:", empty);
+
+        var whitespace = InboxChatPrompt.Build([Issue(labels: ["  "], assignees: ["", " "])]);
+        Assert.DoesNotContain("Labels:", whitespace);
+        Assert.DoesNotContain("Assignees:", whitespace);
+    }
+
+    [Fact]
+    public void Build_CapsDetailedIssuesAndSummarizesTheRest()
+    {
+        var issues = Enumerable.Range(1, InboxChatPrompt.MaxDetailedIssues + 5)
+            .Select(n => Issue(number: n, url: null))
+            .ToList();
+
+        var prompt = InboxChatPrompt.Build(issues);
+
+        var headings = prompt.Split("\n").Count(l => l.StartsWith("## ", StringComparison.Ordinal));
+        Assert.Equal(InboxChatPrompt.MaxDetailedIssues, headings);
+        Assert.Contains("Plus 5 more selected issues, which you can fetch with gh issue view.", prompt);
+    }
+
+    [Fact]
+    public void Build_EmptySelection_ReturnsEmptyString()
+    {
+        Assert.Equal(string.Empty, InboxChatPrompt.Build([]));
+    }
+
+    [Fact]
+    public void Title_DependsOnSelectionSize()
+    {
+        Assert.Null(InboxChatPrompt.Title([]));
+        Assert.Equal("#4766", InboxChatPrompt.Title([Issue()]));
+        Assert.Equal("3 issues", InboxChatPrompt.Title([Issue(number: 1), Issue(number: 2), Issue(number: 3)]));
+    }
+
+    [Fact]
+    public void ResolveIssueUrl_PrefersExplicitUrlThenDerivesThenReturnsNull()
+    {
+        Assert.Equal(
+            "https://github.com/owner/repo/issues/4766",
+            InboxApp.ResolveIssueUrl(Issue()));
+
+        Assert.Equal(
+            "https://github.com/acme/widgets/issues/12",
+            InboxApp.ResolveIssueUrl(Issue(number: 12, repository: "acme/widgets", url: null)));
+
+        Assert.Null(InboxApp.ResolveIssueUrl(Issue(repository: null, url: null)));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Apps.Chat;
 using Ivy.Tendril.Apps.Inbox.Dialogs;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Apps.Views.Sheets;
@@ -114,6 +115,7 @@ public class ContentView(
     public override object Build()
     {
         var client = UseService<IClientProvider>();
+        var nav = UseNavigation();
         var openFile = UseState<string?>(null);
         var isAutoAcceptSettingsOpen = UseState(false);
         var updateStream = UseStream<DataTableCellUpdate>();
@@ -223,6 +225,7 @@ public class ContentView(
                 client: client,
                 showIssueSheet: showIssueSheet,
                 updateStream: updateStream,
+                nav: nav,
                 isMyIssues: true,
                 openAutoAcceptSettings: () => isAutoAcceptSettingsOpen.Set(true)
             );
@@ -240,6 +243,7 @@ public class ContentView(
                 client: client,
                 showIssueSheet: showIssueSheet,
                 updateStream: updateStream,
+                nav: nav,
                 isMyIssues: false
             );
         }
@@ -382,6 +386,7 @@ public class ContentView(
         IClientProvider client,
         Action<GitHubIssue> showIssueSheet,
         IWriteStream<DataTableCellUpdate> updateStream,
+        INavigator nav,
         bool isMyIssues = false,
         Action? openAutoAcceptSettings = null)
     {
@@ -443,6 +448,16 @@ public class ContentView(
                 | new Button("Select All").Ghost().Small().OnClick(SelectAll)
                 | new Button("Deselect All").Ghost().Small().Disabled(selectedCount == 0).OnClick(DeselectAll)
                 | Text.Muted($"{selectedCount} of {allIssues.Count} selected").Small()
+                | new Button(selectedCount > 0 ? $"Open Chat ({selectedCount})" : "Open Chat")
+                    .Icon(Icons.MessageCircle)
+                    .Outline().Small()
+                    .Tooltip("Discuss the selected issues with the coding agent")
+                    .Disabled(selectedCount == 0)
+                    .OnClick(() => ChatLauncher.Open(
+                        nav,
+                        config,
+                        InboxChatPrompt.Build(selectedIssuesList),
+                        InboxChatPrompt.Title(selectedIssuesList)))
                 | new Button(selectedCount > 0 ? $"Fire off in Tendril ({selectedCount})" : "Fire off in Tendril")
                     .Icon(Icons.Zap)
                     .Primary().Small()

--- a/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
@@ -296,6 +296,11 @@ public class InboxApp : ViewBase
         return sanitized.Length > 60 ? sanitized[..60].TrimEnd('-') : sanitized;
     }
 
+    public static string? ResolveIssueUrl(GitHubIssue issue) =>
+        issue.Url ?? (issue.Repository != null
+            ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
+            : null);
+
     public static string TruncateBody(string? body, int maxLength = 500)
     {
         if (string.IsNullOrWhiteSpace(body)) return "";

--- a/src/Ivy.Tendril/Apps/Inbox/InboxChatPrompt.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/InboxChatPrompt.cs
@@ -1,0 +1,76 @@
+using Ivy.Tendril.Services.Git;
+
+namespace Ivy.Tendril.Apps.Inbox;
+
+/// <summary>
+/// Builds the chat prompt sent when the user opens Chat for the issues selected in the Inbox.
+/// </summary>
+internal static class InboxChatPrompt
+{
+    /// Issues rendered in full before the prompt collapses the rest into a single line.
+    public const int MaxDetailedIssues = 20;
+
+    /// Characters of each issue body kept in the prompt.
+    public const int BodyPreviewLength = 500;
+
+    public static string Build(IReadOnlyList<GitHubIssue> issues)
+    {
+        if (issues.Count == 0) return string.Empty;
+
+        var blocks = new List<string>
+        {
+            $"Let's discuss {issues.Count} GitHub issue{(issues.Count == 1 ? "" : "s")} I selected in the Tendril Inbox. Read them and help me decide what to do."
+        };
+
+        foreach (var issue in issues.Take(MaxDetailedIssues))
+        {
+            blocks.Add(BuildIssueBlock(issue));
+        }
+
+        if (issues.Count > MaxDetailedIssues)
+        {
+            blocks.Add($"Plus {issues.Count - MaxDetailedIssues} more selected issues, which you can fetch with gh issue view.");
+        }
+
+        return string.Join("\n\n", blocks);
+    }
+
+    public static string? Title(IReadOnlyList<GitHubIssue> issues) => issues.Count switch
+    {
+        0 => null,
+        1 => $"#{issues[0].Number}",
+        _ => $"{issues.Count} issues"
+    };
+
+    private static string BuildIssueBlock(GitHubIssue issue)
+    {
+        var lines = new List<string>
+        {
+            string.IsNullOrEmpty(issue.Repository)
+                ? $"## #{issue.Number}: {issue.Title}"
+                : $"## {issue.Repository}#{issue.Number}: {issue.Title}"
+        };
+
+        if (InboxApp.ResolveIssueUrl(issue) is { } url)
+        {
+            lines.Add($"URL: {url}");
+        }
+
+        var labels = issue.Labels.Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
+        if (labels.Length > 0)
+        {
+            lines.Add($"Labels: {string.Join(", ", labels)}");
+        }
+
+        var assignees = issue.Assignees.Where(a => !string.IsNullOrWhiteSpace(a)).ToArray();
+        if (assignees.Length > 0)
+        {
+            lines.Add($"Assignees: {string.Join(", ", assignees)}");
+        }
+
+        var body = InboxApp.TruncateBody(issue.Body, BodyPreviewLength);
+        lines.Add(string.IsNullOrEmpty(body) ? "No description provided." : body);
+
+        return string.Join("\n", lines);
+    }
+}


### PR DESCRIPTION
Fixes #2569

# Summary

## Changes

Added an "Open Chat" button to the Inbox issues action bar, beside "Fire off in Tendril", so a
selection of GitHub issues can be discussed with the coding agent instead of being turned into plans
first. The prompt is assembled by a new pure static class, `InboxChatPrompt`, and dispatched through
`ChatLauncher.Open`, so it honours the `chatMode` setting (terminal `AgentApp` or `ChatApp`). Clicking
sends the prompt immediately and leaves the selection intact, so the same issues can still be fired
off afterwards.

## API Changes

- **New** `internal static class Ivy.Tendril.Apps.Inbox.InboxChatPrompt` with:
  - `public const int MaxDetailedIssues = 20` - issues rendered in full before the rest collapse into a single line
  - `public const int BodyPreviewLength = 500` - characters of each issue body kept
  - `public static string Build(IReadOnlyList<GitHubIssue> issues)` - the prompt, or `string.Empty` for an empty list
  - `public static string? Title(IReadOnlyList<GitHubIssue> issues)` - `null`, `#{Number}`, or `{Count} issues`
- **New** `public static string? InboxApp.ResolveIssueUrl(GitHubIssue issue)` - the issue's `Url`, else a URL derived from `Repository` and `Number`, else `null`
- **Changed** `ContentView.BuildIssuesView` (private) takes an additional `INavigator nav` parameter

No public HTTP, CLI or config surface changed.

## Files Modified

**New:**
- `src/Ivy.Tendril/Apps/Inbox/InboxChatPrompt.cs` - the prompt and title builders
- `src/Ivy.Tendril.Test/Apps/InboxChatPromptTests.cs` - 13 tests over the new statics

**Changed:**
- `src/Ivy.Tendril/Apps/Inbox/ContentView.cs` - the button, the `UseNavigation()` hook, and `nav` threaded into `BuildIssuesView`
- `src/Ivy.Tendril/Apps/Inbox/InboxApp.cs` - the `ResolveIssueUrl` helper

The three existing places that derive an issue URL inline were deliberately left alone; a
recommendation registered during planning tracks adopting the helper there.

## Manual Testing

1. Run the app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Open the **Inbox** app and pick either **My Issues** or a project's issues.
3. With nothing selected, confirm the new **Open Chat** button sits between the "N of M selected"
   text and "Fire off in Tendril", is outlined rather than filled, is disabled, and shows the tooltip
   "Discuss the selected issues with the coding agent" on hover.
4. Tick one issue. The button should read **Open Chat (1)** and become enabled.
5. Click it. Chat (or the terminal agent pane, depending on the `chatMode` setting) opens and the
   agent turn starts immediately with a prompt beginning
   `Let's discuss 1 GitHub issue I selected in the Tendril Inbox.` followed by a
   `## owner/repo#N: <title>` block carrying the URL, labels, assignees and the first 500 characters
   of the body.
6. Navigate back to the Inbox. The issue should **still be selected**, and "Fire off in Tendril"
   should still work on it.
7. Select several issues and click again: the lead line should say `N GitHub issues` and one block per
   issue should appear in list order.
8. Click **Select All** on a list with more than 20 issues and click **Open Chat**: exactly 20 issue
   blocks should be rendered, followed by a single
   `Plus N more selected issues, which you can fetch with gh issue view.` line.
9. Switch `chatMode` in Settings between terminal and non-terminal and repeat step 5, to confirm both
   targets receive the prompt.

---
## Commits

- 8755771e: Add Inbox chat prompt builder and issue url helper, for plan 00407
- c57c8ee3: Add Open Chat action to the Inbox issues action bar, for plan 00407

---
Created using [Ivy Tendril](https://ivy.app).
