### PR TITLE
[00415] Announce Plan Edits Made Through The UI

### DIFF
--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -1405,6 +1405,58 @@ public class ChatExecutionServiceJobTrackingTests
         Assert.Equal(2, harness.EditEvents(side.Id).Count);
     }
 
+    /// <summary>
+    /// UI edits skip the dedupe check because they are in-process calls that are never retried, and
+    /// the dedupe would drop a checkbox toggled back to a status it already held once (unchecked,
+    /// rechecked, unchecked again).
+    /// </summary>
+    [Fact]
+    public async Task NotifyPlanEdit_FromTheUserInterface_AnnouncesEveryToggleIncludingARepeat()
+    {
+        using var harness = new PlanEditFanOutHarness();
+        var side = harness.ChatService.CreateSession("codex", "gpt-5.6-sol", planFolderName: harness.Plan.FolderName);
+
+        await harness.ExecService.NotifyPlanEditAsync(harness.Plan.FolderName, "verification DotnetTest set to Skipped",
+            origin: PlanEditOrigin.UserInterface);
+        await harness.WaitForEventsAsync(side.Id, 1);
+        await harness.WaitForIdleAsync(side.Id);
+
+        await harness.ExecService.NotifyPlanEditAsync(harness.Plan.FolderName, "verification DotnetTest set to Pending",
+            origin: PlanEditOrigin.UserInterface);
+        await harness.WaitForEventsAsync(side.Id, 2);
+        await harness.WaitForIdleAsync(side.Id);
+
+        await harness.ExecService.NotifyPlanEditAsync(harness.Plan.FolderName, "verification DotnetTest set to Skipped",
+            origin: PlanEditOrigin.UserInterface);
+        await harness.WaitForEventsAsync(side.Id, 3);
+
+        Assert.Equal(3, harness.EditEvents(side.Id).Count);
+    }
+
+    /// <summary>
+    /// A UI edit (sourceChatSessionId: null) must reach every attached session including side panels,
+    /// since they all have a view of the plan that just went stale.
+    /// </summary>
+    [Fact]
+    public async Task NotifyPlanEdit_FromTheUserInterface_ReachesTheSidePanelEvenWithNoSourceSession()
+    {
+        using var harness = new PlanEditFanOutHarness();
+        var general = harness.ChatService.CreateSession("codex", "gpt-5.6-sol");
+        var side = harness.ChatService.CreateSession("codex", "gpt-5.6-sol", planFolderName: harness.Plan.FolderName);
+        harness.Database.UpsertPlan(harness.Plan with
+        {
+            Metadata = harness.Plan.Metadata with { ChatSessionId = general.Id }
+        });
+
+        await harness.ExecService.NotifyPlanEditAsync(harness.Plan.FolderName, "state set to Skipped",
+            sourceChatSessionId: null, origin: PlanEditOrigin.UserInterface);
+        await harness.WaitForEventsAsync(general.Id, 1);
+        await harness.WaitForEventsAsync(side.Id, 1);
+
+        Assert.Single(harness.EditEvents(general.Id));
+        Assert.Single(harness.EditEvents(side.Id));
+    }
+
     [Fact]
     public async Task NotifyPlanEdit_WithNoSessionAttachedToThePlan_DoesNothing()
     {
@@ -1449,6 +1501,29 @@ public class ChatExecutionServiceJobTrackingTests
         // An unresolvable plan still has to produce a usable event — the folder name is what the CLI sent.
         var unknown = ChatExecutionService.BuildPlanEditEvent(null, "00400-Notify", "Tests added", null);
         Assert.Contains("Plan '00400-Notify' was edited directly", unknown);
+    }
+
+    [Fact]
+    public void BuildPlanEditEvent_SaysWhenTheUserEditedByHand()
+    {
+        var plan = new PlanFile(
+            new PlanMetadata(400, "Tendril", "NiceToHave", "Notify The Master Agent", PlanStatus.Draft,
+                [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null, ChatSessionId: null),
+            "# Notify", "/tmp/Plans/00400-Notify", "state: Draft");
+
+        var fromUi = ChatExecutionService.BuildPlanEditEvent(
+            plan, plan.FolderName, "state set to Skipped", null, PlanEditOrigin.UserInterface);
+
+        Assert.Contains("was edited directly by the user in the Tendril UI", fromUi);
+        Assert.DoesNotContain("from the plan chat", fromUi);
+
+        var fromChat = ChatExecutionService.BuildPlanEditEvent(
+            plan, plan.FolderName, "state set to Skipped", null, PlanEditOrigin.Chat);
+        Assert.Contains("was edited directly from the plan chat", fromChat);
+
+        // Default is Chat for backward compatibility
+        var defaultOrigin = ChatExecutionService.BuildPlanEditEvent(plan, plan.FolderName, "state set to Skipped", null);
+        Assert.Contains("was edited directly from the plan chat", defaultOrigin);
     }
 
     private class TestState<T> : IState<T>

--- a/src/Ivy.Tendril.Test/PlanChatTests.cs
+++ b/src/Ivy.Tendril.Test/PlanChatTests.cs
@@ -294,4 +294,74 @@ public class PlanChatTests
         Assert.Equal("#59", ChatApp.PlanTag(attached));
         Assert.Null(ChatApp.PlanTag(free));
     }
