### PR TITLE
[00410] Stop Saving Empty Chats to History

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatAppArgsTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatAppArgsTests.cs
@@ -1,0 +1,35 @@
+using Ivy.Tendril.Apps.Chat;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Chat;
+
+public class ChatAppArgsTests
+{
+    [Fact]
+    public void NewChat_NamesNoSessionAndNoPrompt()
+    {
+        var args = new ChatAppArgs(NewChat: true);
+
+        Assert.True(args.NewChat);
+        Assert.Null(args.SessionId);
+        Assert.Null(args.Prompt);
+    }
+
+    [Fact]
+    public void NewChat_IsNotEqualToTheDefaultArgs()
+    {
+        // The shell keys a page on its args, so this inequality is what makes clicking + rebuild the
+        // chat view rather than leaving the previous session on screen.
+        Assert.NotEqual(new ChatAppArgs(), new ChatAppArgs(NewChat: true));
+        Assert.NotEqual(new ChatAppArgs(SessionId: "abc"), new ChatAppArgs(NewChat: true));
+        Assert.Equal(new ChatAppArgs(NewChat: true), new ChatAppArgs(NewChat: true));
+    }
+
+    [Fact]
+    public void DefaultArgs_DoNotRequestANewChat()
+    {
+        Assert.False(new ChatAppArgs().NewChat);
+        Assert.False(new ChatAppArgs(SessionId: "abc").NewChat);
+        Assert.False(new ChatAppArgs(Prompt: "Hello").NewChat);
+    }
+}

--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
@@ -36,7 +36,7 @@ public class ChatLauncherTests
     }
 
     [Fact]
-    public void NewSessionTarget_ChatMode_CreatesChatSessionAndSelectsIt()
+    public void NewSessionTarget_ChatMode_DefersSessionCreation()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "TendrilLauncherTest_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
@@ -49,9 +49,30 @@ public class ChatLauncherTests
 
             Assert.Equal(typeof(ChatApp), app);
             var chatArgs = Assert.IsType<ChatAppArgs>(args);
-            var session = Assert.Single(chats.GetSessions());
-            Assert.Equal(session.Id, chatArgs.SessionId);
-            Assert.False(session.IsTerminal());
+            Assert.True(chatArgs.NewChat);
+            Assert.Null(chatArgs.SessionId);
+            Assert.Empty(chats.GetSessions());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void NewSessionTarget_ChatMode_StillPrunesAbandonedEmptySessions()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilLauncherTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = Config(ChatModes.Chat, tempDir);
+            var chats = new ChatHistoryService(config);
+            var abandoned = chats.CreateSession("codex", "default", kind: ChatSessionKinds.Chat);
+
+            ChatLauncher.NewSessionTarget(config, chats, TestAgentRunner.Create());
+
+            Assert.Null(chats.GetSession(abandoned.Id));
         }
         finally
         {

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -846,4 +846,52 @@ public class ChatHistoryServiceTests
                 Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void PruneEmptySessions_KeepsEmptyTerminalSessions()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var terminal = service.CreateSession("claude", "opus", "Terminal", kind: ChatSessionKinds.Terminal);
+            var chat = service.CreateSession("claude", "opus", "Chat", kind: ChatSessionKinds.Chat);
+
+            service.PruneEmptySessions();
+
+            // A terminal pane opened without an initial prompt has no messages, but closing it is the
+            // pane's decision, not the prune's.
+            Assert.NotNull(service.GetSession(terminal.Id));
+            Assert.Null(service.GetSession(chat.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void PruneEmptySessions_RaisesSessionsChangedWhenARowDisappears()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            service.CreateSession("claude", "opus", "Empty", kind: ChatSessionKinds.Chat);
+            var raised = 0;
+            service.SessionsChanged += (_, _) => raised++;
+
+            service.PruneEmptySessions();
+
+            // The chat app's sidebar refresh hangs off this event: no event, no row removal.
+            Assert.Equal(1, raised);
+
+            service.PruneEmptySessions();
+            Assert.Equal(1, raised);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -775,6 +775,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         {
             if (!CheckTabExists(closedIndex)) return;
 
+            var closedTab = tabs.Value[closedIndex];
             var wasSelected = selectedIndex.Value == closedIndex;
             var newTabs = tabs.Value.RemoveAt(closedIndex);
             int? newIndex = null;
@@ -798,6 +799,16 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             }
 
             tabs.Set(newTabs);
+
+            // PruneEmptySessions leaves terminal sessions alone, so a pane closed without anything
+            // typed into it is retired here instead. The tab is already gone from tabs, so the
+            // SessionsChanged this raises finds nothing left for CloseTabsOfDeletedSessions to close.
+            // The non-null session check keeps this a no-op when that handler is the caller.
+            if (IsAgentTab(closedTab) && chatService.GetSession(closedTab.Id) is { } closedSession
+                && (closedSession.Messages == null || closedSession.Messages.Count == 0))
+            {
+                chatService.DeleteSession(closedTab.Id);
+            }
 
             if (!wasSelected) return;
 

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -215,6 +215,12 @@ public class ChatApp : ViewBase
                 chatService.ClearSessionCompleted(activeSessionId.Value);
             }
 
+            // Prune on entry, not only on teardown. Subscribing first means the SessionsChanged this
+            // raises reaches OnSessionsChanged, which rebuilds and republishes the sidebar list
+            // without the removed rows. A prune in the dispose callback alone races the incoming
+            // view's publish, so an abandoned chat can linger in the shell's snapshot.
+            chatService.PruneEmptySessions(activeSessionId: activeSessionId.Value);
+
             return Disposable.Create(() =>
             {
                 chatService.SessionsChanged -= OnSessionsChanged;

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -226,8 +226,9 @@ public class ChatApp : ViewBase
             });
         });
 
