### PR TITLE
[00423] Show Job Completion Time in the Jobs Table

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs
@@ -14,6 +14,7 @@ public class JobsTableColumnLabelTests
         { nameof(JobItemRow.Type), "Type" },
         { nameof(JobItemRow.Project), "Project" },
         { nameof(JobItemRow.Timer), "Timer" },
+        { nameof(JobItemRow.Timestamp), "Timestamp" },
         { nameof(JobItemRow.AgentOutput), "Agent Output" },
         { nameof(JobItemRow.LastOutputTimestamp), "Last Output Timestamp" },
         { nameof(JobItemRow.Cost), "Cost" },

--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableFilterTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableFilterTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -8,14 +9,15 @@ namespace Ivy.Tendril.Test.Apps.Jobs;
 
 public class JobsTableFilterTests
 {
-    private static JobItem MakeJob(string id, JobStatus status, DateTime? completedAt = null) => new()
+    private static JobItem MakeJob(string id, JobStatus status, DateTime? completedAt = null, DateTime? startedAt = null) => new()
     {
         Id = id,
         Type = "ExecutePlan",
         PlanFile = $"{id}-Plan",
         Project = "Test",
         Status = status,
-        CompletedAt = completedAt
+        CompletedAt = completedAt,
+        StartedAt = startedAt
     };
 
     [Fact]
@@ -91,6 +93,60 @@ public class JobsTableFilterTests
         var singleCompleted = Assert.Single(completedRows);
         Assert.Equal("Completed", singleCompleted.Status);
         Assert.Equal("job-4", singleCompleted.Id);
+    }
+
+    [Fact]
+    public void JobItemRow_Timestamp_RendersCompletionInstantInLocalTime()
+    {
+        var planService = new FakePlanReaderService();
+        var completedAt = new DateTime(2026, 9, 12, 12, 5, 0, DateTimeKind.Utc);
+        var jobs = new List<JobItem> { MakeJob("job-1", JobStatus.Completed, completedAt: completedAt) };
+
+        var rows = JobsApp.BuildJobRows(jobs, planService);
+
+        // Derived, never hardcoded: a literal "09-12 14:05" only holds in one time zone.
+        var expected = completedAt.ToLocalTime().ToString(JobsApp.TimestampFormat, CultureInfo.InvariantCulture);
+        Assert.Equal(expected, Assert.Single(rows).Timestamp);
+    }
+
+    [Fact]
+    public void JobItemRow_Timestamp_IsPlaceholderForRunningJob_EvenWhenStarted()
+    {
+        var planService = new FakePlanReaderService();
+        var jobs = new List<JobItem>
+        {
+            MakeJob("job-1", JobStatus.Running, startedAt: new DateTime(2026, 9, 12, 12, 5, 0, DateTimeKind.Utc))
+        };
+
+        var rows = JobsApp.BuildJobRows(jobs, planService);
+
+        // The column is a completion time only: StartedAt is deliberately not consulted.
+        Assert.Equal("-", Assert.Single(rows).Timestamp);
+    }
+
+    [Fact]
+    public void JobItemRow_Timestamp_IsPlaceholderWhenJobHasNeitherStamp()
+    {
+        var planService = new FakePlanReaderService();
+        var jobs = new List<JobItem> { MakeJob("job-1", JobStatus.Pending) };
+
+        var rows = JobsApp.BuildJobRows(jobs, planService);
+
+        Assert.Equal("-", Assert.Single(rows).Timestamp);
+    }
+
+    [Fact]
+    public void BuildDataTableUpdates_DoesNotStreamTheTimestampCell()
+    {
+        var jobService = new FilterTestFakeJobService();
+        jobService.Jobs.Add(MakeJob("job-running", JobStatus.Running));
+
+        var updates = JobsApp.BuildDataTableUpdates(jobService, new Dictionary<string, string>()).ToList();
+
+        // The value only changes on a terminal transition, which already forces a full rebuild through
+        // BuildJobRows. A seventh cell here would be dead weight.
+        Assert.NotEmpty(updates);
+        Assert.DoesNotContain(updates, u => u.ColumnName == nameof(JobItemRow.Timestamp));
     }
 
     private class FilterTestFakeJobService : IJobService

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -27,6 +27,7 @@ public partial class JobsApp
                 Type = j.Type,
                 Project = string.Join(", ", ProjectHelper.ParseProjects(j.Project)),
                 Timer = JobsApp.FormatTimer(j),
+                Timestamp = JobsApp.FormatTimestamp(j),
                 Cost = FormatJobCost(j),
                 Tokens = j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : "",
                 AgentOutput = JobsApp.FormatAgentOutput(j),

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -72,6 +72,7 @@ public partial class JobsApp
             .Width(t => t.Prompt, Size.Px(250))
             .Width(t => t.Project, Size.Px(150))
             .Width(t => t.Timer, Size.Px(80))
+            .Width(t => t.Timestamp, Size.Px(110))
             .Width(t => t.AgentOutput, Size.Px(100))
             .Width(t => t.Cost, Size.Px(80))
             .Width(t => t.Tokens, Size.Px(80))

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Models;
 
