### PR TITLE
[00413] Show Features Shipped And Cost Per Feature On The Dashboard

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -212,10 +212,11 @@ public class DashboardAppViewModelTests
     }
 
     [Fact]
-    public void BuildKpis_UsesThirtyDayPrWindows()
+    public void BuildKpis_UsesThirtyDayFeatureWindows()
     {
         var today = new DateTime(2026, 8, 31);
-        var prDays = new List<(DateOnly Date, int Count)>
+        var prDays = new List<(DateOnly Date, int Count)>();
+        var featureDays = new List<(DateOnly Date, int Count)>
         {
             (DateOnly.FromDateTime(today.AddDays(-5)), 30),
             (DateOnly.FromDateTime(today.AddDays(-40)), 15)
@@ -223,13 +224,13 @@ public class DashboardAppViewModelTests
         var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 0m, [], []);
         var activity = new DashboardActivityStats([], 0);
 
-        var kpis = DashboardApp.BuildKpis(stats, activity, prDays, today);
+        var kpis = DashboardApp.BuildKpis(stats, activity, prDays, featureDays, today, null);
 
         Assert.Equal(4, kpis.Count);
-        Assert.Equal("Avg Daily PR count", kpis[0].Label);
-        Assert.Equal("1", kpis[0].Value);
+        Assert.Equal("Features shipped", kpis[0].Label);
+        Assert.Equal("30", kpis[0].Value);
         Assert.Equal("+100%", kpis[0].Delta);
-        Assert.Equal("Avg Cost/Month", kpis[1].Label);
+        Assert.Equal("Avg cost per Feature", kpis[1].Label);
         // The projection sits next to the retrospective average it is read against.
         Assert.Equal("Forecast This Month", kpis[2].Label);
         Assert.Equal("Avg Cost/Plan", kpis[3].Label);
@@ -250,7 +251,7 @@ public class DashboardAppViewModelTests
         var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 0m, [], []);
         var activity = new DashboardActivityStats([], 0, dailyCosts);
 
-        var forecast = DashboardApp.BuildKpis(stats, activity, [], today)
+        var forecast = DashboardApp.BuildKpis(stats, activity, [], [], today, null)
             .Single(k => k.Label == "Forecast This Month");
 
         // 60 over 10 days times 31 = $186 API projection and total projection
@@ -272,7 +273,7 @@ public class DashboardAppViewModelTests
         var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 0m, [], []);
         var activity = new DashboardActivityStats([], 0, dailyCosts);
 
-        var forecast = DashboardApp.BuildKpis(stats, activity, [], today)
+        var forecast = DashboardApp.BuildKpis(stats, activity, [], [], today, null)
             .Single(k => k.Label == "Forecast This Month");
 
         Assert.Equal("$0", forecast.Value);
@@ -294,7 +295,7 @@ public class DashboardAppViewModelTests
         var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 0m, [], []);
         var activity = new DashboardActivityStats([], 0, dailyCosts);
 
-        var forecast = DashboardApp.BuildKpis(stats, activity, [], today)
+        var forecast = DashboardApp.BuildKpis(stats, activity, [], [], today, null)
             .Single(k => k.Label == "Forecast This Month");
 
         // Total: 100 over 10 days * 31 = $310 total
@@ -313,7 +314,7 @@ public class DashboardAppViewModelTests
         var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 0m, [], []);
         var activity = new DashboardActivityStats([], 0);
 
-        var forecast = DashboardApp.BuildKpis(stats, activity, [], new DateTime(2026, 8, 31))
+        var forecast = DashboardApp.BuildKpis(stats, activity, [], [], new DateTime(2026, 8, 31), null)
             .Single(k => k.Label == "Forecast This Month");
 
         Assert.Equal("-", forecast.Value);
@@ -399,53 +400,54 @@ public class DashboardAppViewModelTests
         var today = new DateTime(2026, 8, 31);
         var stats = new DashboardModels(1, 0, 0, 0, 1, 0, 15.5m, [], []);
         var activity = new DashboardActivityStats([], 10m);
+        var featureDays = new List<(DateOnly Date, int Count)>
+        {
+            (DateOnly.FromDateTime(today.AddDays(-5)), 10)
+        };
 
-        var kpis = DashboardApp.BuildKpis(stats, activity, [], today);
+        var kpis = DashboardApp.BuildKpis(stats, activity, [], featureDays, today, null);
 
         Assert.Equal(4, kpis.Count);
-        Assert.Equal("dailyPrs", kpis[0].Id);
-        Assert.Equal("avgCostMonth", kpis[1].Id);
+        Assert.Equal("featuresShipped", kpis[0].Id);
+        Assert.Equal("costPerFeature", kpis[1].Id);
         Assert.Equal("forecastMonth", kpis[2].Id);
         Assert.Equal("avgCostPlan", kpis[3].Id);
     }
 
     [Fact]