-        // The chat session the args name, when it still exists; a bare prompt starts a fresh chat;
-        // otherwise the most recent chat. Terminal sessions belong to the AgentApp pane, never here.
+        // The chat session the args name, when it still exists; NewChat or a bare prompt starts a
+        // fresh chat; otherwise the most recent chat. Terminal sessions belong to the AgentApp pane,
+        // never here.
         ChatSessionModel? InitialSession()
         {
             if (!string.IsNullOrEmpty(args?.SessionId))
@@ -235,6 +236,7 @@ public class ChatApp : ViewBase
                 var named = chatService.GetSession(args.SessionId);
                 if (named != null && !named.IsTerminal()) return named;
             }
+            if (args?.NewChat == true) return null;
             if (!string.IsNullOrEmpty(args?.Prompt)) return null;
             return chatService.GetSessions().FirstOrDefault(s => !s.IsTerminal());
         }
@@ -293,9 +295,12 @@ public class ChatApp : ViewBase
                 navigator.Navigate(typeof(AgentApp), new AgentAppArgs());
                 return;
             }
+            // No session is created here: SendMessage creates one on demand, so a chat the user
+            // never types into never reaches the history. Until then the Chats list shows no row
+            // and no selection.
             chatService.PruneEmptySessions();
-            var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort, kind: ChatSessionKinds.Chat);
-            SelectSession(newSess.Id);
+            activeSessionId.Set((string?)null);
+            navigator.Navigate(typeof(ChatApp), new ChatAppArgs(NewChat: true));
         }
 
         void SendMessage(ChatSendMessageDto dto)

--- a/src/Ivy.Tendril/Apps/Chat/ChatAppArgs.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatAppArgs.cs
@@ -1,3 +1,5 @@
 namespace Ivy.Tendril.Apps.Chat;
 
-public record ChatAppArgs(string? Prompt = null, string? SessionId = null);
+// NewChat opens a blank composer with no session behind it: the session is created when the first
+// message is sent, so abandoning the chat leaves nothing in the history.
+public record ChatAppArgs(string? Prompt = null, string? SessionId = null, bool NewChat = false);

--- a/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
@@ -19,15 +19,17 @@ internal static class ChatLauncher
         navigator.Navigate(app, args);
     }
 
+    // runner is unused now that neither mode creates a session here, but it stays in the signature
+    // so the call sites and their tests keep compiling.
     public static (Type App, object? Args) NewSessionTarget(IConfigService config, IChatHistoryService chats, IAgentRunner runner)
     {
+        _ = runner;
         if (UsesTerminal(config)) return (typeof(AgentApp), new AgentAppArgs());
 
+        // Both modes defer creation: the chat page creates its session when the first message is
+        // sent, the shell creates a terminal pane's session when the pane opens.
         chats.PruneEmptySessions();
-        var agent = config.Settings.CodingAgent ?? "claude";
-        var models = ChatApp.GetModelsForAgent(runner, agent);
-        var session = chats.CreateSession(agent, models.Count > 0 ? models[0].Id : "default", kind: ChatSessionKinds.Chat);
-        return (typeof(ChatApp), new ChatAppArgs(SessionId: session.Id));
+        return (typeof(ChatApp), new ChatAppArgs(NewChat: true));
     }
 
     public static void StartNew(INavigator navigator, IConfigService config, IChatHistoryService chats, IAgentRunner runner)

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -824,6 +824,14 @@ public class ChatHistoryService : IChatHistoryService
                 continue;
             }
 