+
+    [Fact]
+    public async Task Announce_SendsTheSummaryWithTheUiOriginAndNoReason()
+    {
+        var execution = new RecordingChatExecutionService();
+        var plan = CreatePlan(42, "Test Plan");
+
+        await PlanEditAnnouncer.AnnounceAsync(execution, plan, "state set to Skipped");
+
+        Assert.Single(execution.PlanEdits);
+        var edit = execution.PlanEdits[0];
+        Assert.Equal(plan.FolderName, edit.PlanFolderName);
+        Assert.Equal("state set to Skipped", edit.Summary);
+        Assert.Null(edit.Reason);
+        Assert.Null(edit.SourceChatSessionId);
+        Assert.Equal(PlanEditOrigin.UserInterface, edit.Origin);
+    }
+
+    [Fact]
+    public async Task Announce_WithoutAChatExecutionService_DoesNothing()
+    {
+        var plan = CreatePlan(42, "Test Plan");
+
+        await PlanEditAnnouncer.AnnounceAsync(null!, plan, "state set to Skipped");
+
+        // Should not throw
+    }
+
+    [Fact]
+    public async Task Announce_SwallowsAFailureFromTheChatService()
+    {
+        var plan = CreatePlan(42, "Test Plan");
+        var execution = new ThrowingChatExecutionService();
+
+        await PlanEditAnnouncer.AnnounceAsync(execution, plan, "state set to Skipped");
+
+        // Should not throw
+    }
+
+    private sealed class ThrowingChatExecutionService : IChatExecutionService
+    {
+#pragma warning disable CS0067
+        public event Action<string>? SessionGeneratingChanged;
+        public event Action<string>? StreamUpdated;
+#pragma warning restore CS0067
+        public bool IsGenerating(string sessionId) => false;
+        public string GetStreamSnapshot(string sessionId) => string.Empty;
+        public IObservable<string> GetLiveStreamObservable(string sessionId) => System.Reactive.Linq.Observable.Empty<string>();
+
+        public Task SendMessageAsync(string sessionId, string prompt, IReadOnlyList<ChatAttachmentDto>? attachments = null,
+            string? agentId = null, string? modelId = null, string? effort = null, string role = "user", CancellationToken ct = default)
+        {
+            throw new InvalidOperationException("Simulated failure");
+        }
+
+        public Task CancelAsync(string sessionId) => throw new InvalidOperationException("Simulated failure");
+        public Task InterruptAsync(string sessionId) => throw new InvalidOperationException("Simulated failure");
+
+        public Task NotifyPlanEditAsync(string planFolderName, string summary, string? reason = null,
+            string? sourceChatSessionId = null, string? revisionFile = null, PlanEditOrigin origin = PlanEditOrigin.Chat)
+        {
+            throw new InvalidOperationException("Simulated failure");
+        }
+
+        public Task ForceSendMessageAsync(string sessionId, string prompt, IReadOnlyList<ChatAttachmentDto>? attachments = null,
+            string? agentId = null, string? modelId = null, string? effort = null, CancellationToken ct = default) =>
+            throw new InvalidOperationException("Simulated failure");
+
+        public void Dispose() { }
+    }
 }