@@ -90,6 +91,25 @@ public partial class JobsApp
 
         return "-";
     }
+
+    /// <summary>
+    ///     The Timestamp cell: when the job finished, as a clock rather than the duration
+    ///     <see cref="FormatTimer" /> reports. <see cref="JobItem.CompletedAt" /> is stamped only on a
+    ///     terminal transition and is UTC, so it is converted to the viewer's local time; a job that has
+    ///     not finished has nothing to show and gets "-", the same placeholder the Timer column uses.
+    /// </summary>
+    internal static string FormatTimestamp(JobItem job)
+    {
+        if (job.CompletedAt is not { } completedAt) return "-";
+
+        return completedAt.ToLocalTime().ToString(TimestampFormat, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    ///     One shape for every row, and it sorts correctly as a string within a calendar year, which
+    ///     outlives the 100 job window restored from SQLite on startup.
+    /// </summary>
+    internal const string TimestampFormat = "MM-dd HH:mm";
 
     private static string FormatTimeSpan(TimeSpan span)
     {

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -359,6 +359,11 @@ public record JobItemRow
     public string Type { get; init; } = "";
     public string Project { get; init; } = "";
     public string Timer { get; init; } = "";
+    /// <summary>
+    /// When the job finished, in the viewer's local time. Empty of meaning for a job that has not
+    /// reached a terminal status, which renders "-"; the Timer column beside it carries the duration.
+    /// </summary>
+    public string Timestamp { get; init; } = "";
     public string AgentOutput { get; init; } = "";
     public DateTime? LastOutputTimestamp { get; init; }
     public string Cost { get; init; } = "";


### PR DESCRIPTION
﻿# Summary

## Changes

Added a visible `Timestamp` column to the Jobs table, showing when each job finished. It reads
`JobItem.CompletedAt` (stamped UTC on every terminal transition), converts to the viewer's local time and
formats as `MM-dd HH:mm`; a job that has not finished renders `-`. It sits directly after `Timer`, which
reports how long a job took rather than when it ended, so the two read together. The live cell-update
stream is deliberately left at its existing six cells, since the value only changes on the same terminal
transition that already forces a full table rebuild.

## API Changes

- `Ivy.Tendril.Models.JobItemRow` gains `public string Timestamp { get; init; }`, positioned after
  `Timer` (position in the record is what sets column order).
- `Ivy.Tendril.Apps.Jobs.JobsApp` gains `internal static string FormatTimestamp(JobItem job)` and
  `internal const string TimestampFormat = "MM-dd HH:mm"`.

No public API, no config key, no CLI command, no `plan.yaml` field changed, so no schema migration is
involved.

## Files Modified

**Jobs app (production)**

- [JobModels.cs](file:///C:/Users/pavel/git/ivy-tendril/src/Ivy.Tendril/Models/JobModels.cs) - the
  `Timestamp` row property.
- [JobsApp.Helpers.cs](file:///C:/Users/pavel/git/ivy-tendril/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs) -
  `FormatTimestamp` and the shared format constant, beside `FormatTimer`.
- [JobsApp.Data.cs](file:///C:/Users/pavel/git/ivy-tendril/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs) - the
  row-builder assignment. `BuildDataTableUpdates` in the same file is unchanged.
- [JobsApp.DataTable.cs](file:///C:/Users/pavel/git/ivy-tendril/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs) -
  a 110px width. Nothing else: a column is visible unless `.Hidden(...)` is called, and filtering is on
  for the whole table.

**Tests**

- [JobsTableFilterTests.cs](file:///C:/Users/pavel/git/ivy-tendril/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableFilterTests.cs) -
  four new facts: a completed job renders its `CompletedAt` in local time (expectation derived, so it
  holds in any time zone), a running job with `StartedAt` still renders `-`, a job with neither stamp
  renders `-`, and `BuildDataTableUpdates` emits no `Timestamp` cell.
- [JobsTableColumnLabelTests.cs](file:///C:/Users/pavel/git/ivy-tendril/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs) -
  the required `ExpectedLabels` entry, without which `ExpectedLabelsCoverEveryProperty` fails.

## Manual Testing

1. Run the app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`.
2. Open the **Jobs** app. A new **Timestamp** column appears between **Timer** and **Agent Output**.
3. On rows for finished jobs (Completed, Failed, Timeout, Stopped), it shows the completion time as
   `09-12 14:05` in your own time zone, not UTC. Cross-check one against the same job's log file in
   `$TENDRIL_HOME/Jobs/` -- the completion time there is UTC, so the column should read that instant
   shifted by your offset.
4. Rows for Running, Queued, Pending and Blocked jobs show `-`. Start a job and watch it: the cell stays
   `-` for the whole run and fills in when the job reaches a terminal status (within the 5s refresh).
5. Type into the filter box under the **Timestamp** header, e.g. `09-12`, and only that day's rows remain.
   The header text is the filter token, which is the invariant plan 00100 protects.
6. The default sort is unchanged: Id descending, newest first.

---
## Commits

- `40559439` Show job completion time in the Jobs table (plan 00423)
- `6fc61493` Cover the Jobs table Timestamp column (plan 00423)

---
Created using [Ivy Tendril](https://ivy.app).