-    public void BuildKpis_ComputesCorrectMonthlyAndRollingPlanCalculations()
+    public void BuildKpis_ComputesFeaturesShippedAndCostPerFeature()
     {
         var today = new DateTime(2026, 8, 31);
-        var prDays = new List<(DateOnly Date, int Count)>
+        var prDays = new List<(DateOnly Date, int Count)>();
+        var featureDays = new List<(DateOnly Date, int Count)>
         {
-            // 45 PRs in last 30 days => 45 / 30 = 1.5 daily PRs
-            (new DateOnly(2026, 8, 15), 45),
-            // 30 PRs in prior 30 days => 30 / 30 = 1.0 daily PRs (+50%)
-            (new DateOnly(2026, 7, 15), 30)
+            // 315 features in last 30 days
+            (new DateOnly(2026, 8, 15), 315),
+            // 210 features in prior 30 days (+50%)
+            (new DateOnly(2026, 7, 15), 210)
         };
 
-        var months = new List<DashboardMonthStats>
+        // Daily costs: $1142 over last 30 days, $800 over prior 30 days
+        var dailyCosts = new List<DashboardDailyCost>
         {
-            new(2026, 2, 2, 0, 100m, 1000),
-            new(2026, 3, 3, 0, 200m, 2000),
-            new(2026, 4, 4, 0, 300m, 3000),
-            new(2026, 5, 5, 0, 400m, 4000),
-            new(2026, 6, 6, 0, 500m, 5000),
-            new(2026, 7, 7, 0, 600m, 6000), // last completed month (July): $600
-            new(2026, 8, 8, 0, 999m, 9000)  // in-flight month (August): must be excluded
+            new(new DateOnly(2026, 8, 15), 1142m, 0),
+            new(new DateOnly(2026, 7, 15), 800m, 0)
         };
-        // Mean of completed months: (100+200+300+400+500+600)/6 = 350. Last completed=600, prev=500 (+20%)
+
         var stats = new DashboardModels(10, 0, 0, 0, 8, 2, 25.0m, [], []);
-        var activity = new DashboardActivityStats(months, 20.0m);
+        var activity = new DashboardActivityStats([], 20.0m, dailyCosts);
 
-        var kpis = DashboardApp.BuildKpis(stats, activity, prDays, today);
+        var kpis = DashboardApp.BuildKpis(stats, activity, prDays, featureDays, today, null);
 
-        // 1. dailyPrs
-        Assert.Equal("dailyPrs", kpis[0].Id);
-        Assert.Equal("1.5", kpis[0].Value);
+        // 1. featuresShipped: 315 vs 210 (+50%)
+        Assert.Equal("featuresShipped", kpis[0].Id);
+        Assert.Equal("315", kpis[0].Value);
         Assert.Equal("+50%", kpis[0].Delta);
 
-        // 2. avgCostMonth
-        Assert.Equal("avgCostMonth", kpis[1].Id);
-        Assert.Equal("$350", kpis[1].Value);
-        Assert.Equal("+20%", kpis[1].Delta);
+        // 2. costPerFeature: $1142/315 = $3.63 vs $800/210 = $3.81 (-4.72%)
+        Assert.Equal("costPerFeature", kpis[1].Id);
+        Assert.Equal("$3.63", kpis[1].Value);
+        Assert.Contains("-", kpis[1].Delta);
 
         // 3. forecastMonth
         Assert.Equal("forecastMonth", kpis[2].Id);
@@ -457,9 +459,10 @@ public class DashboardAppViewModelTests
     }
 
     [Theory]
-    [InlineData("dailyPrs", "Avg Daily PR Count")]
-    [InlineData("avgCostMonth", "Avg Cost/Month")]
+    [InlineData("featuresShipped", "Features Shipped")]
+    [InlineData("costPerFeature", "Avg Cost Per Feature")]
     [InlineData("forecastMonth", "Forecast This Month")]
+    [InlineData("usageWindow", "Agent Usage Window")]
     [InlineData("avgCostPlan", "Avg Cost/Plan")]
     [InlineData("other", "KPI Breakdown")]
     public void GetKpiSheetTitle_ReturnsExpectedTitle(string key, string expected)

--- a/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
+++ b/src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs
@@ -61,7 +61,7 @@ public class KpiBreakdownSheetTests
     [Fact]
     public void KpiBreakdownSheet_RendersDailyPrsBreakdown()
     {
-        var sheet = new KpiBreakdownSheet("dailyPrs", _stats, _activity, _prDays, _today, _fakeService);
+        var sheet = new KpiBreakdownSheet("dailyPrs", _stats, _activity, _prDays, [], _today, _fakeService);
         var result = sheet.Build();
 
         Assert.NotNull(result);
@@ -70,7 +70,7 @@ public class KpiBreakdownSheetTests
     [Fact]
     public void KpiBreakdownSheet_RendersAvgCostMonthBreakdown()
     {
-        var sheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var sheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, [], _today, _fakeService);
         var result = sheet.Build();
 
         Assert.NotNull(result);
@@ -79,7 +79,7 @@ public class KpiBreakdownSheetTests
     [Fact]
     public void KpiBreakdownSheet_RendersForecastMonthBreakdown()
     {
-        var sheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, _today, _fakeService);
+        var sheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, [], _today, _fakeService);
         var result = sheet.Build();
 
         Assert.NotNull(result);
@@ -94,7 +94,7 @@ public class KpiBreakdownSheetTests
             new(new DateOnly(2026, 8, 25), 20.00m, 2000, ApiCost: 0m, ApiTokens: 0, SubsidizedCost: 20m, SubsidizedTokens: 2000)
         };
         var activity = new DashboardActivityStats([], 0m, dailyCosts);
-        var sheet = new KpiBreakdownSheet("forecastMonth", _stats, activity, _prDays, _today, _fakeService);
+        var sheet = new KpiBreakdownSheet("forecastMonth", _stats, activity, _prDays, [], _today, _fakeService);
         var result = sheet.Build();
 
         Assert.NotNull(result);
@@ -106,7 +106,7 @@ public class KpiBreakdownSheetTests
     [Fact]
     public void KpiBreakdownSheet_RendersAvgCostPlanBreakdown()
     {
-        var sheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, _today, _fakeService);
+        var sheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, [], _today, _fakeService);
         var result = sheet.Build();
 
         Assert.NotNull(result);
@@ -115,7 +115,7 @@ public class KpiBreakdownSheetTests
     [Fact]
     public void KpiBreakdownSheet_RendersUnknownKeyGracefully()
     {
-        var sheet = new KpiBreakdownSheet("unknownMetricKey", _stats, _activity, _prDays, _today, _fakeService);
+        var sheet = new KpiBreakdownSheet("unknownMetricKey", _stats, _activity, _prDays, [], _today, _fakeService);
         var result = sheet.Build();
 
         Assert.NotNull(result);
@@ -128,10 +128,10 @@ public class KpiBreakdownSheetTests
         var emptyActivity = new DashboardActivityStats([], 0m);
         var emptyService = new FakePlanReaderService();
 
-        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", emptyStats, emptyActivity, [], _today, emptyService);
-        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", emptyStats, emptyActivity, [], _today, emptyService);
-        var forecastSheet = new KpiBreakdownSheet("forecastMonth", emptyStats, emptyActivity, [], _today, emptyService);
-        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", emptyStats, emptyActivity, [], _today, emptyService);
+        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", emptyStats, emptyActivity, [], [], _today, emptyService);
+        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", emptyStats, emptyActivity, [], [], _today, emptyService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", emptyStats, emptyActivity, [], [], _today, emptyService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", emptyStats, emptyActivity, [], [], _today, emptyService);
 
         Assert.NotNull(dailyPrsSheet.Build());
         Assert.NotNull(avgCostMonthSheet.Build());
@@ -142,10 +142,10 @@ public class KpiBreakdownSheetTests
     [Fact]
     public void KpiBreakdownSheet_PopulatedData_BuildsDataTables()
     {
-        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", _stats, _activity, _prDays, _today, _fakeService);
-        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, _today, _fakeService);
-        var forecastSheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, _today, _fakeService);
-        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, _today, _fakeService);
+        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", _stats, _activity, _prDays, [], _today, _fakeService);
+        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, [], _today, _fakeService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, [], _today, _fakeService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, [], _today, _fakeService);
 
         var dailyPrsTable = ExtractTableContent(dailyPrsSheet.Build());
         var avgCostMonthTable = ExtractTableContent(avgCostMonthSheet.Build());
