### PR TITLE
[00417] Settle Whether an Empty Plan Chat Session Survives a Restart

### DIFF
--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -923,6 +923,153 @@ public class ChatExecutionServiceJobTrackingTests
     }
 
     [Fact]
+    public async Task JobFinished_WhenThePlansRecordedSessionIsGone_ReportsIntoThePlansOwnSession()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilJobFinishedDeadSessionTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var liveSession = chatService.CreateSession("codex", "gpt-5.6-sol", planFolderName: "00042-TestPlan");
+
+            var dbPath = Path.Combine(tempDir, "test.db");
+            using var db = new PlanDatabaseService(dbPath, NullLogger<PlanDatabaseService>.Instance);
+            var plan = new PlanFile(
+                new PlanMetadata(42, "Tendril", "NiceToHave", "Test Plan", PlanStatus.Draft,
+                    [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null, ChatSessionId: "deadsession"),
+                "# Test",
+                Path.Combine(tempDir, "00042-TestPlan"),
+                "state: Draft"
+            );
+            db.UpsertPlan(plan);
+
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService,
+                planReaderService: null,
+                database: db);
+
+            var job = new JobItem
+            {
+                Id = "00200",
+                Type = "ExecutePlan",
+                PlanFile = plan.FolderName,
+                Project = "Tendril",
+                Status = JobStatus.Completed,
+                StatusMessage = "Plan execution finished"
+            };
+
+            fakeJobService.FireJobFinished(job);
+
+            Assert.Equal(liveSession.Id, job.ChatSessionId);
+
+            var deadline = DateTime.UtcNow.AddSeconds(3);
+            ChatSessionModel? updatedSession = null;
+            while (DateTime.UtcNow < deadline)
+            {
+                updatedSession = chatService.GetSession(liveSession.Id);
+                if (updatedSession?.Messages.Any(m => m.Role == "system" && m.Content.Contains("Job 00200")) == true)
+                    break;
+                await Task.Delay(20);
+            }
+
+            Assert.NotNull(updatedSession);
+            var systemMsg = updatedSession.Messages.FirstOrDefault(m => m.Role == "system" && m.Content.Contains("Job 00200"));
+            Assert.NotNull(systemMsg);
+            Assert.Contains("ExecutePlan", systemMsg.Content);
+            Assert.Contains("Completed", systemMsg.Content);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task JobFinished_WhenThePlanHasNoLiveSessionAtAll_DispatchesNothing()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilJobFinishedNoSessionTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+
+            var dbPath = Path.Combine(tempDir, "test.db");
+            using var db = new PlanDatabaseService(dbPath, NullLogger<PlanDatabaseService>.Instance);
+            var plan = new PlanFile(
+                new PlanMetadata(42, "Tendril", "NiceToHave", "Test Plan", PlanStatus.Draft,
+                    [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null, ChatSessionId: "deadsession"),
+                "# Test",
+                Path.Combine(tempDir, "00042-TestPlan"),
+                "state: Draft"
+            );
+            db.UpsertPlan(plan);
+
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService,
+                planReaderService: null,
+                database: db);
+
+            var job = new JobItem
+            {
+                Id = "00200",
+                Type = "ExecutePlan",
+                PlanFile = plan.FolderName,
+                Project = "Tendril",
+                Status = JobStatus.Completed,
+                StatusMessage = "Plan execution finished"
+            };
+
+            var sessionsBefore = chatService.GetSessions();
+
+            fakeJobService.FireJobFinished(job);
+
+            await Task.Delay(100);
+
+            var sessionsAfter = chatService.GetSessions();
+            Assert.Equal(sessionsBefore.Count, sessionsAfter.Count);
+            Assert.False(sessionsAfter.Any(s => s.Messages.Any(m => m.Role == "system" && m.Content.Contains("Job 00200"))));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
     public void StartJob_InheritsPlanLinkedChatSessionId_AndTracksInChatSession()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "TendrilInheritChatJobTest_" + Guid.NewGuid().ToString("N"));