+            // A terminal session's lifetime belongs to its pane, not to the chat app. A pane opened
+            // without an initial prompt has no messages, so pruning it here would close the pane out
+            // from under the user; the shell deletes it when its tab closes instead.
+            if (session.IsTerminal())
+            {
+                continue;
+            }
+
             if (session.Messages == null || session.Messages.Count == 0)
             {
                 if (_sessions.TryRemove(id, out _))

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -73,5 +73,11 @@ public interface IChatHistoryService
     void RemoveSpawnedJobs(string sessionId, IEnumerable<string> jobIds);
     IReadOnlyList<string> GetSpawnedJobs(string sessionId);
     bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers);
+    /// <summary>
+    ///     Drops chat sessions that hold no messages, so a chat the user never typed into is not kept
+    ///     in the history. The session named by <paramref name="activeSessionId" />, any session that
+    ///     is generating, and every terminal session are left alone: a terminal session belongs to its
+    ///     pane, which may legitimately be open with nothing typed into it yet.
+    /// </summary>
     void PruneEmptySessions(string? activeSessionId = null);
 }


### PR DESCRIPTION
Fixes #2570

# Stop Saving Empty Chats to History

Fixes [issue #2570](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/2570), reported by
@rorychatt: clicking `+` in the Chats sidebar and then switching away without typing left an empty
chat in the history.

## Changes

**The chat session is now created when the first message is sent, not when `+` is clicked.**
`ChatAppArgs` gains a `NewChat` flag. `ChatApp.StartNewChat` and `ChatLauncher.NewSessionTarget`
navigate with `ChatAppArgs(NewChat: true)` and create nothing; `InitialSession()` returns null for
that flag, so the page renders a blank composer with no session behind it. `SendMessage` already
created the session on demand, with the same agent, model, effort and kind the eager call used, so a
sent message behaves exactly as before. A chat the user never types into now has nothing to clean up,
because it never existed.

While the user is composing a not-yet-created chat, the Chats list shows no row and no selection. The
real row appears, selected and titled from the message, after the first send. This is the same
pattern `PlanChatView` already uses.

**Empty chats are pruned when the chat view is entered, not only when it is torn down.** The only
prune on the sidebar's switch path used to be the outgoing view's dispose callback, which races the
incoming view's sidebar publish, so an abandoned row could survive the switch depending on framework
ordering. `PruneEmptySessions` is now also called inside the view's `UseEffect`, after the
subscriptions are attached, which inverts the order to subscribe, prune, republish: the resulting
`SessionsChanged` reaches the live view, which rebuilds the sidebar list without the removed rows.
The dispose-time prune stays for the case where the chat app is closed entirely. This covers
zero-message sessions left on disk by older builds.

**The prune no longer closes a live terminal pane.** A terminal pane opened with no initial prompt
has zero messages, is not generating, and is not the chat app's active session, so the prune used to
delete its session and `CloseTabsOfDeletedSessions` closed the pane out from under the user. In
terminal chat mode, opening two panes without typing was enough to lose the first.
`PruneEmptySessions` now skips terminal sessions; a terminal session's lifetime belongs to its pane.
So empty terminals still do not linger in the history, `TendrilAppShell.OnTabClose` deletes the
session of a closing agent tab that never received a message.

## API Changes

- `ChatAppArgs` gains a third parameter: `ChatAppArgs(string? Prompt = null, string? SessionId =
  null, bool NewChat = false)`. Positional record, used with named arguments at every call site, so
  appending is source compatible.
- `IChatHistoryService.PruneEmptySessions(string? activeSessionId = null)` keeps its signature but
  changes contract: terminal sessions are now never pruned. Documented with an XML doc comment on the
  interface member. The signature is unchanged because `FakeChatHistoryService` in
  `DeleteSessionDialogTests.cs` also implements the interface.
- `ChatLauncher.NewSessionTarget(IConfigService, IChatHistoryService, IAgentRunner)` no longer uses
  its `IAgentRunner` argument. The parameter is retained (discarded with `_ = runner;`) so its three
  call sites and their tests keep compiling.

No frontend change. `ChatWidget.tsx` already sends a null `sessionId` when no session is active and
its composer is not gated on one.

## Files Modified

| File | Change |
| --- | --- |
| `src/Ivy.Tendril/Apps/Chat/ChatAppArgs.cs` | Added the `NewChat` flag |
| `src/Ivy.Tendril/Apps/Chat/ChatApp.cs` | `InitialSession` honours `NewChat`; `StartNewChat` creates no session; prune added on view entry |
| `src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs` | `NewSessionTarget` defers creation in chat mode, as it already did in terminal mode |
| `src/Ivy.Tendril/Services/ChatHistoryService.cs` | `PruneEmptySessions` skips terminal sessions |
| `src/Ivy.Tendril/Services/IChatHistoryService.cs` | Documented the prune contract |
| `src/Ivy.Tendril/AppShell/TendrilAppShell.cs` | `OnTabClose` retires an agent tab's session when it has no messages |
| `src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs` | Rewrote the eager-creation test; added an abandoned-session prune test |
| `src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs` | Added terminal-survives and `SessionsChanged`-fires tests |
| `src/Ivy.Tendril.Test/Apps/Chat/ChatAppArgsTests.cs` | New: the `NewChat` args contract, including the record equality the shell rebuild depends on |

Three commits: `8f58ebb1` (deferred creation), `7bb33c65` (prune on entry), `6291c2b0` (terminal
sessions).

## Verification

| Verification | Result |
| --- | --- |
| DotnetFormat | Pass, `--verify-no-changes` clean |
| DotnetBuild | Pass, `--warnaserror --no-incremental`, 0 warnings |
| DotnetTest | Pass, 57 of 57 in the plan's filter; 5 tests added |
| CheckResult | Pass |

The full suite reports 18 failures (`JobServiceLogCostTests`, `JobServiceCompletionGuardTests`,
`JobServiceRecoveredExecutionTests`, `ProjectSyncTests`, `QuestionAnswersTests`,
`QuestionValidationServiceTests`, `RevisionWriterTests`). These are pre-existing, measured rather
than assumed: with this plan's changes reverted to the base commit the identical 18 tests fail, test
for test. None of those classes touch chat sessions, the chat app, the launcher, the history service
or the app shell. See `Verification/DotnetTest.md`.

### Expect red CI, for reasons that predate this branch

`origin/development` gained `.github/workflows/backend-checks.yml` after this branch was cut, so this
is the first plan in this area to be gated by it. Two of its steps are already failing on unmodified
`development` and this branch does not change that either way:

- `dotnet build src/Ivy.Tendril/Ivy.Tendril.slnx --configuration Release --warnaserror` fails on 29
  `IVYHOOK005`/`IVYHOOK007` diagnostics in `src/Ivy.Tendril.Widgets/.samples`, a project this plan does
  not touch and which does not reference `Ivy.Tendril`.
- `dotnet test` fails on the 18 pre-existing failures above.

Both are already Pending recommendations on plan 00407. Verification here was run per-csproj instead of
through the solution, because `Ivy.Tendril.slnx` hard-references a sibling `Ivy-Framework` checkout that
does not exist next to a worktree; CI checks Ivy-Framework out alongside, so it builds this branch
against Ivy-Framework `HEAD` rather than the pinned `Ivy` NuGet package used locally.

## Manual Testing

The visible symptom is a UI ordering effect, so it is not fully automatable.

1. `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. With at least two existing chats, click `+`. No new row should appear and the composer should be
   blank.
3. Click another chat in the sidebar. Confirm no "New Chat" row was left behind. This is the
   reported bug.
4. Click `+`, type a message, send. Confirm a row appears, titled from the message, and selected.
5. Click `+` again. Confirm the composer goes blank again (the second-click case, which depends on
   the args differing after the send).
6. With `chatMode: terminal`, open two panes without typing in either. Confirm the first pane stays
   open. Then close one without typing and confirm it leaves no row in the history.

---

## Commits

- 6291c2b0 Plan 00410: Leave live terminal sessions out of the empty-session prune
- 7bb33c65 Plan 00410: Prune empty chat sessions when the chat view is entered
- 8f58ebb1 Plan 00410: Create the chat session only when the first message is sent

---
Created using [Ivy Tendril](https://ivy.app).