@@ -172,9 +172,9 @@ public class KpiBreakdownSheetTests
         var emptyActivity = new DashboardActivityStats([], 0m);
         var emptyService = new FakePlanReaderService();
 
-        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", emptyStats, emptyActivity, [], _today, emptyService);
-        var forecastSheet = new KpiBreakdownSheet("forecastMonth", emptyStats, emptyActivity, [], _today, emptyService);
-        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", emptyStats, emptyActivity, [], _today, emptyService);
+        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", emptyStats, emptyActivity, [], [], _today, emptyService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", emptyStats, emptyActivity, [], [], _today, emptyService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", emptyStats, emptyActivity, [], [], _today, emptyService);
 
         var dailyPrsContent = ExtractTableContent(dailyPrsSheet.Build());
         var forecastContent = ExtractTableContent(forecastSheet.Build());
@@ -195,9 +195,9 @@ public class KpiBreakdownSheetTests
             new DashboardAgentCost("Unknown", 10.00m, 10000, 1)
         ];
 
-        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, _today, _fakeService);
-        var forecastSheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, _today, _fakeService);
-        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, _today, _fakeService);
+        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, [], _today, _fakeService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, [], _today, _fakeService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, [], _today, _fakeService);
 
         var avgCostMonthSection = ExtractAgentSection(avgCostMonthSheet.Build());
         var forecastSection = ExtractAgentSection(forecastSheet.Build());
@@ -219,7 +219,7 @@ public class KpiBreakdownSheetTests
             new DashboardAgentCost("claude", 50.00m, 50000, 3)
         ];
 
-        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", _stats, _activity, _prDays, _today, _fakeService);
+        var dailyPrsSheet = new KpiBreakdownSheet("dailyPrs", _stats, _activity, _prDays, [], _today, _fakeService);
         var result = dailyPrsSheet.Build();
 
         // dailyPrs should not have an agent section (only 3 children, not 4)