--- a/src/Ivy.Tendril.Test/PlanChatTests.cs
+++ b/src/Ivy.Tendril.Test/PlanChatTests.cs
@@ -58,16 +58,45 @@ public class PlanChatTests
         {
             var session = service.CreateSession("claude", "opus", "#59 Revamp", planFolderName: "00059-revamp");
             Assert.Equal("00059-revamp", session.PlanFolderName);
-            service.AddMessage(session.Id, "user", "Hello");
 
-            // CreateSession only writes a session that has messages, so the reload below needs one.
-            // An empty plan session surviving a restart is a separate question (see the plan 00400
-            // recommendations); what this asserts is that the plan link is part of what gets persisted.
+            // A session becomes durable from its first message, plan-linked or not (see
+            // ChatHistoryServiceTests.AddMessage_PersistsSessionToDisk). The reload below needs one
+            // message so the session is persisted. What this asserts is that the plan link is part of
+            // what gets persisted.
             service.AddMessage(session.Id, "user", "Let's talk");
 
             var reloaded = new ChatHistoryService(new ConfigService(new TendrilSettings(), tempDir)).GetSession(session.Id);
             Assert.NotNull(reloaded);
             Assert.Equal("00059-revamp", reloaded.PlanFolderName);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void CreateSession_DoesNotPersistAPlanSessionUntilItHasAMessage()
+    {
+        var (service, tempDir) = CreateChatService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus", "#59 Revamp", planFolderName: "00059-revamp");
+            Assert.Equal("00059-revamp", session.PlanFolderName);
+
+            var chatsDir = Path.Combine(tempDir, "Chats");
+            var sessionFile = Path.Combine(chatsDir, $"{session.Id}.json");
+            Assert.False(File.Exists(sessionFile));
+
+            var reloaded = new ChatHistoryService(new ConfigService(new TendrilSettings(), tempDir));
+            Assert.Null(reloaded.GetSession(session.Id));
+
+            service.AddMessage(session.Id, "user", "First message");
+
+            Assert.True(File.Exists(sessionFile));
+            var reloadedAfterMessage = new ChatHistoryService(new ConfigService(new TendrilSettings(), tempDir));
+            Assert.NotNull(reloadedAfterMessage.GetSession(session.Id));
+            Assert.Equal("00059-revamp", reloadedAfterMessage.GetSession(session.Id)?.PlanFolderName);
         }
         finally
         {

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -650,14 +650,11 @@ public class ContentView(
     internal void EmitManualExecutionEvent(string jobId)
     {
         if (selectedPlan is null) return;
-        var chatSessionId = selectedPlan.ChatSessionId;
-        if (string.IsNullOrEmpty(chatSessionId))
-        {
-            chatSessionId = jobService.GetJob(jobId)?.ChatSessionId;
-        }
-        if (string.IsNullOrEmpty(chatSessionId)) return;
-
         var chatService = _chatHistoryService;
+        var chatSessionId = selectedPlan.ChatSessionId;
+        if (chatService?.GetSession(chatSessionId ?? "") == null)
+            chatSessionId = jobService.GetJob(jobId)?.ChatSessionId;
+        if (string.IsNullOrEmpty(chatSessionId)) return;
 
         if (chatService != null)
         {

--- a/src/Ivy.Tendril/Apps/Views/PlanChatSessions.cs
+++ b/src/Ivy.Tendril/Apps/Views/PlanChatSessions.cs
@@ -29,8 +29,10 @@ internal static class PlanChatSessions
     }
 
     /// <summary>
-    ///     Starts the plan's session. The plan learns the session id when it has none yet, so jobs
-    ///     launched from the page report their completion into this chat.
+    ///     Starts the plan's session. The plan learns the session id at once (when it has none yet),
+    ///     but the session becomes durable only with its first message. Therefore plan.ChatSessionId
+    ///     is a hint whose target must be checked before use — it may name a session that was pruned
+    ///     at restart. Jobs launched from the page report their completion into this chat.
     /// </summary>
     public static ChatSessionModel CreateForPlan(
         IChatHistoryService chatService,

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -912,42 +912,9 @@ public sealed class ChatExecutionService : IChatExecutionService
         string? targetSessionId = job.ChatSessionId;
         if (string.IsNullOrEmpty(targetSessionId) && !string.IsNullOrEmpty(job.PlanFile))
         {
-            var folderName = Path.GetFileName(job.PlanFile);
-            var planReader = ResolvedPlanReaderService;
-            var plan = planReader?.GetPlanByFolder(job.PlanFile) ?? (folderName != job.PlanFile ? planReader?.GetPlanByFolder(folderName) : null);
-            targetSessionId = plan?.ChatSessionId;
-
-            if (string.IsNullOrEmpty(targetSessionId))
-            {
-                var db = ResolvedDatabase;
-                var dbPlan = db?.GetPlanByFolder(job.PlanFile) ?? (folderName != job.PlanFile ? db?.GetPlanByFolder(folderName) : null);
-                targetSessionId = dbPlan?.ChatSessionId;
-
-                if (string.IsNullOrEmpty(targetSessionId) && db != null)
-                {
-                    try
-                    {
-                        var jobs = db.GetJobsForPlan(folderName);
-                        if (jobs.Count == 0 && folderName != job.PlanFile)
-                            jobs = db.GetJobsForPlan(job.PlanFile);
-
-                        targetSessionId = jobs
-                            .Where(j => !string.IsNullOrEmpty(j.ChatSessionId))
-                            .OrderByDescending(j => j.StartedAt)
-                            .ThenByDescending(j => j.Id)
-                            .FirstOrDefault()?.ChatSessionId;
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogDebug(ex, "Failed to resolve historical jobs for plan {PlanFile}", job.PlanFile);
-                    }
-                }
-            }
-
+            targetSessionId = ResolveLivePlanChatSession(job.PlanFile);
             if (!string.IsNullOrEmpty(targetSessionId))
-            {
                 job.ChatSessionId = targetSessionId;
-            }
         }
 
         if (string.IsNullOrEmpty(targetSessionId))
@@ -980,6 +947,43 @@ public sealed class ChatExecutionService : IChatExecutionService
             _notifiedPlanEdits.TryAdd($"{targetSessionId}:{planFolder}:{edit.EditKey}", 0);
 
         AnnounceDeferredPlanEdits(job, edits, excludeSessionId: targetSessionId);
+    }
+
+    private string? ResolveLivePlanChatSession(string planFile)
+    {
+        var folderName = Path.GetFileName(planFile);
+        var planReader = ResolvedPlanReaderService;
+        var plan = planReader?.GetPlanByFolder(planFile)
+            ?? (folderName != planFile ? planReader?.GetPlanByFolder(folderName) : null);
+        var db = ResolvedDatabase;
+        var dbPlan = db?.GetPlanByFolder(planFile)
+            ?? (folderName != planFile ? db?.GetPlanByFolder(folderName) : null);
+
+        var candidates = new List<string?> { plan?.ChatSessionId, dbPlan?.ChatSessionId };
+
+        // The plan's own panel sessions, newest first: GetSessions is ordered by UpdatedAt.
+        candidates.AddRange(_chatService.GetSessions()
+            .Where(s => string.Equals(s.PlanFolderName, folderName, StringComparison.OrdinalIgnoreCase))
+            .Select(s => s.Id));
+
+        if (db != null)
+        {
+            try
+            {
+                var jobs = db.GetJobsForPlan(folderName);
+                if (jobs.Count == 0 && folderName != planFile) jobs = db.GetJobsForPlan(planFile);
+                candidates.AddRange(jobs
+                    .Where(j => !string.IsNullOrEmpty(j.ChatSessionId))
+                    .OrderByDescending(j => j.StartedAt).ThenByDescending(j => j.Id)
+                    .Select(j => j.ChatSessionId));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to resolve historical jobs for plan {PlanFile}", planFile);
+            }
+        }
+
+        return candidates.FirstOrDefault(id => !string.IsNullOrEmpty(id) && _chatService.GetSession(id!) != null);
     }
 
     public async Task NotifyPlanEditAsync(

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -797,6 +797,10 @@ public class ChatHistoryService : IChatHistoryService
 
     private void PersistSessionToDisk(ChatSessionModel session)
     {
+        // A session becomes durable from its first message. Zero-message sessions are deliberately
+        // memory-only, and are pruned or deleted at load time (LoadSessionsFromDisk, PruneEmptySessions).
+        // This applies uniformly: plan-linked sessions are no exception and also persist only after
+        // receiving at least one message.
         if (session == null || session.Messages == null || session.Messages.Count == 0) return;
         try
         {


### PR DESCRIPTION
﻿# Summary

## Changes

Implemented the decision to keep the current session persistence behavior: plan chat sessions become durable from their first message, not at creation time. Added documentation explaining this rule, refactored session resolution to check liveness, and added comprehensive tests to verify the behavior.

## API Changes

**ChatExecutionService:**
- Added `ResolveLivePlanChatSession(string planFile)` private method - resolves a plan's chat session by checking multiple candidate sources and returning the first live session

**ChatHistoryService:**
- Added documentation clarifying that sessions (including plan-linked sessions) become durable only after receiving their first message

**PlanChatSessions:**
- Updated `CreateForPlan` documentation to clarify that `plan.ChatSessionId` is a hint that must be validated before use

## Files Modified

**Services:**
- `src/Ivy.Tendril/Services/ChatHistoryService.cs` - Added comment documenting session durability rule
- `src/Ivy.Tendril/Services/ChatExecutionService.cs` - Refactored OnJobFinished to use new ResolveLivePlanChatSession method

**Apps:**
- `src/Ivy.Tendril/Apps/Views/PlanChatSessions.cs` - Updated CreateForPlan doc comment
- `src/Ivy.Tendril/Apps/Plans/ContentView.cs` - Added liveness check in EmitManualExecutionEvent

**Tests:**
- `src/Ivy.Tendril.Test/PlanChatTests.cs` - Removed duplicate message, added CreateSession_DoesNotPersistAPlanSessionUntilItHasAMessage test
- `src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs` - Added two tests for dead session resolution

## Manual Testing

1. Run the app and open a plan's chat panel
2. Type a message but do not send it, then restart the app
3. Verify that the empty chat session is gone after restart (expected behavior - session wasn't persisted)
4. Open the plan's chat panel again, send a message, then restart
5. Verify that the chat session with the message persists across the restart
6. Test the job completion notification flows by executing a plan with various chat session states


---
## Commits

- 09ceb4a3 Resolve plan chat sessions by liveness not presence

---
Created using [Ivy Tendril](https://ivy.app).