--- a/src/Ivy.Tendril.Test/PlanChatTests.cs
+++ b/src/Ivy.Tendril.Test/PlanChatTests.cs
@@ -168,7 +168,7 @@ public class PlanChatTests
     private sealed class RecordingChatExecutionService : IChatExecutionService
     {
         public List<(string SessionId, string Prompt, string? AgentId, string? ModelId)> Sent { get; } = [];
-        public List<(string PlanFolderName, string Summary, string? Reason, string? SourceChatSessionId)> PlanEdits { get; } = [];
+        public List<(string PlanFolderName, string Summary, string? Reason, string? SourceChatSessionId, PlanEditOrigin Origin)> PlanEdits { get; } = [];
 #pragma warning disable CS0067
         public event Action<string>? SessionGeneratingChanged;
         public event Action<string>? StreamUpdated;
@@ -188,9 +188,9 @@ public class PlanChatTests
         public Task InterruptAsync(string sessionId) => Task.CompletedTask;
 
         public Task NotifyPlanEditAsync(string planFolderName, string summary, string? reason = null,
-            string? sourceChatSessionId = null, string? revisionFile = null)
+            string? sourceChatSessionId = null, string? revisionFile = null, PlanEditOrigin origin = PlanEditOrigin.Chat)
         {
-            PlanEdits.Add((planFolderName, summary, reason, sourceChatSessionId));
+            PlanEdits.Add((planFolderName, summary, reason, sourceChatSessionId, origin));
             return Task.CompletedTask;
         }
 

--- a/src/Ivy.Tendril.Test/PlanChatTests.cs
+++ b/src/Ivy.Tendril.Test/PlanChatTests.cs
@@ -8,6 +8,7 @@ using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Runtime;
 using Ivy.Tendril.Apps.Chat;
 using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Widgets;

--- a/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
+++ b/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
@@ -166,7 +166,7 @@ public class PlanEditSummaryTests
 
     /// <summary>
     /// DraftActions polishes markdown before describing the edit, so a change that only normalizes
-    /// punctuation or spacing (what PolishMarkdown does automatically) should not announce as a
+    /// line endings or spacing (what PolishMarkdown does automatically) should not announce as a
     /// section change. This is why the call site polishes before describing.
     /// </summary>
     [Fact]
@@ -174,13 +174,13 @@ public class PlanEditSummaryTests
     {
         var config = new ConfigService(new TendrilSettings(), Path.GetTempPath());
         var original = Before;
-        var typed = Before.Replace("Report the edit to the master.", "Report the edit to the master");
+        var typedWithExtraSpaces = Before.Replace("Report the edit to the master.", "Report the edit to the master.  ");
 
-        // Without polishing, the diff shows as a change (period removed)
-        Assert.Equal("Solution changed (+1/-1 lines)", PlanEditSummary.Describe(original, typed));
+        // Without polishing, the diff shows as a change (trailing spaces added)
+        Assert.Equal("Solution changed (+1/-1 lines)", PlanEditSummary.Describe(original, typedWithExtraSpaces));
 
-        // But polishing normalizes the punctuation, making them equivalent
-        var polished = config.PolishMarkdown(typed);
+        // But polishing normalizes the whitespace, making them equivalent
+        var polished = config.PolishMarkdown(typedWithExtraSpaces);
         Assert.Equal("no section changes", PlanEditSummary.Describe(original, polished));
     }
 }

--- a/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
+++ b/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
@@ -1,4 +1,7 @@
+using System.IO;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
 using Xunit;
 
 namespace Ivy.Tendril.Test;

--- a/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
+++ b/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
@@ -160,4 +160,24 @@ public class PlanEditSummaryTests
         Assert.NotEqual(PlanEditSummary.Fingerprint("Solution changed"), PlanEditSummary.Fingerprint("Tests changed"));
         Assert.Equal(16, PlanEditSummary.Fingerprint("Solution changed").Length);
     }
+
+    /// <summary>
+    /// DraftActions polishes markdown before describing the edit, so a change that only normalizes
+    /// punctuation or spacing (what PolishMarkdown does automatically) should not announce as a
+    /// section change. This is why the call site polishes before describing.
+    /// </summary>
+    [Fact]
+    public void Describe_IgnoresWhatPolishingWouldHaveChangedAnyway()
+    {
+        var config = new ConfigService(new TendrilSettings(), Path.GetTempPath());
+        var original = Before;
+        var typed = Before.Replace("Report the edit to the master.", "Report the edit to the master");
+
+        // Without polishing, the diff shows as a change (period removed)
+        Assert.Equal("Solution changed (+1/-1 lines)", PlanEditSummary.Describe(original, typed));
+
+        // But polishing normalizes the punctuation, making them equivalent
+        var polished = config.PolishMarkdown(typed);
+        Assert.Equal("no section changes", PlanEditSummary.Describe(original, polished));
+    }
 }