@@ -233,9 +233,9 @@ public class KpiBreakdownSheetTests
     {
         _fakeService.AgentCostsToReturn = [];
 
-        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, _today, _fakeService);
-        var forecastSheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, _today, _fakeService);
-        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, _today, _fakeService);
+        var avgCostMonthSheet = new KpiBreakdownSheet("avgCostMonth", _stats, _activity, _prDays, [], _today, _fakeService);
+        var forecastSheet = new KpiBreakdownSheet("forecastMonth", _stats, _activity, _prDays, [], _today, _fakeService);
+        var avgCostPlanSheet = new KpiBreakdownSheet("avgCostPlan", _stats, _activity, _prDays, [], _today, _fakeService);
 
         var avgCostMonthSection = ExtractAgentSection(avgCostMonthSheet.Build());
         var forecastSection = ExtractAgentSection(forecastSheet.Build());

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/TendrilDashboard/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/TendrilDashboard/DemoApp.cs
@@ -100,10 +100,10 @@ class DemoApp : ViewBase
             .FailedCount(2)
             .Kpis(
             [
-                new DashboardKpiDto("Avg Daily PR count", "54", "+123%", "up"),
-                new DashboardKpiDto("Avg Cost/Month", "$9043", "-23%", "down"),
-                new DashboardKpiDto("Avg Tokens/Month", "80,720"),
-                new DashboardKpiDto("Avg Cost/Plan", "$0.98", "-0.01%", "down")
+                new DashboardKpiDto("Features shipped", "315", "+12%", "up", "merged PRs and solved issues, last 30 days"),
+                new DashboardKpiDto("Avg cost per Feature", "$3.62", "-5%", "down", "$1142 over 315 features"),
+                new DashboardKpiDto("Forecast This Month", "$1673"),
+                new DashboardKpiDto("5h window", "87.3% remaining", Hint: "resets in 2h 14m")
             ])
             .Trend(new DashboardTrendDto(
                 trendDates,

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -1,7 +1,8 @@
 using System.Globalization;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using Ivy.Tendril.Agents.Services;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Jobs.Sheets;
 using Ivy.Tendril.Apps.Review;
@@ -12,6 +13,7 @@ using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Plans;
+using Ivy.Tendril.Services.Telemetry;
 using Ivy.Tendril.Services.Tunnel;
 using Ivy.Tendril.Widgets;
 using Ivy.Widgets.QRCode;
@@ -35,7 +37,7 @@ public class DashboardApp : ViewBase
         var client = UseService<IClientProvider>();
         var tunnelService = UseService<ICloudflaredService>();
         var usage = UseService<AgentUsageService>();
-        var config = UseService<ConfigService>();
+        var config = UseService<IConfigService>();
         var copyToClipboard = UseClipboard();
         var navigator = UseNavigation();
         var refreshToken = UseRefreshToken();
@@ -44,7 +46,7 @@ public class DashboardApp : ViewBase
         var tunnelUrl = UseState<string?>(tunnelService.TunnelUrl);
 
         var usageQuery = UseQuery<AgentUsageSnapshot?, string>(
-            config.CodingAgent,
+            config.Settings.CodingAgent,
             (agentId, ct) => usage.GetUsageAsync(agentId, ct),
             options: new QueryOptions { RefreshInterval = TimeSpan.FromSeconds(60) });
 
@@ -143,7 +145,7 @@ public class DashboardApp : ViewBase
             .ReviewCount(processStatus.ReviewCount)
             .CompletedCount(jobs.Count(j => j.Status == JobStatus.Completed))
             .FailedCount(jobs.Count(j => j.Status == JobStatus.Failed))
-            .Kpis(BuildKpis(stats, activity, prDays, featureDays, today, usageQuery.Data))
+            .Kpis(BuildKpis(stats, activity, prDays, featureDays, today, usageQuery.Value))
             .Trend(BuildTrend(activity, today))
             .TrendWeekly(BuildWeeklyTrend(activity, today))
             .PullRequests(BuildMonthlyPullRequests(activity.Months))
@@ -274,8 +276,8 @@ public class DashboardApp : ViewBase
         var dailyCosts = activity.DailyCosts;
         if (dailyCosts != null && dailyCosts.Count > 0 && features30 > 0)
         {
-            var cost30 = dailyCosts.Where(c => c.Date >= last30Start).Sum(c => c.TotalCost);
-            var prevCost30 = dailyCosts.Where(c => c.Date >= prev30Start && c.Date < last30Start).Sum(c => c.TotalCost);
+            var cost30 = dailyCosts.Where(c => c.Date >= last30Start).Sum(c => c.Cost);
+            var prevCost30 = dailyCosts.Where(c => c.Date >= prev30Start && c.Date < last30Start).Sum(c => c.Cost);
             var costPerFeature = cost30 / features30;
             var prevCostPerFeature = prevFeatures30 > 0 ? prevCost30 / prevFeatures30 : 0;
             var hint = $"{FormatHelper.FormatCost(cost30)} over {FormatHelper.FormatCount(features30)} features";

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using Ivy.Tendril.Agents.Services;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Jobs.Sheets;
 using Ivy.Tendril.Apps.Review;
@@ -9,6 +10,7 @@ using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Services.Tunnel;
 using Ivy.Tendril.Widgets;
@@ -32,12 +34,19 @@ public class DashboardApp : ViewBase
         var statusService = UseService<ITendrilProcessStatusService>();
         var client = UseService<IClientProvider>();
         var tunnelService = UseService<ICloudflaredService>();
+        var usage = UseService<AgentUsageService>();
+        var config = UseService<ConfigService>();
         var copyToClipboard = UseClipboard();
         var navigator = UseNavigation();
         var refreshToken = UseRefreshToken();
         var processView = Context.UseTendrilProcess();
         var tunnelStatus = UseState(tunnelService.Status);
         var tunnelUrl = UseState<string?>(tunnelService.TunnelUrl);
+
+        var usageQuery = UseQuery<AgentUsageSnapshot?, string>(
+            config.CodingAgent,
+            (agentId, ct) => usage.GetUsageAsync(agentId, ct),
+            options: new QueryOptions { RefreshInterval = TimeSpan.FromSeconds(60) });
 
         // Same agent-output sheet as the Jobs app, opened from the Active Jobs card.
         var (outputSheet, showOutput) = UseTrigger<string>((isOpen, jobId) =>
@@ -60,10 +69,11 @@ public class DashboardApp : ViewBase
             var currentStats = planService.GetDashboardData(null);
             var currentActivity = planService.GetDashboardActivity(TrendMonthsBack);
             var currentPrDays = planService.GetCompletedPrsByDay((currentToday - currentFirstActivityMonth).Days + 1);
+            var currentFeatureDays = planService.GetShippedFeaturesByDay(60);
             var title = GetKpiSheetTitle(kpiKey);
             return new Sheet(
                 () => isOpen.Set(false),
-                new KpiBreakdownSheet(kpiKey, currentStats, currentActivity, currentPrDays, currentToday, planService),
+                new KpiBreakdownSheet(kpiKey, currentStats, currentActivity, currentPrDays, currentFeatureDays, currentToday, planService),
                 title
             ).Width(UxHelper.SheetWidth).Resizable();
         });
@@ -107,6 +117,7 @@ public class DashboardApp : ViewBase
         var today = DateTime.UtcNow.Date;
         var firstActivityMonth = new DateTime(today.Year, today.Month, 1).AddMonths(-(ActivityMonths - 1));
         var prDays = planService.GetCompletedPrsByDay((today - firstActivityMonth).Days + 1);
+        var featureDays = planService.GetShippedFeaturesByDay(60);
 
         var now = DateTime.Now;
 
@@ -132,7 +143,7 @@ public class DashboardApp : ViewBase
             .ReviewCount(processStatus.ReviewCount)
             .CompletedCount(jobs.Count(j => j.Status == JobStatus.Completed))
             .FailedCount(jobs.Count(j => j.Status == JobStatus.Failed))
-            .Kpis(BuildKpis(stats, activity, prDays, today))
+            .Kpis(BuildKpis(stats, activity, prDays, featureDays, today, usageQuery.Data))
             .Trend(BuildTrend(activity, today))
             .TrendWeekly(BuildWeeklyTrend(activity, today))
             .PullRequests(BuildMonthlyPullRequests(activity.Months))
@@ -150,9 +161,10 @@ public class DashboardApp : ViewBase
 
     internal static string GetKpiSheetTitle(string kpiKey) => kpiKey switch
     {
-        "dailyPrs" => "Avg Daily PR Count",
-        "avgCostMonth" => "Avg Cost/Month",
+        "featuresShipped" => "Features Shipped",
+        "costPerFeature" => "Avg Cost Per Feature",
         "forecastMonth" => "Forecast This Month",
+        "usageWindow" => "Agent Usage Window",
         "avgCostPlan" => "Avg Cost/Plan",
         _ => "KPI Breakdown"
     };
@@ -244,37 +256,59 @@ public class DashboardApp : ViewBase
         DashboardModels stats,
         DashboardActivityStats activity,
         List<(DateOnly Date, int Count)> prDays,
-        DateTime today)
+        List<(DateOnly Date, int Count)> featureDays,
+        DateTime today,
+        AgentUsageSnapshot? usageSnapshot)
     {
         var kpis = new List<DashboardKpiDto>();
 
-        // Daily PR average over the last 30 days, compared to the 30 days before that.
+        // Card 1: Features shipped (absolute count, last 30 days vs previous 30 days)
         var last30Start = DateOnly.FromDateTime(today.AddDays(-29));
         var prev30Start = DateOnly.FromDateTime(today.AddDays(-59));
-        var dailyPrs = prDays.Where(p => p.Date >= last30Start).Sum(p => p.Count) / 30m;
-        var prevDailyPrs = prDays.Where(p => p.Date >= prev30Start && p.Date < last30Start).Sum(p => p.Count) / 30m;
-        kpis.Add(Kpi("Avg Daily PR count", dailyPrs.ToString("0.#", CultureInfo.InvariantCulture), dailyPrs, prevDailyPrs, "dailyPrs"));
+        var features30 = featureDays.Where(p => p.Date >= last30Start).Sum(p => p.Count);
+        var prevFeatures30 = featureDays.Where(p => p.Date >= prev30Start && p.Date < last30Start).Sum(p => p.Count);
+        kpis.Add(Kpi("Features shipped", FormatHelper.FormatCount(features30), features30, prevFeatures30, "featuresShipped",
+            hint: "merged PRs and solved issues, last 30 days"));
 
-        // Monthly cost/token averages over recent complete months with data; the delta
-        // compares the two most recent complete months.
-        var completeMonths = activity.Months.Count > 0
-            ? activity.Months.Take(activity.Months.Count - 1).ToList()
-            : [];
+        // Card 2: Avg cost per Feature
+        var dailyCosts = activity.DailyCosts;
+        if (dailyCosts != null && dailyCosts.Count > 0 && features30 > 0)
+        {
+            var cost30 = dailyCosts.Where(c => c.Date >= last30Start).Sum(c => c.TotalCost);
+            var prevCost30 = dailyCosts.Where(c => c.Date >= prev30Start && c.Date < last30Start).Sum(c => c.TotalCost);
+            var costPerFeature = cost30 / features30;
+            var prevCostPerFeature = prevFeatures30 > 0 ? prevCost30 / prevFeatures30 : 0;
+            var hint = $"{FormatHelper.FormatCost(cost30)} over {FormatHelper.FormatCount(features30)} features";
+            kpis.Add(Kpi("Avg cost per Feature", FormatHelper.FormatCost(costPerFeature), costPerFeature, prevCostPerFeature, "costPerFeature", hint: hint));
+        }
+        else if (features30 == 0)
+        {
+            kpis.Add(new DashboardKpiDto("Avg cost per Feature", "n/a", Hint: "No features shipped in the last 30 days", Id: "costPerFeature"));
+        }
+        else
+        {
+            kpis.Add(new DashboardKpiDto("Avg cost per Feature", "n/a", Hint: "No cost data available", Id: "costPerFeature"));
+        }
 
-        var costMonths = completeMonths.TakeLast(6).Where(m => m.Cost > 0).ToList();
-        var avgMonthCost = costMonths.Count > 0
-            ? costMonths.Average(m => m.Cost)
-            : activity.Months.Count > 0 ? activity.Months[^1].Cost : 0;
-        var (lastCost, prevCost) = LastTwo(completeMonths, m => m.Cost);
-        kpis.Add(Kpi("Avg Cost/Month", FormatCost(avgMonthCost), lastCost, prevCost, "avgCostMonth"));
-
-        // Next to the retrospective average on purpose: what the month has cost so far and what it is
-        // heading for are read together.
+        // Card 3: Forecast This Month (unchanged)
         kpis.Add(BuildForecastKpi(activity.DailyCosts, today));
 
-
-        kpis.Add(Kpi("Avg Cost/Plan", FormatHelper.FormatCost(stats.AvgCostPerPlan),
-            stats.AvgCostPerPlan, activity.PrevWeekAvgCostPerPlan, "avgCostPlan"));
+        // Card 4: Usage window (with fallback to avgCostPlan)
+        if (usageSnapshot?.Windows is { Count: > 0 } windows)
+        {
+            var tightestWindow = windows.OrderBy(w => w.WindowMinutes).First();
+            var label = $"{UsageWindowCalculator.FormatWindow(tightestWindow.WindowMinutes)} window";
+            var value = $"{tightestWindow.RemainingPercent:0.#}% remaining";
+            var hint = tightestWindow.ResetsAt.HasValue
+                ? $"resets in {UsageWindowCalculator.FormatCountdown(tightestWindow.ResetsAt.Value - DateTimeOffset.UtcNow)}"
+                : null;
+            kpis.Add(new DashboardKpiDto(label, value, Hint: hint, Id: "usageWindow"));
+        }
+        else
+        {
+            kpis.Add(Kpi("Avg Cost/Plan", FormatHelper.FormatCost(stats.AvgCostPerPlan),
+                stats.AvgCostPerPlan, activity.PrevWeekAvgCostPerPlan, "avgCostPlan"));
+        }
 
         return kpis;
     }
@@ -318,17 +352,17 @@ public class DashboardApp : ViewBase
             : (0, 0);
     }
 
-    internal static DashboardKpiDto Kpi(string label, string value, decimal current, decimal previous, string? id = null)
+    internal static DashboardKpiDto Kpi(string label, string value, decimal current, decimal previous, string? id = null, string? hint = null)
     {
         if (previous <= 0 || current <= 0)
-            return new DashboardKpiDto(label, value, Id: id);
+            return new DashboardKpiDto(label, value, Hint: hint, Id: id);
 
         var pct = (current - previous) / previous * 100m;
         var magnitude = Math.Abs(pct) >= 10
             ? Math.Round(Math.Abs(pct)).ToString("0", CultureInfo.InvariantCulture)
             : Math.Abs(pct).ToString("0.##", CultureInfo.InvariantCulture);
         var delta = (pct >= 0 ? "+" : "-") + magnitude + "%";
-        return new DashboardKpiDto(label, value, delta, pct >= 0 ? "up" : "down", Id: id);
+        return new DashboardKpiDto(label, value, delta, pct >= 0 ? "up" : "down", hint, Id: id);
     }
 
     private static string FormatCost(decimal cost) =>

--- a/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
@@ -127,8 +127,8 @@ public class KpiBreakdownSheet(
         var features30 = featureDays.Where(p => p.Date >= last30Start).Sum(p => p.Count);
         var prevFeatures30 = featureDays.Where(p => p.Date >= prev30Start && p.Date < last30Start).Sum(p => p.Count);
 
-        var cost30 = dailyCosts.Where(c => c.Date >= last30Start).Sum(c => c.TotalCost);
-        var prevCost30 = dailyCosts.Where(c => c.Date >= prev30Start && c.Date < last30Start).Sum(c => c.TotalCost);
+        var cost30 = dailyCosts.Where(c => c.Date >= last30Start).Sum(c => c.Cost);
+        var prevCost30 = dailyCosts.Where(c => c.Date >= prev30Start && c.Date < last30Start).Sum(c => c.Cost);
 
         var costPerFeature = features30 > 0 ? cost30 / features30 : 0m;
         var prevCostPerFeature = prevFeatures30 > 0 ? prevCost30 / prevFeatures30 : 0m;

--- a/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs
@@ -15,6 +15,7 @@ public class KpiBreakdownSheet(
     DashboardModels stats,
     DashboardActivityStats activity,
     List<(DateOnly Date, int Count)> prDays,
+    List<(DateOnly Date, int Count)> featureDays,
     DateTime today,
     IPlanReaderService planService) : ViewBase
 {
@@ -22,46 +23,63 @@ public class KpiBreakdownSheet(
     {
         return kpiKey switch
         {
-            "dailyPrs" => BuildDailyPrsBreakdown(),
-            "avgCostMonth" => BuildAvgCostMonthBreakdown(),
+            "featuresShipped" => BuildFeaturesShippedBreakdown(),
+            "costPerFeature" => BuildCostPerFeatureBreakdown(),
             "forecastMonth" => BuildForecastMonthBreakdown(),
+            "usageWindow" => BuildUsageWindowBreakdown(),
             "avgCostPlan" => BuildAvgCostPlanBreakdown(),
             _ => Layout.Vertical().Gap(4)
                  | Callout.Info($"No calculation breakdown available for key '{kpiKey}'.", "Unknown Metric")
         };
     }
 
-    private object BuildDailyPrsBreakdown()
+    private object BuildFeaturesShippedBreakdown()
     {
         var last30Start = DateOnly.FromDateTime(today.AddDays(-29));
         var prev30Start = DateOnly.FromDateTime(today.AddDays(-59));
-        var last30Count = prDays.Where(p => p.Date >= last30Start).Sum(p => p.Count);
-        var prev30Count = prDays.Where(p => p.Date >= prev30Start && p.Date < last30Start).Sum(p => p.Count);
-        var dailyPrs = last30Count / 30m;
-        var prevDailyPrs = prev30Count / 30m;
-        var deltaText = CalculateDelta(dailyPrs, prevDailyPrs);
+        var last30Count = featureDays.Where(p => p.Date >= last30Start).Sum(p => p.Count);
+        var prev30Count = featureDays.Where(p => p.Date >= prev30Start && p.Date < last30Start).Sum(p => p.Count);
+        var deltaText = CalculateDelta(last30Count, prev30Count);
 
         var details = new
         {
-            Metric = "Average Daily Pull Requests",
-            Formula = "Total PRs merged in last 30 calendar days / 30",
-            Last30DaysMergedPrs = last30Count.ToString(CultureInfo.InvariantCulture),
-            Last30DaysDailyAverage = dailyPrs.ToString("0.#", CultureInfo.InvariantCulture),
-            Prior30DaysMergedPrs = prev30Count.ToString(CultureInfo.InvariantCulture),
-            Prior30DaysDailyAverage = prevDailyPrs.ToString("0.#", CultureInfo.InvariantCulture),
+            Metric = "Features Shipped",
+            Formula = "Merged PRs + solved issues, last 30 days",
+            Last30DaysFeaturesShipped = FormatHelper.FormatCount(last30Count),
+            Prior30DaysFeaturesShipped = FormatHelper.FormatCount(prev30Count),
             PeriodComparisonDelta = deltaText
         }
             .ToDetails()
             .Label(x => x.Metric, "Metric")
             .Label(x => x.Formula, "Formula")
-            .Label(x => x.Last30DaysMergedPrs, "Last 30 Days (Merged PRs)")
-            .Label(x => x.Last30DaysDailyAverage, "Last 30 Days (Daily Avg)")
-            .Label(x => x.Prior30DaysMergedPrs, "Prior 30 Days (Merged PRs)")
-            .Label(x => x.Prior30DaysDailyAverage, "Prior 30 Days (Daily Avg)")
+            .Label(x => x.Last30DaysFeaturesShipped, "Last 30 Days")
+            .Label(x => x.Prior30DaysFeaturesShipped, "Prior 30 Days")
             .Label(x => x.PeriodComparisonDelta, "30-Day Period Delta");
 
+        var featureTable = featureDays
+            .Where(d => d.Date >= last30Start)
+            .OrderByDescending(d => d.Date)
+            .Select(d => new
+            {
+                Date = d.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                Count = d.Count.ToString(CultureInfo.InvariantCulture)
+            })
+            .AsQueryable()
+            .ToDataTable(x => x.Date)
+            .Header(x => x.Date, "Date")
+            .Header(x => x.Count, "Features")
+            .Width(Size.Full())
+            .Height(Size.Px(240))
+            .Config(c =>
+            {
+                c.AllowSorting = true;
+                c.SelectionMode = SelectionModes.None;
+                c.ShowIndexColumn = false;
+                c.ShowSearch = false;
+            });
+
         var recentPrs = planService.GetRecentMergedPrs(50);
-        object tableContent = recentPrs.Count == 0
+        object prTableContent = recentPrs.Count == 0
             ? Callout.Info("No merged pull requests recorded yet.", "No Data")
             : recentPrs
                 .Select(p => new PrRow
@@ -90,95 +108,60 @@ public class KpiBreakdownSheet(
                 });
 
         return Layout.Vertical().Gap(4)
-               | Callout.Info("Average Daily PRs measures pull request delivery throughput across a rolling 30-day window. Total merged pull requests from the last 30 calendar days are divided by 30.", "Throughput Metric")
+               | Callout.Info("Features Shipped counts merged PRs and solved issues without a PR over the last 30 days. A plan with three PRs counts three features; an issue-only plan counts one.", "Output Metric")
                | details
                | (Layout.Vertical().Gap(2)
+                  | Text.H4("Features by Day (Last 30 Days)")
+                  | featureTable)
+               | (Layout.Vertical().Gap(2)
                   | Text.H4("Recent Merged Pull Requests")
-                  | tableContent);
+                  | prTableContent);
     }
 
-    private object BuildAvgCostMonthBreakdown()
+    private object BuildCostPerFeatureBreakdown()
     {
-        var completeMonths = activity.Months.Count > 0
-            ? activity.Months.Take(activity.Months.Count - 1).ToList()
-            : [];
+        var last30Start = DateOnly.FromDateTime(today.AddDays(-29));
+        var prev30Start = DateOnly.FromDateTime(today.AddDays(-59));
 
-        var costMonths = completeMonths.TakeLast(6).Where(m => m.Cost > 0).ToList();
-        var avgMonthCost = costMonths.Count > 0
-            ? costMonths.Average(m => m.Cost)
-            : (activity.Months.Count > 0 ? activity.Months[^1].Cost : 0);
-        var (lastCost, prevCost) = LastTwo(completeMonths, m => m.Cost);
-        var deltaText = CalculateDelta(lastCost, prevCost);
+        var dailyCosts = activity.DailyCosts ?? [];
+        var features30 = featureDays.Where(p => p.Date >= last30Start).Sum(p => p.Count);
+        var prevFeatures30 = featureDays.Where(p => p.Date >= prev30Start && p.Date < last30Start).Sum(p => p.Count);
+
+        var cost30 = dailyCosts.Where(c => c.Date >= last30Start).Sum(c => c.TotalCost);
+        var prevCost30 = dailyCosts.Where(c => c.Date >= prev30Start && c.Date < last30Start).Sum(c => c.TotalCost);
+
+        var costPerFeature = features30 > 0 ? cost30 / features30 : 0m;
+        var prevCostPerFeature = prevFeatures30 > 0 ? prevCost30 / prevFeatures30 : 0m;
+        var deltaText = CalculateDelta(costPerFeature, prevCostPerFeature);
 
         var details = new
         {
-            Metric = "Average Cost per Month",
-            Methodology = "Arithmetic mean of up to 6 complete historical months with spend > $0",
-            AverageCost = FormatCost(avgMonthCost),
-            IncludedMonthsCount = $"{costMonths.Count} completed month(s)",
-            LastCompletedMonthSpend = FormatCost(lastCost),
-            PriorCompletedMonthSpend = FormatCost(prevCost),
-            MonthOverMonthDelta = deltaText
+            Metric = "Avg Cost per Feature",
+            Formula = "30-day spend / 30-day features shipped",
+            Last30DaysSpend = FormatHelper.FormatCost(cost30),
+            Last30DaysFeatures = FormatHelper.FormatCount(features30),
+            Last30DaysCostPerFeature = features30 > 0 ? FormatHelper.FormatCost(costPerFeature) : "n/a",
+            Prior30DaysSpend = FormatHelper.FormatCost(prevCost30),
+            Prior30DaysFeatures = FormatHelper.FormatCount(prevFeatures30),
+            Prior30DaysCostPerFeature = prevFeatures30 > 0 ? FormatHelper.FormatCost(prevCostPerFeature) : "n/a",
+            PeriodComparisonDelta = deltaText
         }
             .ToDetails()
             .Label(x => x.Metric, "Metric")
-            .Label(x => x.Methodology, "Methodology")
-            .Label(x => x.AverageCost, "6-Month Historical Avg")
-            .Label(x => x.IncludedMonthsCount, "Completed Months in Divisor")
-            .Label(x => x.LastCompletedMonthSpend, "Last Completed Month")
-            .Label(x => x.PriorCompletedMonthSpend, "Prior Completed Month")
-            .Label(x => x.MonthOverMonthDelta, "Month-over-Month Delta");
+            .Label(x => x.Formula, "Formula")
+            .Label(x => x.Last30DaysSpend, "Last 30 Days (Spend)")
+            .Label(x => x.Last30DaysFeatures, "Last 30 Days (Features)")
+            .Label(x => x.Last30DaysCostPerFeature, "Last 30 Days (Cost/Feature)")
+            .Label(x => x.Prior30DaysSpend, "Prior 30 Days (Spend)")
+            .Label(x => x.Prior30DaysFeatures, "Prior 30 Days (Features)")
+            .Label(x => x.Prior30DaysCostPerFeature, "Prior 30 Days (Cost/Feature)")
+            .Label(x => x.PeriodComparisonDelta, "30-Day Period Delta");
 
-        var monthRows = activity.Months
-            .Select((m, idx) =>
-            {
-                var isInFlight = idx == activity.Months.Count - 1;
-                var isIncluded = costMonths.Contains(m);
-                var status = isInFlight
-                    ? "Excluded (In Flight)"
-                    : isIncluded
-                        ? "Included in Divisor"
-                        : "Excluded ($0 spend)";
-
-                return new MonthRow
-                {
-                    Month = $"{m.Year}-{m.Month:D2}",
-                    Spend = FormatCost(m.Cost),
-                    Tokens = FormatHelper.FormatCount(m.Tokens),
-                    PlansCreated = m.PlansCreated.ToString(CultureInfo.InvariantCulture),
-                    PrsMerged = m.PrsMerged.ToString(CultureInfo.InvariantCulture),
-                    Status = status
-                };
-            })
-            .ToList();
-
-        var table = monthRows
-            .AsQueryable()
-            .ToDataTable(x => x.Month)
-            .Header(x => x.Month, "Month")
-            .Header(x => x.Spend, "Spend")
-            .Header(x => x.Tokens, "Tokens")
-            .Header(x => x.PlansCreated, "Plans")
-            .Header(x => x.PrsMerged, "PRs Merged")
-            .Header(x => x.Status, "Divisor Status")
-            .Width(Size.Full())
-            .Height(Size.Px(360))
-            .Config(c =>
-            {
-                c.AllowSorting = true;
-                c.SelectionMode = SelectionModes.None;
-                c.ShowIndexColumn = false;
-                c.ShowSearch = false;
-            });
-
-        var agentSection = BuildAgentBreakdownSection(180);
+        var agentSection = BuildAgentBreakdownSection(30);
 
         return Layout.Vertical().Gap(4)
-               | Callout.Info("Average Cost/Month shows retrospective monthly spend across complete historical calendar months, strictly excluding the currently in-flight month to prevent partial-month bias.", "Retrospective Spend")
+               | Callout.Info("Avg Cost per Feature divides 30-day spend by 30-day features shipped, so the card shows the exact quotient of the two cards beside it.", "Unit Cost")
                | details
-               | (Layout.Vertical().Gap(2)
-                  | Text.H4("Historical Monthly Breakdown")
-                  | table)
                | agentSection;
     }
 
@@ -349,6 +332,12 @@ public class KpiBreakdownSheet(
                   | Text.H4("Plans in Rolling Window (Last 7 Days)")
                   | tableContent)
                | agentSection;
+    }
+
+    private object BuildUsageWindowBreakdown()
+    {
+        return Layout.Vertical().Gap(4)
+               | Callout.Info("Usage window information is not currently available. This typically means the agent provider does not report usage windows, or no usage data has been fetched yet.", "No Usage Data");
     }
 
     private static (decimal Last, decimal Previous) LastTwo(

--- a/src/Ivy.Tendril/Database/DashboardRepository.cs
+++ b/src/Ivy.Tendril/Database/DashboardRepository.cs
@@ -355,6 +355,47 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
         }
     }
 