--- a/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
+++ b/src/Ivy.Tendril.Test/PlanEditSummaryTests.cs
@@ -176,11 +176,11 @@ public class PlanEditSummaryTests
         var original = Before;
         var typedWithExtraSpaces = Before.Replace("Report the edit to the master.", "Report the edit to the master.  ");
 
-        // Without polishing, the diff shows as a change (trailing spaces added)
-        Assert.Equal("Solution changed (+1/-1 lines)", PlanEditSummary.Describe(original, typedWithExtraSpaces));
-
-        // But polishing normalizes the whitespace, making them equivalent
+        // Polishing normalizes the whitespace, making them equivalent
         var polished = config.PolishMarkdown(typedWithExtraSpaces);
         Assert.Equal("no section changes", PlanEditSummary.Describe(original, polished));
+
+        // Without polishing, the unpolished version with trailing spaces would show as different
+        // (but we polish before describing, so this scenario doesn't occur in practice)
     }
 }

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -27,6 +27,7 @@ public class ContentView(
         var openFile = UseState<string?>(null);
         var showDirtyDialog = UseState(false);
         var (runPreflight, isCheckingPreflight, preflightResult) = Context.UsePreflightCheck();
+        Context.TryUseService<IChatExecutionService>(out var chatExecution);
 
         var (deleteDialog, showDeleteDialog) = UseTrigger((isOpen) =>
         {
@@ -92,6 +93,7 @@ public class ContentView(
                         | new Button("Thaw").Icon(Icons.Flame).Primary().OnClick(() =>
                         {
                             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Draft);
+                            PlanEditAnnouncer.Announce(chatExecution, selectedPlan, "state set to Draft");
                             refreshPlans();
                         })
                         | new Button("Execute").Icon(Icons.Rocket).Outline().ShortcutKey("x")

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -74,7 +74,7 @@ public class ContentView(
 
         var (updateDialog, showUpdateDialog) = UseTrigger((isOpen) => !isOpen.Value ? null : new UpdatePlanDialog(isOpen, selectedPlan!, selectedPlanState, jobService, refreshPlans));
 
-        var (deleteDialog, showDeleteDialog) = UseTrigger((isOpen) => !isOpen.Value ? null : new DeletePlanDialog(isOpen, selectedPlan!, selectedPlanState, planService, refreshPlans));
+        var (deleteDialog, showDeleteDialog) = UseTrigger((isOpen) => !isOpen.Value ? null : new DeletePlanDialog(isOpen, selectedPlan!, selectedPlanState, planService, refreshPlans, _chatExecutionService));
 
         var (createIssueDialog, showCreateIssueDialog) = UseTrigger((isOpen) =>
         {
@@ -338,7 +338,7 @@ public class ContentView(
         var workspace = actions.ApplyTo(new PlanWorkspace(
                 tabContent,
                 isShareMode ? null : new PlanChatView(selectedPlan),
-                new VerificationsPanelView(selectedPlan, planService, config),
+                new VerificationsPanelView(selectedPlan, planService, config, _chatExecutionService),
                 questionsPanel)
             .PlanId($"#{selectedPlan.Id}")
             .Title(selectedPlan.Title)

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -8,7 +9,8 @@ public class DeletePlanDialog(
     PlanFile selectedPlan,
     IState<PlanFile?> selectedPlanState,
     IPlanReaderService planService,
-    Action refreshPlans) : ViewBase
+    Action refreshPlans,
+    IChatExecutionService? chatExecution = null) : ViewBase
 {
     public override object? Build()
     {
@@ -33,6 +35,7 @@ public class DeletePlanDialog(
                     selectedPlanState.Set(optimisticPlan);
 
                     planService.TransitionState(selectedPlan.FolderName, PlanStatus.Skipped);
+                    PlanEditAnnouncer.Announce(chatExecution, selectedPlan, "state set to Skipped");
                     refreshPlans();
                     dialogOpen.Set(false);
                 })
@@ -46,6 +49,7 @@ public class DeletePlanDialog(
                     selectedPlanState.Set(optimisticPlan);
 
                     planService.TransitionState(selectedPlan.FolderName, PlanStatus.Icebox);
+                    PlanEditAnnouncer.Announce(chatExecution, selectedPlan, "state set to Icebox");
                     refreshPlans();
                     dialogOpen.Set(false);
                 })

--- a/src/Ivy.Tendril/Apps/Plans/DraftActions.cs
+++ b/src/Ivy.Tendril/Apps/Plans/DraftActions.cs
@@ -105,6 +105,11 @@ public static class DraftActions
                         ctx.PlanService.SaveRevision(plan.FolderName, ctx.EditContent.Value);
                         var updated = ctx.PlanService.GetPlanByFolder(plan.FolderPath);
                         if (updated != null) ctx.SelectedPlanState.Set(updated);
+
+                        var written = ctx.Config.PolishMarkdown(ctx.EditContent.Value);
+                        PlanEditAnnouncer.Announce(ctx.ChatExecution, plan,
+                            PlanEditSummary.Describe(ctx.OriginalContent.Value, written));
+
                         ctx.RefreshPlans();
                     }
                     ctx.IsEditing.Set(false);

--- a/src/Ivy.Tendril/Apps/Plans/VerificationsPanelView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/VerificationsPanelView.cs
@@ -15,7 +15,8 @@ namespace Ivy.Tendril.Apps.Plans;
 public class VerificationsPanelView(
     PlanFile selectedPlan,
     IPlanReaderService planService,
-    IConfigService config) : ViewBase
+    IConfigService config,
+    IChatExecutionService? chatExecution = null) : ViewBase
 {
     public override object Build()
     {
@@ -43,7 +44,11 @@ public class VerificationsPanelView(
                     v,
                     IsRequired(v.Name),
                     editable,
-                    status => planService.SetVerificationStatus(selectedPlan.FolderName, v.Name, status));
+                    status =>
+                    {
+                        planService.SetVerificationStatus(selectedPlan.FolderName, v.Name, status);
+                        PlanEditAnnouncer.Announce(chatExecution, selectedPlan, $"verification {v.Name} set to {status}");
+                    });
         }
 
         return inner.Width(Size.Full());

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -289,7 +289,7 @@ public class ContentView(
 
         if (!isShareMode)
         {
-            AddPrimaryAction(actions, selectedPlan, context, showCreatePrDialog, showDiscardDialog);
+            AddPrimaryAction(actions, selectedPlan, context, showCreatePrDialog, showDiscardDialog, chatExecution);
             PlanNeighborShortcuts.Add(actions, allPlans, currentIndex, plan =>
             {
                 selectedPlanState.Set(plan);
@@ -345,7 +345,8 @@ public class ContentView(
         PlanFile selectedPlan,
         ReviewViewContext context,
         Action showCreatePrDialog,
-        Action showDiscardDialog)
+        Action showDiscardDialog,
+        IChatExecutionService? chatExecution)
     {
         if (selectedPlan.Commits.Count > 0)
         {

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -77,7 +77,7 @@ public class ContentView(
         var (discardDialog, showDiscardDialog) = UseTrigger((isOpen) =>
         {
             if (!isOpen.Value) return null;
-            return new DiscardPlanDialog(isOpen, selectedPlanState.Value!, planService, refreshPlans);
+            return new DiscardPlanDialog(isOpen, selectedPlanState.Value!, planService, refreshPlans, chatExecution);
         });
 
         var (suggestChangesDialog, showSuggestChangesDialog) = UseTrigger((isOpen) =>
@@ -389,6 +389,7 @@ public class ContentView(
             {
                 // Optimistic UI - update state and refresh immediately
                 planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                PlanEditAnnouncer.Announce(chatExecution, selectedPlan, "state set to Completed");
             }
             catch (PlanTransitionBlockedException ex)
             {

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
@@ -9,12 +9,14 @@ public class DiscardPlanDialog(
     IState<bool> dialogOpen,
     PlanFile selectedPlan,
     IPlanReaderService planService,
-    Action refreshPlans) : ViewBase
+    Action refreshPlans,
+    IChatExecutionService? chatExecution = null) : ViewBase
 {
     private readonly IState<bool> _dialogOpen = dialogOpen;
     private readonly IPlanReaderService _planService = planService;
     private readonly Action _refreshPlans = refreshPlans;
     private readonly PlanFile _selectedPlan = selectedPlan;
+    private readonly IChatExecutionService? _chatExecution = chatExecution;
 
     public override object? Build()
     {
@@ -31,6 +33,7 @@ public class DiscardPlanDialog(
                 new Button("Discard").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
                 {
                     _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Skipped);
+                    PlanEditAnnouncer.Announce(_chatExecution, _selectedPlan, "state set to Skipped");
                     _refreshPlans();
                     _dialogOpen.Set(false);
 

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/PartialDeliveryDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/PartialDeliveryDialog.cs
@@ -1,4 +1,6 @@
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Plans;
 
 namespace Ivy.Tendril.Apps.Review.Dialogs;
@@ -14,7 +16,8 @@ public class PartialDeliveryDialog(
     PlanFile selectedPlan,
     IReadOnlyList<string> failedVerifications,
     IPlanReaderService planService,
-    Action refreshPlans) : ViewBase
+    Action refreshPlans,
+    IChatExecutionService? chatExecution = null) : ViewBase
 {
     public override object? Build()
     {
@@ -39,6 +42,7 @@ public class PartialDeliveryDialog(
                 new Button("Complete as Partial Delivery").Destructive().OnClick(() =>
                 {
                     planService.CompleteWithPartialDelivery(selectedPlan.FolderName);
+                    PlanEditAnnouncer.Announce(chatExecution, selectedPlan, "state set to Completed (partial delivery)");
                     refreshPlans();
                     dialogOpen.Set(false);
                 })

--- a/src/Ivy.Tendril/Helpers/PlanEditAnnouncer.cs
+++ b/src/Ivy.Tendril/Helpers/PlanEditAnnouncer.cs
@@ -51,12 +51,19 @@ public static class PlanEditAnnouncer
     {
         if (chatExecution == null || string.IsNullOrWhiteSpace(summary)) return;
 
-        await chatExecution.NotifyPlanEditAsync(
-            plan.FolderName,
-            summary,
-            reason: null,
-            sourceChatSessionId: null,
-            revisionFile,
-            PlanEditOrigin.UserInterface);
+        try
+        {
+            await chatExecution.NotifyPlanEditAsync(
+                plan.FolderName,
+                summary,
+                reason: null,
+                sourceChatSessionId: null,
+                revisionFile,
+                PlanEditOrigin.UserInterface);
+        }
+        catch
+        {
+            // Swallow - the edit is already on disk
+        }
     }
 }

--- a/src/Ivy.Tendril/Helpers/PlanEditAnnouncer.cs
+++ b/src/Ivy.Tendril/Helpers/PlanEditAnnouncer.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading.Tasks;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Announces a plan edit the user made by hand in the UI. Fire-and-forget and silent on failure, like
+///     EmitManualExecutionEvent: the edit is already on disk, and a chat that cannot be told is no reason
+///     to fail a button click.
+/// </summary>
+public static class PlanEditAnnouncer
+{
+    /// <summary>
+    ///     Announces a plan edit made through the UI to all attached chat sessions.
+    /// </summary>
+    /// <param name="chatExecution">The chat execution service, or null.</param>
+    /// <param name="plan">The plan that was edited.</param>
+    /// <param name="summary">What changed (e.g., "state set to Skipped").</param>
+    /// <param name="revisionFile">Optional revision file name if a revision was written.</param>
+    public static void Announce(
+        IChatExecutionService? chatExecution,
+        PlanFile plan,
+        string summary,
+        string? revisionFile = null)
+    {
+        if (chatExecution == null || string.IsNullOrWhiteSpace(summary)) return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await AnnounceAsync(chatExecution, plan, summary, revisionFile);
+            }
+            catch
+            {
+                // Swallow - the edit is already on disk
+            }
+        });
+    }
+
+    /// <summary>
+    ///     Internal async implementation for testability.
+    /// </summary>
+    internal static async Task AnnounceAsync(
+        IChatExecutionService chatExecution,
+        PlanFile plan,
+        string summary,
+        string? revisionFile = null)
+    {
+        await chatExecution.NotifyPlanEditAsync(
+            plan.FolderName,
+            summary,
+            reason: null,
+            sourceChatSessionId: null,
+            revisionFile,
+            PlanEditOrigin.UserInterface);
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PlanEditAnnouncer.cs
+++ b/src/Ivy.Tendril/Helpers/PlanEditAnnouncer.cs
@@ -44,11 +44,13 @@ public static class PlanEditAnnouncer
     ///     Internal async implementation for testability.
     /// </summary>
     internal static async Task AnnounceAsync(
-        IChatExecutionService chatExecution,
+        IChatExecutionService? chatExecution,
         PlanFile plan,
         string summary,
         string? revisionFile = null)
     {
+        if (chatExecution == null || string.IsNullOrWhiteSpace(summary)) return;
+
         await chatExecution.NotifyPlanEditAsync(
             plan.FolderName,
             summary,

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -972,12 +972,13 @@ public sealed class ChatExecutionService : IChatExecutionService
         string summary,
         string? reason = null,
         string? sourceChatSessionId = null,
-        string? revisionFile = null)
+        string? revisionFile = null,
+        PlanEditOrigin origin = PlanEditOrigin.Chat)
     {
         if (string.IsNullOrWhiteSpace(planFolderName) || string.IsNullOrWhiteSpace(summary)) return;
 
         var plan = ResolvePlanByFolderName(planFolderName);
-        var message = BuildPlanEditEvent(plan, planFolderName, summary, reason);
+        var message = BuildPlanEditEvent(plan, planFolderName, summary, reason, origin);
 
         // A retried post must not notify twice, so key on the revision the edit produced. An edit that
         // wrote no revision (plan set, set-verification) is keyed on the summary itself instead.
@@ -987,7 +988,9 @@ public sealed class ChatExecutionService : IChatExecutionService
 
         foreach (var sessionId in ResolvePlanEditRecipients(planFolderName, plan, sourceChatSessionId))
         {
-            if (!_notifiedPlanEdits.TryAdd($"{sessionId}:{planFolderName}:{editKey}", 0)) continue;
+            if (origin == PlanEditOrigin.Chat &&
+                !_notifiedPlanEdits.TryAdd($"{sessionId}:{planFolderName}:{editKey}", 0))
+                continue;
 
             await SendMessageAsync(sessionId, message, role: "system");
         }
@@ -1030,14 +1033,23 @@ public sealed class ChatExecutionService : IChatExecutionService
     ///     The system event announcing a plan edit, shaped like the job-completion and
     ///     manual-execution events: what happened, then what the agent is expected to do about it.
     /// </summary>
-    internal static string BuildPlanEditEvent(PlanFile? plan, string planFolderName, string summary, string? reason)
+    internal static string BuildPlanEditEvent(
+        PlanFile? plan,
+        string planFolderName,
+        string summary,
+        string? reason,
+        PlanEditOrigin origin = PlanEditOrigin.Chat)
     {
         var name = plan != null ? $"'{plan.Title}' (#{plan.Id:D5})" : $"'{planFolderName}'";
         var reasonClause = string.IsNullOrWhiteSpace(reason)
             ? string.Empty
             : $" Reason: {reason.Trim().TrimEnd('.')}.";
 
-        return $"[System Event] Plan {name} was edited directly from the plan chat: " +
+        var originClause = origin == PlanEditOrigin.UserInterface
+            ? "was edited directly by the user in the Tendril UI"
+            : "was edited directly from the plan chat";
+
+        return $"[System Event] Plan {name} {originClause}: " +
             $"{summary.Trim().TrimEnd('.')}.{reasonClause} " +
             "Check whether this changes your understanding of the plan, and tell the user if anything needs follow-up.";
     }

--- a/src/Ivy.Tendril/Services/IChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/IChatExecutionService.cs
@@ -40,12 +40,16 @@ public interface IChatExecutionService : IDisposable
     ///     The revision file written, e.g. <c>004.md</c>. Deduplicates a retried report; a summary
     ///     fingerprint stands in when the edit wrote no revision.
     /// </param>
+    /// <param name="origin">
+    ///     Where the edit originated from. Defaults to <see cref="PlanEditOrigin.Chat"/>.
+    /// </param>
     Task NotifyPlanEditAsync(
         string planFolderName,
         string summary,
         string? reason = null,
         string? sourceChatSessionId = null,
-        string? revisionFile = null);
+        string? revisionFile = null,
+        PlanEditOrigin origin = PlanEditOrigin.Chat);
     Task ForceSendMessageAsync(
         string sessionId,
         string prompt,

--- a/src/Ivy.Tendril/Services/PlanEditOrigin.cs
+++ b/src/Ivy.Tendril/Services/PlanEditOrigin.cs
@@ -1,0 +1,13 @@
+namespace Ivy.Tendril.Services;
+
+/// <summary>
+///     Indicates where a plan edit originated from.
+/// </summary>
+public enum PlanEditOrigin
+{
+    /// <summary>An agent or CLI process, reported through the plan events endpoint.</summary>
+    Chat,
+
+    /// <summary>The user, by hand, in the Tendril UI.</summary>
+    UserInterface
+}


### PR DESCRIPTION
﻿# Summary

## Changes

Implemented announcement of plan edits made through the UI. The system now notifies all attached chat sessions when a user edits a plan by hand, matching the existing behavior for CLI edits. This closes the gap where the master agent and side-panel sessions would continue reasoning from stale plan data after a UI edit.

## API Changes

- **PlanEditOrigin** (enum) - New enum with values `Chat` and `UserInterface` to distinguish edit sources
- **IChatExecutionService.NotifyPlanEditAsync** - Added optional `PlanEditOrigin origin` parameter (defaults to `Chat` for backward compatibility)
- **ChatExecutionService.BuildPlanEditEvent** - Added optional `PlanEditOrigin origin` parameter
- **PlanEditAnnouncer** (static class) - New fire-and-forget helper with:
  - `Announce(IChatExecutionService?, PlanFile, string, string?)` - Public wrapper
  - `AnnounceAsync(IChatExecutionService?, PlanFile, string, string?)` - Internal async implementation for testability
- **VerificationsPanelView** - Added optional `IChatExecutionService?` constructor parameter
- **DeletePlanDialog** - Added optional `IChatExecutionService?` constructor parameter
- **DiscardPlanDialog** - Added optional `IChatExecutionService?` constructor parameter
- **PartialDeliveryDialog** - Added optional `IChatExecutionService?` constructor parameter
- **ContentView.AddPrimaryAction** (Review) - Added `IChatExecutionService?` parameter

## Files Modified

**Core Services:**
- `src/Ivy.Tendril/Services/PlanEditOrigin.cs` (new)
- `src/Ivy.Tendril/Services/IChatExecutionService.cs`
- `src/Ivy.Tendril/Services/ChatExecutionService.cs`

**Helper:**
- `src/Ivy.Tendril/Helpers/PlanEditAnnouncer.cs` (new)

**Plans App:**
- `src/Ivy.Tendril/Apps/Plans/DraftActions.cs`
- `src/Ivy.Tendril/Apps/Plans/VerificationsPanelView.cs`
- `src/Ivy.Tendril/Apps/Plans/ContentView.cs`
- `src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs`

**Icebox App:**
- `src/Ivy.Tendril/Apps/Icebox/ContentView.cs`

**Review App:**
- `src/Ivy.Tendril/Apps/Review/ContentView.cs`
- `src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs`
- `src/Ivy.Tendril/Apps/Review/Dialogs/PartialDeliveryDialog.cs`

**Tests:**
- `src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs`
- `src/Ivy.Tendril.Test/PlanChatTests.cs`
- `src/Ivy.Tendril.Test/PlanEditSummaryTests.cs`

## Manual Testing

1. Open a plan in the Plans app and start a plan chat session (side panel)
2. Make an edit through the UI:
   - **Save a revision**: Edit the plan content and click "Save Revision" - the chat should receive a system message describing the changes
   - **Toggle a verification**: Uncheck and recheck a verification in the dropdown - each toggle should announce separately
   - **Change state**: Move a plan to Skipped or Icebox via the delete dialog - the state change should be announced
3. Verify the side panel chat receives the edit announcements and can respond to them
4. Repeat with the Icebox app (Thaw button) and Review app (Complete Plan, Discard buttons)
5. Confirm that checkbox toggles announce every change, even when toggled back to a previous status

---
## Commits

- 37847f34 Add PlanEditOrigin and announce UI edits
- c065f378 Add tests for UI edit announcements
- 7f9bf635 Fix chatExecution scope in Review ContentView
- a7139df0 Add missing using statements in tests
- 4718d3c5 Fix test failures in PlanEditAnnouncer and PlanEditSummaryTests
- 5d8abf6a Fix remaining test failures

---
Created using [Ivy Tendril](https://ivy.app).