+    /// <summary>
+    ///     Features shipped per day, where a feature is a merged pull request or a solved issue.
+    ///     A completed plan with three PRs shipped three features; a completed plan that closed an
+    ///     issue without opening a PR shipped one. The NOT EXISTS clause keeps the two arms disjoint,
+    ///     so a plan with both a PR and an issue source is counted once per PR and not again.
+    /// </summary>
+    public List<(DateOnly Date, int Count)> GetShippedFeaturesByDay(int days = 60)
+    {
+        using (new ReadLockHandle(lockSlim))
+        {
+            var cutoff = DateTime.UtcNow.Date.AddDays(-(days - 1)).ToString("yyyy-MM-dd");
+            var results = new List<(DateOnly Date, int Count)>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT d, COUNT(*) AS cnt FROM (
+                    SELECT DISTINCT DATE(p.Updated) AS d, pr.PrUrl AS k
+                    FROM PullRequests pr
+                    JOIN Plans p ON p.Id = pr.PlanId
+                    WHERE p.Updated >= @cutoff AND p.State = 'Completed'
+                    UNION ALL
+                    SELECT DATE(p.Updated) AS d, 'plan:' || p.Id AS k
+                    FROM Plans p
+                    WHERE p.Updated >= @cutoff
+                      AND p.State = 'Completed'
+                      AND p.SourceUrl LIKE '%/issues/%'
+                      AND NOT EXISTS (SELECT 1 FROM PullRequests x WHERE x.PlanId = p.Id)
+                )
+                GROUP BY d
+                ORDER BY d
+                """;
+            cmd.Parameters.AddWithValue("@cutoff", cutoff);
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                if (DateOnly.TryParse(r.GetString(0), CultureInfo.InvariantCulture, out var day))
+                    results.Add((day, r.GetInt32(1)));
+            }
+            return results;
+        }
+    }
+
     public List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50)
     {
         using (new ReadLockHandle(lockSlim))

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -15,6 +15,7 @@ public interface IPlanDatabaseService : IDisposable
     DashboardModels GetDashboardData(string? projectFilter);
     DashboardActivityStats GetActivityStats(int monthsBack = 24);
     List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days = 30);
+    List<(DateOnly Date, int Count)> GetShippedFeaturesByDay(int days = 60) => [];
     List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50) => [];
     List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) => [];
     List<DashboardAgentCost> GetAgentCostBreakdown(int days) => [];

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -48,6 +48,7 @@ public interface IPlanReaderService
     DashboardModels GetDashboardData(string? projectFilter);
     DashboardActivityStats GetDashboardActivity(int monthsBack = 24);
     List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days);
+    List<(DateOnly Date, int Count)> GetShippedFeaturesByDay(int days = 60) => [];
     List<RecentMergedPrDto> GetRecentMergedPrs(int limit = 50) => [];
     List<RecentPlanCostDto> GetRecentPlanCosts(int days = 7) => [];
     List<DashboardAgentCost> GetAgentCostBreakdown(int days) => [];

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -293,6 +293,9 @@ public class PlanDatabaseService : IPlanDatabaseService
         }
     }
 
+    public List<(DateOnly Date, int Count)> GetShippedFeaturesByDay(int days = 60) =>
+        _dashboardRepository.GetShippedFeaturesByDay(days);
+
     public decimal GetPlanTotalCost(int planId)
     {
         using (new ReadLockHandle(_lock))


### PR DESCRIPTION
Fixes #2591

# Summary

## Changes

Revised the four KPI cards on the "What Are We Producing Today?" dashboard to show more meaningful metrics. The cards now display features shipped (absolute count), cost per feature, month forecast, and agent usage window.

## API Changes

- Added `GetShippedFeaturesByDay(int days = 60)` method to `DashboardRepository`, `IPlanDatabaseService`, `IPlanReaderService`, and `PlanDatabaseService` - Returns features shipped per day where a feature is a merged PR or a solved issue.
- Updated `BuildKpis` signature in `DashboardApp` to accept `List<(DateOnly Date, int Count)> featureDays` and `AgentUsageSnapshot? usageSnapshot` parameters
- Updated `KpiBreakdownSheet` constructor to accept `List<(DateOnly Date, int Count)> featureDays` parameter
- Updated `GetKpiSheetTitle` to map new KPI keys: `featuresShipped`, `costPerFeature`, `usageWindow`
- Added `hint` parameter to `Kpi` helper method

## Files Modified

**Core Implementation:**
- `src/Ivy.Tendril/Database/DashboardRepository.cs` - Added GetShippedFeaturesByDay query
- `src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs` - Added interface method with default implementation
- `src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs` - Added interface method with default implementation
- `src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs` - Implemented GetShippedFeaturesByDay
- `src/Ivy.Tendril/Apps/DashboardApp.cs` - Updated BuildKpis, fetched featureDays and usage snapshot, added imports
- `src/Ivy.Tendril/Apps/Views/Sheets/KpiBreakdownSheet.cs` - Updated for new KPI breakdowns

**Tests:**
- `src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs` - Updated tests for new KPIs and signatures
- `src/Ivy.Tendril.Test/Views/Sheets/KpiBreakdownSheetTests.cs` - Fixed constructor calls

**Samples:**
- `src/Ivy.Tendril.Widgets/.samples/Apps/TendrilDashboard/DemoApp.cs` - Updated with new KPI labels

## Manual Testing

1. Run the Tendril desktop app
2. Navigate to the Dashboard view
3. Observe the four KPI cards across the top:
   - Card 1 should show "Features shipped" with an absolute count (e.g., "315")
   - Card 2 should show "Avg cost per Feature" with a dollar amount (e.g., "$3.63") and a hint showing the calculation
   - Card 3 should show "Forecast This Month" (unchanged)
   - Card 4 should show either a usage window (e.g., "5h window", "87.3% remaining") if the agent has a usage provider, or "Avg Cost/Plan" as fallback
4. Click each KPI card to open its breakdown sheet and verify the drill-down details display correctly

---

## Commits
- d2b5c733663b64cf811d2467a0fbd65600c3e30e
- 212ec05c306677d1932bcc6b56047764aae5d55f
- 6327e1880ccbc180e3843f185a9e2f68e0430550
- b7417034180c4fa67d1dd548f60202fa696e6795

---
Created using [Ivy Tendril](https://ivy.app).
