### PR TITLE
[00408] Stop the Workspace Freezing on Bursts of Plan Closes and Job Exits

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/JobLogPathsTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/JobLogPathsTests.cs
@@ -195,4 +195,44 @@ public class JobLogPathsTests : IDisposable
 
         Assert.Equal(["00010-00044-ExpandPlan.md", "00011-00044-ExecutePlan.md"], found);
     }
+
+    [Fact]
+    public void LogsByPlanId_GroupsWhatLogsForPlanIdReturnsPerPlan()
+    {
+        var jobs = JobLogPaths.EnsureJobsDir(_tendrilHome);
+        foreach (var name in new[]
+                 {
+                     "00011-00044-ExecutePlan.md", "00010-00044-ExpandPlan.md",
+                     "00011-00044-ExecutePlan.prompt.md", "00012-00099-ExecutePlan.md",
+                     "00013-00044-ExecutePlan.raw.jsonl"
+                 })
+            File.WriteAllText(Path.Combine(jobs, name), "x");
+
+        var grouped = JobLogPaths.LogsByPlanId(_tendrilHome);
+
+        Assert.Equal(["00044", "00099"], grouped.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray());
+        Assert.Equal(JobLogPaths.LogsForPlanId(_tendrilHome, "00044"), grouped["00044"]);
+        Assert.Equal(JobLogPaths.LogsForPlanId(_tendrilHome, "00099"), grouped["00099"]);
+
+        // Oldest job id first — the cost sync pairs the rows of costs.csv with this order.
+        Assert.Equal(["00010-00044-ExpandPlan.md", "00011-00044-ExecutePlan.md"],
+            grouped["00044"].Select(f => Path.GetFileName(f)!).ToArray());
+    }
+
+    [Fact]
+    public void LogsByPlanId_LogWithNoPlanIdSegment_LandsInNoGroup()
+    {
+        var jobs = JobLogPaths.EnsureJobsDir(_tendrilHome);
+        // The shape a CreatePlan job writes, plus a middle segment that is not a plan id.
+        File.WriteAllText(Path.Combine(jobs, "00013-CreatePlan.md"), "x");
+        File.WriteAllText(Path.Combine(jobs, "00014-notaplan-ExecutePlan.md"), "x");
+
+        Assert.Empty(JobLogPaths.LogsByPlanId(_tendrilHome));
+    }
+
+    [Fact]
+    public void LogsByPlanId_MissingJobsDir_ReturnsEmpty()
+    {
+        Assert.Empty(JobLogPaths.LogsByPlanId(_tendrilHome));
+    }
 }

--- a/src/Ivy.Tendril.Test/AppShell/AppShellNotificationTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/AppShellNotificationTests.cs
@@ -1,3 +1,5 @@
+using Ivy.Tendril.AppShell;
+using Microsoft.Reactive.Testing;
 using static Ivy.Tendril.AppShell.TendrilAppShell;
 
 namespace Ivy.Tendril.Test.AppShell;
@@ -30,5 +32,124 @@ public class AppShellNotificationTests
     {
         // The setting only governs the native path; it must not disable the web toast.
         Assert.True(ShouldShowInAppToast(isDesktop: false, desktopNotificationsEnabled: false));
+    }
+
+    private static JobNotification Finished(string plan) =>
+        new("ExecutePlan Completed", plan, true);
+
+    private static JobNotification Failed(string plan) =>
+        new("ExecutePlan Failed", $"{plan}: verification failed", false);
+
+    [Fact]
+    public void Summarize_FewNotifications_AreShownAsTheyArrived()
+    {
+        var batch = new List<JobNotification> { Finished("00001-A"), Failed("00002-B"), Finished("00003-C") };
+
+        Assert.Equal(batch, NotificationBurstSummarizer.Summarize(batch));
+    }
+
+    [Fact]
+    public void Summarize_BurstOfCompletions_CollapsesToOneToast()
+    {
+        var batch = Enumerable.Range(1, 5).Select(i => Finished($"0000{i}-Plan")).ToList();
+
+        var summarized = NotificationBurstSummarizer.Summarize(batch);
+
+        var summary = Assert.Single(summarized);
+        Assert.Equal(NotificationBurstSummarizer.SummaryTitle, summary.Title);
+        Assert.Equal("5 jobs finished", summary.Message);
+        Assert.True(summary.IsSuccess);
+    }
+
+    [Fact]
+    public void Summarize_BurstWithAFailure_KeepsTheFailureVisible()
+    {
+        var batch = Enumerable.Range(1, 6).Select(i => Finished($"0000{i}-Plan")).ToList();
+        batch.Add(Failed("00007-Broken"));
+
+        var summarized = NotificationBurstSummarizer.Summarize(batch);
+
+        Assert.Equal(2, summarized.Count);
+        Assert.Equal("6 jobs finished, 1 failed", summarized[0].Message);
+        // The failure keeps its own toast: which plan failed, and why, is what the user acts on.
+        Assert.Equal("00007-Broken: verification failed", summarized[1].Message);
+        Assert.False(summarized[1].IsSuccess);
+    }
+
+    [Fact]
+    public void Summarize_BurstOfFailures_AddsNoSummary()
+    {
+        var batch = Enumerable.Range(1, 4).Select(i => Failed($"0000{i}-Plan")).ToList();
+
+        var summarized = NotificationBurstSummarizer.Summarize(batch);
+
+        Assert.Equal(batch, summarized);
+    }
+
+    [Fact]
+    public void Summarize_SingleCompletionAmongFailures_ReadsAsOneJob()
+    {
+        var batch = new List<JobNotification>
+        {
+            Failed("00001-A"), Failed("00002-B"), Failed("00003-C"), Finished("00004-D")
+        };
+
+        var summarized = NotificationBurstSummarizer.Summarize(batch);
+
+        Assert.Equal("1 job finished, 3 failed", summarized[0].Message);
+    }
+
+    [Fact]
+    public void Summarizer_BurstWithinTheWindow_ShowsOneToast()
+    {
+        var scheduler = new TestScheduler();
+        var shown = new List<JobNotification>();
+        var window = TimeSpan.FromMilliseconds(300);
+        using var summarizer = new NotificationBurstSummarizer(shown.Add, window, scheduler);
+
+        for (var i = 1; i <= 5; i++)
+            summarizer.Add(Finished($"0000{i}-Plan"));
+
+        // Nothing until the window closes: the burst is what is being waited for.
+        Assert.Empty(shown);
+
+        scheduler.AdvanceBy(window.Ticks);
+
+        var summary = Assert.Single(shown);
+        Assert.Equal("5 jobs finished", summary.Message);
+    }
+
+    [Fact]
+    public void Summarizer_ALaterBurst_IsSummarizedOnItsOwn()
+    {
+        var scheduler = new TestScheduler();
+        var shown = new List<JobNotification>();
+        var window = TimeSpan.FromMilliseconds(300);
+        using var summarizer = new NotificationBurstSummarizer(shown.Add, window, scheduler);
+
+        for (var i = 1; i <= 4; i++)
+            summarizer.Add(Finished($"0000{i}-Plan"));
+        scheduler.AdvanceBy(window.Ticks);
+
+        for (var i = 5; i <= 9; i++)
+            summarizer.Add(Finished($"0000{i}-Plan"));
+        scheduler.AdvanceBy(window.Ticks);
+
+        Assert.Equal(["4 jobs finished", "5 jobs finished"], shown.Select(n => n.Message));
+    }
+
+    [Fact]
+    public void Summarizer_SingleNotification_IsShownUnchanged()
+    {
+        var scheduler = new TestScheduler();
+        var shown = new List<JobNotification>();
+        var window = TimeSpan.FromMilliseconds(300);
+        using var summarizer = new NotificationBurstSummarizer(shown.Add, window, scheduler);
+
+        summarizer.Add(Failed("00001-Broken"));
+        scheduler.AdvanceBy(window.Ticks);
+
+        var only = Assert.Single(shown);
+        Assert.Equal("00001-Broken: verification failed", only.Message);
     }
 }

--- a/src/Ivy.Tendril.Test/Apps/ReviewContentViewRefreshTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/ReviewContentViewRefreshTests.cs
@@ -1,0 +1,60 @@
+using ReviewContentView = Ivy.Tendril.Apps.Review.ContentView;
+
+namespace Ivy.Tendril.Test.Apps;
+
+/// <summary>
+///     The Review content view rebuilt itself for every <c>PlansChanged</c>, whichever plan it named. A
+///     rebuild shells out to git and evaluates the project's review-action conditions in PowerShell, so a
+///     burst of plan closes meant one of those per close for a plan nobody was looking at (#2571).
+/// </summary>
+public class ReviewContentViewRefreshTests
+{
+    [Fact]
+    public void ShouldRefreshFor_UnrelatedFolder_IsIgnored()
+    {
+        Assert.False(ReviewContentView.ShouldRefreshFor("00408-StopTheFreezing", "00420-SomethingElse"));
+        Assert.False(ReviewContentView.ShouldRefreshFor(
+            @"D:\.tendril\Plans\00408-StopTheFreezing", "00420-SomethingElse"));
+    }
+
+    [Fact]
+    public void ShouldRefreshFor_NullFolder_Refreshes()
+    {
+        // A null folder is a full rescan: anything may have changed, including the selected plan.
+        Assert.True(ReviewContentView.ShouldRefreshFor(null, "00420-SomethingElse"));
+        Assert.True(ReviewContentView.ShouldRefreshFor("", "00420-SomethingElse"));
+    }
+
+    [Fact]
+    public void ShouldRefreshFor_NothingSelected_Refreshes()
+    {
+        Assert.True(ReviewContentView.ShouldRefreshFor("00408-StopTheFreezing", null));
+        Assert.True(ReviewContentView.ShouldRefreshFor("00408-StopTheFreezing", ""));
+    }
+
+    [Fact]
+    public void ShouldRefreshFor_SelectedFolder_Refreshes()
+    {
+        Assert.True(ReviewContentView.ShouldRefreshFor("00408-StopTheFreezing", "00408-StopTheFreezing"));
+    }
+
+    [Fact]
+    public void ShouldRefreshFor_ComparesTheLastSegmentOnly()
+    {
+        // The watcher raises a full path; NotifyChanged callers raise a bare folder name. Both name the
+        // same plan and both have to match the selected plan's folder name.
+        Assert.True(ReviewContentView.ShouldRefreshFor(
+            @"D:\.tendril\Plans\00408-StopTheFreezing", "00408-StopTheFreezing"));
+        Assert.True(ReviewContentView.ShouldRefreshFor(
+            "D:/.tendril/Plans/00408-StopTheFreezing/", "00408-StopTheFreezing"));
+        Assert.True(ReviewContentView.ShouldRefreshFor(
+            @"D:\.tendril\Plans\00408-StopTheFreezing", @"C:\somewhere\else\00408-StopTheFreezing"));
+    }
+
+    [Fact]
+    public void ShouldRefreshFor_IsCaseInsensitive()
+    {
+        // Folder names round-trip through paths the user may have typed with any casing.
+        Assert.True(ReviewContentView.ShouldRefreshFor("00408-stopthefreezing", "00408-StopTheFreezing"));
+    }
+}

--- a/src/Ivy.Tendril.Test/FakePlanReaderService.cs
+++ b/src/Ivy.Tendril.Test/FakePlanReaderService.cs
@@ -162,9 +162,16 @@ internal class FakePlanReaderService : IPlanReaderService
     {
     }
 
+    /// <summary>
+    ///     What <see cref="FlushPendingWritesAsync" /> hands back. A test that needs a write queue which
+    ///     never drains — a queued write parked on the cross-process plan lock — sets a task that never
+    ///     completes.
+    /// </summary>
+    public Task FlushTask { get; set; } = Task.CompletedTask;
+
     public Task FlushPendingWritesAsync()
     {
-        return Task.CompletedTask;
+        return FlushTask;
     }
 
     public List<RecommendationYaml> GetRecommendationsForPlan(string folderName)

--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -1,8 +1,10 @@
 using System.Reactive.Linq;
 using Ivy.Core.Hooks;
 using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Microsoft.Reactive.Testing;
 
 namespace Ivy.Tendril.Test;
 
@@ -155,36 +157,92 @@ public class JobsAppRefreshGatingTests
     [Fact]
     public void JobChangeHookDisposable_SubscribesOnlyToJobsStructureChanged()
     {
+        var scheduler = new TestScheduler();
         var jobService = new FakeJobService();
         var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, JobsApp.JobRefreshWindow, scheduler);
 
-        using var hook = JobsApp.JobChangeHookDisposable(jobService, token);
+        using var hook = JobsApp.JobChangeHookDisposable(jobService, coalescer);
 
         // JobPropertyChanged should not trigger a refresh
         jobService.FireJobPropertyChanged();
+        scheduler.AdvanceBy(JobsApp.JobRefreshWindow.Ticks);
         Assert.Equal(0, refreshCount());
 
         // JobsStructureChanged should trigger a refresh
         jobService.FireJobsStructureChanged();
+        scheduler.AdvanceBy(JobsApp.JobRefreshWindow.Ticks);
         Assert.Equal(1, refreshCount());
 
-        // Multiple structure changes trigger multiple refreshes
+        // Structure changes in a later window refresh again
         jobService.FireJobsStructureChanged();
+        scheduler.AdvanceBy(JobsApp.JobRefreshWindow.Ticks);
         Assert.Equal(2, refreshCount());
     }
 
     [Fact]
     public void JobChangeHookDisposable_Dispose_UnhooksJobsStructureChanged()
     {
+        var scheduler = new TestScheduler();
         var jobService = new FakeJobService();
         var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, JobsApp.JobRefreshWindow, scheduler);
 
-        var hook = JobsApp.JobChangeHookDisposable(jobService, token);
+        var hook = JobsApp.JobChangeHookDisposable(jobService, coalescer);
         jobService.FireJobsStructureChanged();
+        scheduler.AdvanceBy(JobsApp.JobRefreshWindow.Ticks);
         Assert.Equal(1, refreshCount());
 
         hook.Dispose();
         jobService.FireJobsStructureChanged();
+        scheduler.AdvanceBy(JobsApp.JobRefreshWindow.Ticks);
+        Assert.Equal(1, refreshCount());
+    }
+
+    [Fact]
+    public void JobChangeHookDisposable_UnchangedSignature_DoesNotRefresh()
+    {
+        var scheduler = new TestScheduler();
+        var jobService = new FakeJobService();
+        jobService.Jobs.Add(MakeJob("job-1", JobStatus.Running));
+        var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, JobsApp.JobRefreshWindow, scheduler);
+
+        // What the view has on screen already matches the job list.
+        var rendered = JobsApp.ComputeStructuralSignature(jobService.GetJobs());
+        using var hook = JobsApp.JobChangeHookDisposable(jobService, coalescer, () => rendered);
+
+        // JobsStructureChanged also fires for changes the table does not show (a cost or token update
+        // lands through the cell update stream instead), and those must not rebuild the view.
+        jobService.Jobs[0].Cost = 1.23m;
+        jobService.FireJobsStructureChanged();
+        scheduler.AdvanceBy(JobsApp.JobRefreshWindow.Ticks);
+
+        Assert.Equal(0, refreshCount());
+    }
+
+    [Fact]
+    public void JobChangeHookDisposable_BurstOfStructuralChanges_RefreshesOnce()
+    {
+        var scheduler = new TestScheduler();
+        var jobService = new FakeJobService();
+        var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, JobsApp.JobRefreshWindow, scheduler);
+
+        var rendered = JobsApp.ComputeStructuralSignature(jobService.GetJobs());
+        using var hook = JobsApp.JobChangeHookDisposable(jobService, coalescer, () => rendered);
+
+        // Ten jobs exiting at once: ten events, one rebuild. This is the fan-out that froze the
+        // workspace when every event rebuilt the table (#2571).
+        for (var i = 0; i < 10; i++)
+        {
+            jobService.Jobs.Add(MakeJob($"job-{i}", JobStatus.Completed, DateTime.UtcNow));
+            jobService.FireJobsStructureChanged();
+            scheduler.AdvanceBy(TimeSpan.FromMilliseconds(10).Ticks);
+        }
+
+        scheduler.AdvanceBy(JobsApp.JobRefreshWindow.Ticks);
+
         Assert.Equal(1, refreshCount());
     }
 

--- a/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Jobs;
@@ -371,5 +373,170 @@ public class PlanDatabaseSyncServiceTests : IDisposable
         var rows = ReadCostRows(1800);
         Assert.Single(rows);
         Assert.Null(rows[0].Agent);
+    }
+
+    private const string DraftYaml =
+        "state: Draft\nproject: Tendril\ntitle: Test Plan\nlevel: NiceToHave\nrepos: []\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n";
+
+    /// <summary>
+    ///     The behaviour #2571 was about: closing a dozen plans in a row raises a dozen change events,
+    ///     and they must not turn into a dozen full rescans. The events are raised straight at
+    ///     <see cref="PlanDatabaseSyncService.OnPlansChanged" /> rather than through
+    ///     <see cref="PlanWatcherService.NotifyChanged" />, whose own debounce would hide the coalescing
+    ///     being asserted here.
+    /// </summary>
+    [Fact]
+    public async Task OnPlansChanged_BurstOfFullRescans_CostsAtMostTwoSyncs()
+    {
+        CreatePlan("01500-TestPlan", DraftYaml, "# Test");
+        _syncService.PerformInitialSync();
+
+        for (var i = 0; i < 20; i++)
+            _syncService.OnPlansChanged(null);
+
+        await _syncService.DrainAsync();
+
+        // One for the pass in flight, at most one more for everything that arrived while it ran.
+        Assert.InRange(_syncService.SyncCount, 1, 2);
+    }
+
+    /// <summary>
+    ///     The freeze itself: <c>PlansChanged</c> is raised from the watcher's timers and from every plan
+    ///     mutation, so a rescan running inline would block whichever thread closed the plan.
+    /// </summary>
+    [Fact]
+    public async Task OnPlansChanged_DoesNotSyncOnTheRaisingThread()
+    {
+        CreatePlan("01500-TestPlan", DraftYaml, "# Test");
+        _syncService.PerformInitialSync();
+
+        var raisingThreadId = Environment.CurrentManagedThreadId;
+        _syncService.OnPlansChanged(null);
+        await _syncService.DrainAsync();
+
+        Assert.NotEqual(0, _syncService.LastSyncThreadId);
+        Assert.NotEqual(raisingThreadId, _syncService.LastSyncThreadId);
+    }
+
+    [Fact]
+    public void TakeWork_FullRescanRequest_SupersedesPendingFolders()
+    {
+        CreatePlan("01500-TestPlan", DraftYaml, "# Test");
+        var folder = Path.Combine(_planReader.PlansDirectory, "01500-TestPlan");
+
+        // RecordPending rather than OnPlansChanged: queuing without waking the worker is what makes the
+        // coalesced state observable from the test thread.
+        _syncService.RecordPending(folder);
+        _syncService.RecordPending(null);
+
+        var (fullRescan, folders) = _syncService.TakeWork();
+
+        Assert.True(fullRescan);
+        Assert.Empty(folders);
+
+        // And the superseded folder is gone rather than queued behind the rescan that covers it.
+        Assert.False(_syncService.TakeWork().FullRescan);
+        Assert.Empty(_syncService.TakeWork().Folders);
+    }
+
+    [Fact]
+    public void TakeWork_DistinctFolders_AreKeptSeparate()
+    {
+        CreatePlan("01500-TestPlan", DraftYaml, "# Test");
+        CreatePlan("01501-OtherPlan", DraftYaml, "# Other");
+        var first = Path.Combine(_planReader.PlansDirectory, "01500-TestPlan");
+        var second = Path.Combine(_planReader.PlansDirectory, "01501-OtherPlan");
+
+        _syncService.RecordPending(first);
+        _syncService.RecordPending(second);
+        _syncService.RecordPending(first);
+
+        var (fullRescan, folders) = _syncService.TakeWork();
+
+        Assert.False(fullRescan);
+        Assert.Equal(2, folders.Count);
+        Assert.Contains(first, folders);
+        Assert.Contains(second, folders);
+    }
+
+    [Fact]
+    public void Dispose_WithSyncInFlight_ReturnsWithinTheShutdownBudget()
+    {
+        for (var i = 0; i < 40; i++)
+            CreatePlan($"0{1500 + i}-TestPlan", DraftYaml, "# Test");
+        _syncService.PerformInitialSync();
+
+        for (var i = 0; i < 10; i++)
+            _syncService.OnPlansChanged(null);
+
+        var stopwatch = Stopwatch.StartNew();
+        _syncService.Dispose();
+        stopwatch.Stop();
+
+        // Bounded at 5s inside Dispose; the slack covers a slow CI disk finishing the pass in flight.
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(20),
+            $"Dispose took {stopwatch.Elapsed.TotalSeconds:F1}s");
+
+        // Idempotent: the fixture disposes it again.
+        _syncService.Dispose();
+    }
+
+    /// <summary>
+    ///     Guards the change-2 refactor: a rescan now enumerates the Jobs directory once and hands the
+    ///     grouped result to every plan, where it used to glob per plan. Both paths must produce the same
+    ///     rows, log timestamps included — those are the only part of a cost row the lookup feeds.
+    /// </summary>
+    [Fact]
+    public async Task SinglePlanSync_AndFullRescan_ProduceTheSameCostRows()
+    {
+        CreateCostPlan("01500-CostPlan",
+            "Promptware,Tokens,Cost,Model,CostSource,Agent\nExecutePlan,50000,1.5000,claude-opus-5,agent,claude\nCreatePr,10000,0.3000,claude-opus-5,agent,claude\n");
+        var jobsDir = JobLogPaths.EnsureJobsDir(_tempDir.Path);
+        File.WriteAllText(Path.Combine(jobsDir, "00001-01500-ExecutePlan.md"),
+            "# Job\n**Completed:** 2026-01-02T03:04:05Z\n");
+        File.WriteAllText(Path.Combine(jobsDir, "00002-01500-CreatePr.md"),
+            "# Job\n**Completed:** 2026-01-03T04:05:06Z\n");
+        // Neither of these belongs to the plan's cost rows: a prompt is not a log, and a CreatePlan log
+        // carries no plan-id segment.
+        File.WriteAllText(Path.Combine(jobsDir, "00003-01500-ExecutePlan.prompt.md"), "prompt");
+        File.WriteAllText(Path.Combine(jobsDir, "00004-CreatePlan.md"), "**Completed:** 2026-01-04T00:00:00Z\n");
+
+        // The lookup path: PerformInitialSync goes through SyncPlanDetails.
+        _syncService.PerformInitialSync();
+        var fromRescan = ReadCostRowsWithTimestamps(1500);
+
+        // The per-plan glob path: a single-folder sync passes no lookup.
+        _syncService.OnPlansChanged(Path.Combine(_planReader.PlansDirectory, "01500-CostPlan"));
+        await _syncService.DrainAsync();
+        var fromSingleSync = ReadCostRowsWithTimestamps(1500);
+
+        Assert.Equal(2, fromRescan.Count);
+        Assert.StartsWith("2026-01-02T03:04:05", fromRescan[0].LogTimestamp);
+        Assert.StartsWith("2026-01-03T04:05:06", fromRescan[1].LogTimestamp);
+        Assert.Equal(fromRescan, fromSingleSync);
+    }
+
+    /// <summary>
+    ///     Cost rows including the log timestamp, which is the part of a row the log lookup feeds. Read as
+    ///     the stored text rather than through <c>GetDateTime</c>, which would shift a UTC value into
+    ///     local time and make the expectations machine dependent.
+    /// </summary>
+    private List<(string Promptware, int Tokens, decimal? Cost, string? LogTimestamp)> ReadCostRowsWithTimestamps(int planId)
+    {
+        using var connection = new SqliteConnection($"Data Source={_dbPath}");
+        connection.Open();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT Promptware, Tokens, Cost, LogTimestamp FROM Costs WHERE PlanId = @p ORDER BY Id";
+        cmd.Parameters.AddWithValue("@p", planId);
+
+        var rows = new List<(string, int, decimal?, string?)>();
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            rows.Add((
+                reader.GetString(0),
+                reader.GetInt32(1),
+                reader.IsDBNull(2) ? null : reader.GetDecimal(2),
+                reader.IsDBNull(3) ? null : reader.GetString(3)));
+        return rows;
     }
 }

--- a/src/Ivy.Tendril.Test/PlanWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanWatcherServiceTests.cs
@@ -56,7 +56,10 @@ public class PlanWatcherServiceTests : IDisposable
     [Fact]
     public void SelfHeal_ReRaisesPlansChanged_AfterLateArrivingContent()
     {
-        using var watcher = new PlanWatcherService(_configService, null, new[] { 50, 150, 300 });
+        // Both delays fall inside the 500ms debounce window, so the whole ladder coalesces — that is
+        // the point of routing self-heal through ScheduleDebounce (#2571). What still has to hold is
+        // that a rescan lands after the content did.
+        using var watcher = new PlanWatcherService(_configService, null, new[] { 50, 150 });
 
         var changeCount = 0;
         var changesAfterContent = 0;
@@ -78,14 +81,62 @@ public class PlanWatcherServiceTests : IDisposable
         WritePlanContent(planDir);
         contentWritten.Set();
 
-        // The staggered self-heal burst must re-raise PlansChanged multiple times, with at least
-        // one rescan after the content landed. Poll for both outcomes rather than sampling at a
-        // single instant — under load the burst's timer callbacks arrive with arbitrary spacing.
+        // Poll rather than sampling at a single instant: under load the timer callbacks arrive with
+        // arbitrary spacing.
         Assert.True(
-            RetryHelper.WaitUntil(
-                () => Volatile.Read(ref changeCount) > 1 && Volatile.Read(ref changesAfterContent) >= 1,
-                TimeSpan.FromSeconds(15)),
-            "Expected multiple self-heal PlansChanged, including at least one after late-arriving content");
+            RetryHelper.WaitUntil(() => Volatile.Read(ref changesAfterContent) >= 1, TimeSpan.FromSeconds(15)),
+            "Expected a self-heal PlansChanged after late-arriving content");
+
+        // Let anything still queued arrive, then hold the ceiling: the ladder is no longer one
+        // uncoalesced fire per timer. Two delays inside one debounce window plus the folder event's
+        // own debounce cannot exceed the ladder length + 1.
+        Thread.Sleep(1000);
+        Assert.InRange(Volatile.Read(ref changeCount), 1, 3);
+    }
+
+    /// <summary>
+    ///     Two plan folders changing at the same moment — a burst of plan closes, or a job finishing while
+    ///     the user closes something else. The escalation to a full rescan is a read-modify-write of
+    ///     <c>_pendingPlanFolder</c>, so without a lock both callers could see it empty, each store their
+    ///     own folder, and the loser's plan would never be re-read. Repeated because it is a race.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentNotifyChanged_ForDifferentFolders_EscalatesToOneFullRescan()
+    {
+        using var watcher = new PlanWatcherService(_configService, null, Array.Empty<int>());
+        var fired = new List<string?>();
+        watcher.PlansChanged += folder =>
+        {
+            lock (fired) fired.Add(folder);
+        };
+
+        for (var round = 0; round < 10; round++)
+        {
+            lock (fired) fired.Clear();
+
+            using var gate = new ManualResetEventSlim(false);
+            var callers = Enumerable.Range(0, 8).Select(i => Task.Run(() =>
+            {
+                gate.Wait();
+                watcher.NotifyChanged($"0170{i}-BurstPlan");
+            })).ToArray();
+
+            gate.Set();
+            await Task.WhenAll(callers);
+
+            Assert.True(
+                RetryHelper.WaitUntil(() =>
+                {
+                    lock (fired) return fired.Count >= 1;
+                }, TimeSpan.FromSeconds(5)),
+                $"Round {round}: expected the debounce to fire");
+
+            lock (fired)
+            {
+                Assert.Single(fired);
+                Assert.Null(fired[0]);
+            }
+        }
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Services/JobServiceSettingsTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobServiceSettingsTests.cs
@@ -1,4 +1,7 @@
+using System.Diagnostics;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Test.Services;
 
@@ -116,6 +119,49 @@ maxConcurrentJobs: 5
         }
         finally
         {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    /// <summary>
+    ///     Starting a plan job flushes queued plan.yaml writes first, so the agent reads what the user
+    ///     just changed. That wait has to be bounded: a queued write can be parked on the cross-process
+    ///     plan lock behind a CLI process, and waiting for it froze whichever thread started the job —
+    ///     the UI thread, when the user clicks Execute (#2571).
+    /// </summary>
+    [Fact]
+    public void StartJob_WhenPlanWritesNeverFlush_ReturnsWithinTheFlushTimeout()
+    {
+        var tempDir = CreateTempConfigFile("jobTimeout: 30\n");
+        var planFolder = Path.Combine(tempDir, "Plans", "00001-TestPlan");
+        Directory.CreateDirectory(planFolder);
+
+        var entries = new List<(LogLevel Level, string Message)>();
+        var planReader = new FakePlanReaderService { FlushTask = new TaskCompletionSource().Task };
+        // maxConcurrentJobs 0: the job reaches the flush and then parks in the queue, instead of
+        // launching an agent process.
+        var jobService = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), null, 0,
+            planReaderService: planReader,
+            logger: new CapturingLogger<JobService>(entries))
+        {
+            PlanWriteFlushTimeout = TimeSpan.FromMilliseconds(200)
+        };
+
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var jobId = jobService.StartJob(new ExecutePlanArgs(planFolder));
+            stopwatch.Stop();
+
+            Assert.Equal(JobStatus.Queued, jobService.GetJob(jobId)?.Status);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+                $"StartJob waited {stopwatch.ElapsedMilliseconds}ms on a write queue that never drains");
+            Assert.Contains(entries, e => e.Level == LogLevel.Warning && e.Message.Contains("did not flush"));
+        }
+        finally
+        {
+            jobService.Dispose();
             Directory.Delete(tempDir, true);
         }
     }

--- a/src/Ivy.Tendril/AppShell/NotificationBurstSummarizer.cs
+++ b/src/Ivy.Tendril/AppShell/NotificationBurstSummarizer.cs
@@ -1,0 +1,78 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace Ivy.Tendril.AppShell;
+
+/// <summary>
+///     Collapses a burst of job notifications into one toast. A wave of jobs exiting together raised a
+///     toast each, and every toast is a client round trip plus a card the user has to read past — at the
+///     moment the workspace is already busy syncing those same exits (#2571). Failures keep their own
+///     toast: which plan failed, and why, is the part worth reading.
+/// </summary>
+internal sealed class NotificationBurstSummarizer : IDisposable
+{
+    /// <summary>
+    ///     How long notifications are collected before they are shown. The window opens at the first
+    ///     notification, so a shell with nothing happening pays nothing.
+    /// </summary>
+    internal static readonly TimeSpan DefaultWindow = TimeSpan.FromMilliseconds(300);
+
+    /// <summary>Up to this many notifications in one window are shown exactly as they arrived.</summary>
+    internal const int MaxIndividual = 3;
+
+    internal const string SummaryTitle = "Jobs Finished";
+
+    private readonly Subject<JobNotification> _notifications = new();
+    private readonly IDisposable _subscription;
+
+    internal NotificationBurstSummarizer(
+        Action<JobNotification> show, TimeSpan? window = null, IScheduler? scheduler = null)
+    {
+        var burst = window ?? DefaultWindow;
+
+        _subscription = _notifications
+            // Closed by the first notification in the buffer plus the window, rather than
+            // Buffer(TimeSpan), which would tick a timer every window for the life of the shell.
+            .Buffer(() => _notifications.Delay(burst, scheduler ?? Scheduler.Default).Take(1))
+            .Subscribe(batch =>
+            {
+                // Buffer hands back an IList; Summarize is written against the read-only shape the
+                // tests call it with.
+                foreach (var notification in Summarize([.. batch]))
+                    show(notification);
+            });
+    }
+
+    internal void Add(JobNotification notification) => _notifications.OnNext(notification);
+
+    /// <summary>
+    ///     What one window's worth of notifications should be shown as: everything, when there are few
+    ///     enough to read, else one summary of the wave followed by each failure in it.
+    /// </summary>
+    internal static IReadOnlyList<JobNotification> Summarize(IReadOnlyList<JobNotification> batch)
+    {
+        if (batch.Count <= MaxIndividual) return batch;
+
+        var failures = batch.Where(n => !n.IsSuccess).ToList();
+        var finished = batch.Count - failures.Count;
+
+        // A burst that is nothing but failures has nothing to collapse: the failures are all detail,
+        // and a summary on top of them would only be one more card.
+        if (finished == 0) return failures;
+
+        var jobs = finished == 1 ? "job" : "jobs";
+        var message = failures.Count == 0
+            ? $"{finished} {jobs} finished"
+            : $"{finished} {jobs} finished, {failures.Count} failed";
+
+        return [new JobNotification(SummaryTitle, message, true), .. failures];
+    }
+
+    public void Dispose()
+    {
+        _subscription.Dispose();
+        _notifications.OnCompleted();
+        _notifications.Dispose();
+    }
+}

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -418,6 +418,29 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
         UseEffect(() =>
         {
+            // The summarizer flushes on a timer thread, so toasts are posted back to the context the
+            // shell was built on, which is where every other client call here happens.
+            var syncContext = SynchronizationContext.Current;
+
+            void Toast(JobNotification notification)
+            {
+                if (notification.IsSuccess)
+                    client.Toast(notification.Message, notification.Title);
+                else
+                    client.Toast(notification.Message, notification.Title).Destructive();
+            }
+
+            void ShowToast(JobNotification notification)
+            {
+                if (syncContext != null)
+                    syncContext.Post(_ => Toast(notification), null);
+                else
+                    Toast(notification);
+            }
+
+            // A wave of jobs exiting together is one toast, not one per job (#2571).
+            var summarizer = new NotificationBurstSummarizer(ShowToast);
+
             void OnNotification(JobNotification notification)
             {
                 // Read the setting at notification time: the user can toggle it in Settings while
@@ -425,14 +448,15 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 if (!ShouldShowInAppToast(desktopWindow != null, config.Settings.DesktopNotifications))
                     return;
 
-                if (notification.IsSuccess)
-                    client.Toast(notification.Message, notification.Title);
-                else
-                    client.Toast(notification.Message, notification.Title).Destructive();
+                summarizer.Add(notification);
             }
 
             jobService.NotificationReady += OnNotification;
-            return Disposable.Create(() => jobService.NotificationReady -= OnNotification);
+            return Disposable.Create(() =>
+            {
+                jobService.NotificationReady -= OnNotification;
+                summarizer.Dispose();
+            });
         });
 
 

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -68,10 +68,24 @@ public class DashboardApp : ViewBase
             ).Width(UxHelper.SheetWidth).Resizable();
         });
 
-        UseEffect(() => JobsApp.JobChangeHookDisposable(jobService, refreshToken));
-        // Skip(1): the status stream is a BehaviorSubject and replays its
-        // current value on subscribe, which would refresh in a loop.
-        UseEffect(() => statusService.Status.Skip(1).Subscribe(_ => refreshToken.Refresh()));
+        // One coalescer for both signals: a job exiting raises JobsStructureChanged and, ~300ms later, a
+        // new Status — two events for one change, and the dashboard rebuild reads the whole database
+        // (#2571). The 60s interval below stays as the backstop.
+        UseEffect(() =>
+        {
+            var coalescer = new RefreshCoalescer(refreshToken, JobsApp.JobRefreshWindow);
+            var jobChanges = JobsApp.JobChangeHookDisposable(jobService, coalescer);
+            // Skip(1): the status stream is a BehaviorSubject and replays its
+            // current value on subscribe, which would refresh in a loop.
+            var statusChanges = statusService.Status.Skip(1).Subscribe(_ => coalescer.Request());
+
+            return Disposable.Create(() =>
+            {
+                jobChanges.Dispose();
+                statusChanges.Dispose();
+                coalescer.Dispose();
+            });
+        });
         UseInterval(() => { refreshToken.Refresh(); },
             planService.IsDatabaseReady ? TimeSpan.FromSeconds(60) : TimeSpan.FromSeconds(2));
         UseEffect(() =>

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Hooks.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Hooks.cs
@@ -1,15 +1,53 @@
 using System.Reactive.Disposables;
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Apps.Jobs;
 
 public partial class JobsApp
 {
-    internal static IDisposable JobChangeHookDisposable(IJobService jobService, RefreshToken refreshToken)
+    /// <summary>
+    ///     How long a burst of job changes is collapsed over. Matches <c>UseInboxAutoRefresh</c>: short
+    ///     enough to feel immediate, long enough that ten jobs exiting together cost one rebuild.
+    /// </summary>
+    internal static readonly TimeSpan JobRefreshWindow = TimeSpan.FromMilliseconds(400);
+
+    /// <summary>
+    ///     Refreshes <paramref name="refreshToken" /> when the job list changes, owning a coalescer on the
+    ///     caller's behalf. See the overload below for what is gated and why.
+    /// </summary>
+    internal static IDisposable JobChangeHookDisposable(IJobService jobService, RefreshToken refreshToken,
+        Func<string>? renderedSignature = null)
+    {
+        var coalescer = new RefreshCoalescer(refreshToken, JobRefreshWindow);
+        var hook = JobChangeHookDisposable(jobService, coalescer, renderedSignature);
+        return Disposable.Create(() =>
+        {
+            hook.Dispose();
+            coalescer.Dispose();
+        });
+    }
+
+    /// <summary>
+    ///     Requests a refresh through a coalescer the caller owns — for a view that shares one between
+    ///     several signals raised by the same underlying change.
+    /// </summary>
+    /// <param name="renderedSignature">
+    ///     The structural signature of the last render, or null for a view that tracks none. Ten jobs
+    ///     exiting together raise <c>JobsStructureChanged</c> ten times while the first rebuild already
+    ///     shows all ten, so an event whose signature matches what is on screen is dropped before it
+    ///     reaches the coalescer (#2571). The view's 5s interval remains the backstop.
+    /// </param>
+    internal static IDisposable JobChangeHookDisposable(IJobService jobService, RefreshCoalescer coalescer,
+        Func<string>? renderedSignature = null)
     {
         void OnJobsChanged()
         {
-            refreshToken.Refresh();
+            if (renderedSignature != null
+                && ComputeStructuralSignature(jobService.GetJobs()) == renderedSignature())
+                return;
+
+            coalescer.Request();
         }
 
         jobService.JobsStructureChanged += OnJobsChanged;

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -89,7 +89,9 @@ public partial class JobsApp : ViewBase
 
         var renderedSignature = UseRef("");
 
-        UseEffect(() => JobsApp.JobChangeHookDisposable(jobService, refreshToken));
+        // Gated on the same signature the interval below compares, so a burst of job exits that leaves
+        // the table looking identical costs no rebuild at all.
+        UseEffect(() => JobsApp.JobChangeHookDisposable(jobService, refreshToken, () => renderedSignature.Value));
         UseInterval(() =>
         {
             if (JobsApp.ComputeStructuralSignature(jobService.GetJobs()) == renderedSignature.Value) return;

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -42,6 +42,31 @@ public class ContentView(
     private const string ArtifactsTab = "artifacts";
     private const string RecommendationsTab = "recommendations";
 
+    /// <summary>
+    ///     Whether a <c>PlansChanged</c> naming <paramref name="changedFolder" /> should rebuild the
+    ///     content shown for <paramref name="selectedFolder" />. A rebuild runs git subprocesses and one
+    ///     PowerShell condition per configured review action, so doing it because some other plan changed
+    ///     is pure cost (#2571). A null changed folder is a full rescan and always refreshes, as does a
+    ///     view with nothing selected, which has nothing to compare against.
+    /// </summary>
+    /// <remarks>
+    ///     The event carries a full folder path from the watcher and a bare folder name from some
+    ///     <c>NotifyChanged</c> callers, so the two sides are compared on their last segment.
+    /// </remarks>
+    internal static bool ShouldRefreshFor(string? changedFolder, string? selectedFolder)
+    {
+        if (string.IsNullOrEmpty(changedFolder) || string.IsNullOrEmpty(selectedFolder)) return true;
+        return string.Equals(LeafName(changedFolder), LeafName(selectedFolder), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The last path segment, whichever separator the caller used.</summary>
+    private static string LeafName(string folder)
+    {
+        var trimmed = folder.TrimEnd('/', '\\');
+        var lastSeparator = trimmed.LastIndexOfAny(['/', '\\']);
+        return lastSeparator >= 0 ? trimmed[(lastSeparator + 1)..] : trimmed;
+    }
+
     public override object Build()
     {
         var client = UseService<IClientProvider>();
@@ -213,9 +238,23 @@ public class ContentView(
 
         UseEffect(() =>
         {
-            void OnChanged(string? _) => localRefresh.Refresh();
+            // 400ms, as UseInboxAutoRefresh does: a burst of plan mutations must not queue one rebuild
+            // per event, since each rebuild shells out to git and evaluates the project's review-action
+            // conditions in PowerShell (#2571).
+            var coalescer = new RefreshCoalescer(localRefresh, TimeSpan.FromMilliseconds(400));
+
+            void OnChanged(string? changedFolder)
+            {
+                if (!ShouldRefreshFor(changedFolder, selectedPlanState.Value?.FolderName)) return;
+                coalescer.Request();
+            }
+
             planWatcher.PlansChanged += OnChanged;
-            return Disposable.Create(() => planWatcher.PlansChanged -= OnChanged);
+            return Disposable.Create(() =>
+            {
+                planWatcher.PlansChanged -= OnChanged;
+                coalescer.Dispose();
+            });
         });
 
         UseEffect(() =>

--- a/src/Ivy.Tendril/Helpers/JobLogPaths.cs
+++ b/src/Ivy.Tendril/Helpers/JobLogPaths.cs
@@ -88,6 +88,50 @@ public static partial class JobLogPaths
         }
     }
 
+    /// <summary>
+    /// Every plan's job logs in one directory pass, keyed by plan id and oldest job id first — the
+    /// same grouping <see cref="LogsForPlanId" /> produces per plan, for callers that need all of
+    /// them. A full sync used to glob the whole Jobs directory once per plan (339 globs over 6607
+    /// entries on the store that reported #2571); this reads it once.
+    /// </summary>
+    /// <remarks>
+    /// A log with no plan-id segment (the <c>{jobId}-{type}.md</c> shape a CreatePlan job writes)
+    /// belongs to no plan and lands in no group.
+    /// </remarks>
+    internal static Dictionary<string, string[]> LogsByPlanId(string tendrilHome)
+    {
+        var grouped = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        try
+        {
+            var dir = JobsDir(tendrilHome);
+            if (!Directory.Exists(dir)) return grouped;
+
+            foreach (var group in Directory.GetFiles(dir, "*.md")
+                         .Where(f => !f.EndsWith(".prompt.md", StringComparison.OrdinalIgnoreCase))
+                         .Select(f => (Path: f, PlanId: PlanIdSegment(f)))
+                         .Where(f => f.PlanId != null)
+                         // Job ids are fixed-width, so ordinal file-name order is job-id order —
+                         // the same ordering LogsForPlanId gives its callers.
+                         .OrderBy(f => Path.GetFileName(f.Path), StringComparer.Ordinal)
+                         .GroupBy(f => f.PlanId!, StringComparer.Ordinal))
+                grouped[group.Key] = group.Select(f => f.Path).ToArray();
+
+            return grouped;
+        }
+        catch
+        {
+            return grouped;
+        }
+    }
+
+    /// <summary>The plan-id segment of a job artifact's file name, or <c>null</c> for one without.</summary>
+    private static string? PlanIdSegment(string path)
+    {
+        var parts = Path.GetFileNameWithoutExtension(path).Split('-');
+        if (parts.Length < 3) return null;
+        return PlanIdPrefix().IsMatch(parts[1] + "-") ? parts[1] : null;
+    }
+
     /// <summary>Job logs (<c>.md</c>) belonging to <paramref name="planId"/>, oldest job id first.</summary>
     public static string[] LogsForPlanId(string tendrilHome, string planId)
     {

--- a/src/Ivy.Tendril/Helpers/PlanFileLock.cs
+++ b/src/Ivy.Tendril/Helpers/PlanFileLock.cs
@@ -10,6 +10,12 @@ public static class PlanFileLock
     private const int MaxRetries = 50;
     private const int DelayMs = 100;
 
+    /// <summary>
+    ///     The longest <see cref="Acquire" /> can take before it gives up. Callers that block on a write
+    ///     which has to take this lock size their own timeout from it rather than guessing (#2571).
+    /// </summary>
+    public static TimeSpan AcquireBudget { get; } = TimeSpan.FromMilliseconds(MaxRetries * DelayMs);
+
     public static FileStream Acquire(string planFolder)
     {
         var lockPath = Path.Combine(planFolder, "plan.yaml.lock");

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -1125,7 +1125,7 @@ public class JobService : IJobService
         }
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or ExpandPlanArgs or UpdatePlanArgs or SplitPlanArgs)
-            _planReaderService?.FlushPendingWritesAsync().GetAwaiter().GetResult();
+            FlushPendingPlanWrites();
 
         // Snapshot the plan's pre-job state and perform the start transition in one
         // place (only once the job is actually starting, not while blocked) so
@@ -1145,6 +1145,29 @@ public class JobService : IJobService
         job.SlotReserved = true;
         LaunchJob(job);
         return id;
+    }
+
+    /// <summary>
+    ///     How long <see cref="FlushPendingPlanWrites" /> waits: one full plan-lock budget for the write
+    ///     that may be parked on the lock, plus a second for the write itself. Settable for tests.
+    /// </summary>
+    internal TimeSpan PlanWriteFlushTimeout { get; set; } = PlanFileLock.AcquireBudget + TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    ///     Lets queued plan.yaml writes land before the agent reads the file — bounded, rather than
+    ///     waiting however long it takes. A queued write can be parked on the cross-process plan lock
+    ///     behind a CLI process, and blocking on that indefinitely froze whichever thread started the
+    ///     job, which is the UI thread when the user clicks Execute (#2571). Past the budget the job
+    ///     starts anyway: the agent re-reads plan.yaml itself, so a stale read here is recoverable
+    ///     where a frozen workspace is not.
+    /// </summary>
+    private void FlushPendingPlanWrites()
+    {
+        var flush = _planReaderService?.FlushPendingWritesAsync();
+        if (flush == null || flush.Wait(PlanWriteFlushTimeout)) return;
+
+        _logger.LogWarning("Pending plan writes did not flush within {TimeoutMs}ms; starting the job anyway",
+            PlanWriteFlushTimeout.TotalMilliseconds);
     }
 
     /// <summary>

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -40,6 +40,15 @@ public interface IPlanDatabaseService : IDisposable
     void UpdateRecommendationState(int planId, string recommendationTitle, string newState, string? declineReason);
 
     // Sync operations (bulk, called by sync service)
+
+    /// <summary>
+    ///     Opens a batch: one write lock and one transaction held for the caller's whole loop instead of
+    ///     one of each per plan. A full sync otherwise takes the write lock twice per plan, and every
+    ///     acquisition is another chance for a UI read to queue behind it (#2571). Not nestable.
+    /// </summary>
+    /// <returns>A scope that commits when disposed; a no-op for an implementation with no connection.</returns>
+    IDisposable BeginBatch() => NullBatch.Instance;
+
     void UpsertPlan(PlanFile plan);
     void DeletePlan(int planId);
     void UpsertCosts(int planId, List<CostEntry> costs);
@@ -67,6 +76,16 @@ public interface IPlanDatabaseService : IDisposable
     long GetDatabaseSize();
     DateTime GetLastSyncTime();
     void SetLastSyncTime(DateTime time);
+}
+
+/// <summary>
+///     What <see cref="IPlanDatabaseService.BeginBatch" /> hands back when there is nothing to batch —
+///     the in-memory fakes the tests use, which have neither a lock nor a transaction to hold.
+/// </summary>
+internal sealed class NullBatch : IDisposable
+{
+    internal static readonly NullBatch Instance = new();
+    public void Dispose() { }
 }
 
 /// <summary>

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -24,27 +24,88 @@ public class PlanDatabaseService : IPlanDatabaseService
     private readonly DashboardRepository _dashboardRepository;
     private bool _disposed;
 
+    /// <summary>
+    ///     The transaction a <see cref="BeginBatch" /> scope holds open, or null. Only ever read and
+    ///     written by the thread inside the batch, which holds the write lock for its whole scope.
+    /// </summary>
+    private SqliteTransaction? _batchTransaction;
+
+    /// <remarks>
+    ///     A no-op when the calling thread is already inside a <see cref="BeginBatch" /> scope: that
+    ///     scope holds the write lock, which already covers every read under it, and re-entering a
+    ///     non-recursive <see cref="ReaderWriterLockSlim" /> would throw.
+    /// </remarks>
     private sealed class ReadLockHandle : IDisposable
     {
-        private readonly ReaderWriterLockSlim _lock;
+        private readonly ReaderWriterLockSlim? _lock;
         public ReadLockHandle(ReaderWriterLockSlim rwLock)
         {
+            if (rwLock.IsWriteLockHeld) return;
             _lock = rwLock;
             _lock.EnterReadLock();
         }
-        public void Dispose() => _lock.ExitReadLock();
+        public void Dispose() => _lock?.ExitReadLock();
     }
 
+    /// <inheritdoc cref="ReadLockHandle" />
     private sealed class WriteLockHandle : IDisposable
     {
-        private readonly ReaderWriterLockSlim _lock;
+        private readonly ReaderWriterLockSlim? _lock;
         public WriteLockHandle(ReaderWriterLockSlim rwLock)
         {
+            if (rwLock.IsWriteLockHeld) return;
             _lock = rwLock;
             _lock.EnterWriteLock();
         }
-        public void Dispose() => _lock.ExitWriteLock();
+        public void Dispose() => _lock?.ExitWriteLock();
     }
+
+    /// <summary>
+    ///     One write lock and one transaction held across many mutations. A full plan sync otherwise
+    ///     takes the write lock hundreds of times (twice per plan), and every acquisition is another
+    ///     chance to block a UI thread arriving for the read lock — which is how a burst of plan
+    ///     mutations froze a workspace (#2571).
+    /// </summary>
+    private sealed class BatchScope : IDisposable
+    {
+        private readonly PlanDatabaseService _service;
+        private readonly WriteLockHandle _writeLock;
+        private readonly SqliteTransaction _transaction;
+        private bool _disposed;
+
+        public BatchScope(PlanDatabaseService service)
+        {
+            _service = service;
+            _writeLock = new WriteLockHandle(service._lock);
+            _transaction = service._connection.BeginTransaction();
+            service._batchTransaction = _transaction;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            _service._batchTransaction = null;
+            try
+            {
+                _transaction.Commit();
+            }
+            catch (Exception ex)
+            {
+                _service._logger.LogError(ex, "Failed to commit batched database writes");
+                try { _transaction.Rollback(); } catch { /* connection may already be gone */ }
+            }
+            finally
+            {
+                _transaction.Dispose();
+                _writeLock.Dispose();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public IDisposable BeginBatch() => new BatchScope(this);
 
     public PlanDatabaseService(string databasePath, ILogger<PlanDatabaseService> logger)
     {
@@ -574,15 +635,16 @@ public class PlanDatabaseService : IPlanDatabaseService
     {
         using (new WriteLockHandle(_lock))
         {
-            using var transaction = _connection.BeginTransaction();
+            // Inside a batch the caller's transaction is already open and commits with the scope.
+            using var transaction = _batchTransaction == null ? _connection.BeginTransaction() : null;
             try
             {
                 UpsertPlanInternal(plan);
-                transaction.Commit();
+                transaction?.Commit();
             }
             catch
             {
-                transaction.Rollback();
+                transaction?.Rollback();
                 throw;
             }
         }
@@ -752,16 +814,17 @@ public class PlanDatabaseService : IPlanDatabaseService
         {
             if (plans.Count == 0) return;
 
-            using var transaction = _connection.BeginTransaction();
+            // Inside a batch the caller's transaction is already open and commits with the scope.
+            using var transaction = _batchTransaction == null ? _connection.BeginTransaction() : null;
             try
             {
                 foreach (var plan in plans)
                     UpsertPlanInternal(plan, forceOverwrite);
-                transaction.Commit();
+                transaction?.Commit();
             }
             catch
             {
-                transaction.Rollback();
+                transaction?.Rollback();
                 throw;
             }
         }

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
@@ -1,7 +1,9 @@
 using Ivy.Tendril.Helpers;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using System.Threading.Channels;
 using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;
 
@@ -9,6 +11,9 @@ namespace Ivy.Tendril.Services.Plans;
 
 public class PlanDatabaseSyncService : IDisposable
 {
+    /// <summary>How long <see cref="Dispose" /> waits for the worker to finish its current sync.</summary>
+    private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
+
     private readonly IPlanDatabaseService _database;
     private readonly IConfigService _configService;
     private readonly ILogger<PlanDatabaseSyncService> _logger;
@@ -16,6 +21,18 @@ public class PlanDatabaseSyncService : IDisposable
     private readonly IPlanWatcherService _watcher;
     private volatile bool _isInitialSyncComplete;
     private volatile bool _isDatabaseAvailable;
+
+    // The request stream is a wake-up signal, not a work queue: what to sync is decided from the
+    // coalesced state below, so a burst of N events cannot turn into N rescans.
+    private readonly Channel<byte> _wakeUps =
+        Channel.CreateUnbounded<byte>(new UnboundedChannelOptions { SingleReader = true });
+    private readonly ConcurrentDictionary<string, byte> _pendingFolders = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Task _worker;
+    private int _fullSyncPending;
+    private int _syncInFlight;
+    private int _syncCount;
+    private int _singlePlanSyncCount;
+    private int _lastSyncThreadId;
 
     public PlanDatabaseSyncService(
         PlanReaderService planReader,
@@ -30,14 +47,62 @@ public class PlanDatabaseSyncService : IDisposable
         _configService = configService;
         _logger = logger;
 
+        // Long-running rather than a pooled task: the loop is parked on the channel for the life of
+        // the process, and a full rescan is minutes of I/O on a large store — neither belongs on a
+        // thread pool thread.
+        _worker = Task.Factory.StartNew(RunWorker, CancellationToken.None,
+            TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+
         _watcher.PlansChanged += OnPlansChanged;
     }
 
     public bool IsInitialSyncComplete => _isInitialSyncComplete;
 
+    /// <summary>Full rescans performed by the worker. Test seam for the coalescing behaviour.</summary>
+    internal int SyncCount => Volatile.Read(ref _syncCount);
+
+    /// <summary>Single-folder syncs performed by the worker. Test seam.</summary>
+    internal int SinglePlanSyncCount => Volatile.Read(ref _singlePlanSyncCount);
+
+    /// <summary>Managed thread id the last sync ran on, or 0. Test seam.</summary>
+    internal int LastSyncThreadId => Volatile.Read(ref _lastSyncThreadId);
+
     public void Dispose()
     {
         _watcher.PlansChanged -= OnPlansChanged;
+        _wakeUps.Writer.TryComplete();
+
+        // Bounded: shutdown must not hang behind a rescan that is mid-flight on a large store.
+        try
+        {
+            if (!_worker.Wait(ShutdownTimeout))
+                _logger.LogWarning("Database sync worker did not stop within {Timeout}s", ShutdownTimeout.TotalSeconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Database sync worker faulted during shutdown");
+        }
+    }
+
+    /// <summary>
+    ///     Completes once the worker has no sync in flight and nothing queued. Test seam — production
+    ///     code never waits on the sync.
+    /// </summary>
+    internal async Task DrainAsync(TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(30));
+        while (true)
+        {
+            if (Volatile.Read(ref _fullSyncPending) == 0
+                && _pendingFolders.IsEmpty
+                && Volatile.Read(ref _syncInFlight) == 0)
+                return;
+
+            if (DateTime.UtcNow > deadline)
+                throw new TimeoutException("Database sync did not drain within the timeout.");
+
+            await Task.Delay(10).ConfigureAwait(false);
+        }
     }
 
     public void PerformInitialSync()
@@ -59,12 +124,7 @@ public class PlanDatabaseSyncService : IDisposable
                 plans.Count, terminalIds.Count);
             _database.BulkUpsertPlans(plans, true);
             RecoverStuckPlansInDatabase(plans);
-
-            foreach (var plan in plans)
-            {
-                SyncPlanCosts(plan);
-                SyncPlanRecommendations(plan);
-            }
+            SyncPlanDetails(plans);
 
             // Purging old rows keeps the database small; the job artifacts under <TendrilHome>/Jobs/ are
             // kept so a purged job can still be inspected and attached to a bug report.
@@ -88,16 +148,112 @@ public class PlanDatabaseSyncService : IDisposable
         }
     }
 
-    private void OnPlansChanged(string? changedPlanFolder)
+    /// <summary>
+    ///     Queues a sync and returns. Never syncs on the calling thread: PlansChanged is raised from
+    ///     the watcher's timers and from every plan mutation, and a full rescan on a large store is
+    ///     seconds of file and SQLite work — running it inline is what froze the workspace on a burst
+    ///     of plan closes (#2571). Internal rather than private so tests can raise it directly.
+    /// </summary>
+    internal void OnPlansChanged(string? changedPlanFolder)
     {
         if (!_isInitialSyncComplete || !_isDatabaseAvailable) return;
 
+        RecordPending(changedPlanFolder);
+
+        // The state above is published before the wake-up, so the worker (and DrainAsync) can never
+        // see a wake-up without the work it stands for.
+        _wakeUps.Writer.TryWrite(0);
+    }
+
+    /// <summary>
+    ///     Folds one request into the coalesced state without waking the worker. Split out of
+    ///     <see cref="OnPlansChanged" /> so a test can queue several requests and then inspect what one
+    ///     pass takes, which is racy to observe once the worker is awake.
+    /// </summary>
+    internal void RecordPending(string? changedPlanFolder)
+    {
+        if (changedPlanFolder != null && Directory.Exists(changedPlanFolder))
+            _pendingFolders.TryAdd(changedPlanFolder, 0);
+        else
+            // A full rescan supersedes every pending single-folder sync, and a second request while
+            // one is already pending collapses into it.
+            Interlocked.Exchange(ref _fullSyncPending, 1);
+    }
+
+    /// <summary>
+    ///     The coalesced work for one pass. A pending full rescan wins and discards the queued folders,
+    ///     which it re-reads anyway.
+    /// </summary>
+    internal (bool FullRescan, List<string> Folders) TakeWork()
+    {
+        if (Interlocked.Exchange(ref _fullSyncPending, 0) == 1)
+        {
+            _pendingFolders.Clear();
+            return (true, []);
+        }
+
+        var folders = new List<string>();
+        foreach (var folder in _pendingFolders.Keys)
+            if (_pendingFolders.TryRemove(folder, out _))
+                folders.Add(folder);
+
+        return (false, folders);
+    }
+
+    private async Task RunWorker()
+    {
         try
         {
-            if (changedPlanFolder != null && Directory.Exists(changedPlanFolder))
-                SyncSinglePlan(changedPlanFolder);
-            else
+            while (await _wakeUps.Reader.WaitToReadAsync().ConfigureAwait(false))
+            {
+                // Drain every queued wake-up before working: they are signals, and the work they
+                // stand for has already been folded into _fullSyncPending / _pendingFolders.
+                while (_wakeUps.Reader.TryRead(out _)) { }
+
+                Interlocked.Exchange(ref _syncInFlight, 1);
+                try
+                {
+                    DrainOnce();
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _syncInFlight, 0);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Database sync worker stopped unexpectedly");
+        }
+    }
+
+    /// <summary>
+    ///     One pass of the coalesced work. A full rescan wins over any pending single-folder syncs; a
+    ///     request that arrives while this pass runs is picked up by the next one, so a burst costs at
+    ///     most the rescan in flight plus one follow-up.
+    /// </summary>
+    private void DrainOnce()
+    {
+        Volatile.Write(ref _lastSyncThreadId, Environment.CurrentManagedThreadId);
+
+        try
+        {
+            var (fullRescan, folders) = TakeWork();
+            if (fullRescan)
+            {
+                Interlocked.Increment(ref _syncCount);
                 SyncAllPlans();
+                _database.SetLastSyncTime(DateTime.UtcNow);
+                return;
+            }
+
+            if (folders.Count == 0) return;
+
+            foreach (var folder in folders)
+            {
+                Interlocked.Increment(ref _singlePlanSyncCount);
+                SyncSinglePlan(folder);
+            }
 
             _database.SetLastSyncTime(DateTime.UtcNow);
         }
@@ -141,15 +297,32 @@ public class PlanDatabaseSyncService : IDisposable
     {
         var plans = _planReader.GetPlansFromFileSystem();
         _database.BulkUpsertPlans(plans);
+        SyncPlanDetails(plans);
+    }
 
+    /// <summary>
+    ///     Syncs every plan's costs and recommendations in one pass: the Jobs directory is enumerated
+    ///     once for all plans rather than globbed per plan, and the whole loop runs inside one write
+    ///     lock and one transaction rather than two lock acquisitions per plan. Both are what keep a
+    ///     rescan from starving the UI's plan-list reads (#2571).
+    /// </summary>
+    internal void SyncPlanDetails(List<PlanFile> plans)
+    {
+        var logsByPlanId = JobLogPaths.LogsByPlanId(_configService.TendrilHome);
+
+        using var batch = _database.BeginBatch();
         foreach (var plan in plans)
         {
-            SyncPlanCosts(plan);
+            SyncPlanCosts(plan, logsByPlanId);
             SyncPlanRecommendations(plan);
         }
     }
 
-    private void SyncPlanCosts(PlanFile plan)
+    /// <param name="logsByPlanId">
+    ///     Job logs grouped by plan id, built once per rescan. Null falls back to a per-plan glob,
+    ///     which is what a single-folder sync wants.
+    /// </param>
+    private void SyncPlanCosts(PlanFile plan, Dictionary<string, string[]>? logsByPlanId = null)
     {
         var costsPath = Path.Combine(plan.FolderPath, "costs.csv");
         if (!File.Exists(costsPath)) return;
@@ -165,7 +338,11 @@ public class PlanDatabaseSyncService : IDisposable
                 new Dictionary<string, Queue<(string Path, int Num)>>(StringComparer.OrdinalIgnoreCase);
             if (planId != null)
             {
-                var logFiles = JobLogPaths.LogsForPlanId(_configService.TendrilHome, planId)
+                var planLogs = logsByPlanId != null
+                    ? logsByPlanId.TryGetValue(planId, out var grouped) ? grouped : []
+                    : JobLogPaths.LogsForPlanId(_configService.TendrilHome, planId);
+
+                var logFiles = planLogs
                     .Select(f =>
                     {
                         var parts = Path.GetFileNameWithoutExtension(f).Split('-');

--- a/src/Ivy.Tendril/Services/Plans/PlanWatcherService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanWatcherService.cs
@@ -8,9 +8,11 @@ public class PlanWatcherService : IPlanWatcherService
 {
     // Default self-heal cadence: the top-level FSW fires when a plan folder first appears
     // (still empty), but plan.yaml / Revisions land a moment later and writes *inside* the
-    // folder don't re-trigger the watcher. These staggered re-scans surface the now-complete
-    // folder within seconds instead of waiting for the 30s poll.
-    private static readonly int[] DefaultSelfHealDelaysMs = { 1000, 3000, 8000 };
+    // folder don't re-trigger the watcher. These re-scans surface the now-complete folder
+    // within seconds instead of waiting for the 30s poll. Two delays suffice because the
+    // database sync coalesces and reruns after an in-flight pass (#2571), so a rescan that
+    // races the last write is followed by another without a third timer.
+    private static readonly int[] DefaultSelfHealDelaysMs = { 1000, 4000 };
 
     private readonly Timer _debounceTimer;
     private readonly FileSystemWatcher? _watcher;
@@ -18,8 +20,19 @@ public class PlanWatcherService : IPlanWatcherService
     private readonly ILogger<PlanWatcherService>? _logger;
     private readonly int[] _selfHealDelaysMs;
     private readonly object _selfHealLock = new();
+
+    /// <summary>
+    ///     Guards <see cref="_pendingPlanFolder" /> and the debounce timer's Stop/Start pair. Every
+    ///     caller is a timer or an FSW callback on an arbitrary thread pool thread, and a burst of plan
+    ///     mutations has them arriving together: unsynchronized, two concurrent calls could lose the
+    ///     escalation to a full rescan (each seeing a null pending folder) or restart the timer between
+    ///     the other's Stop and Start and drop the pending fire entirely.
+    /// </summary>
+    private readonly object _debounceLock = new();
+
     private List<System.Threading.Timer> _selfHealTimers = new();
     private string? _pendingPlanFolder;
+    private bool _disposed;
 
     public PlanWatcherService(IConfigService config, ILogger<PlanWatcherService>? logger = null,
         int[]? selfHealDelaysMs = null)
@@ -30,8 +43,15 @@ public class PlanWatcherService : IPlanWatcherService
         _debounceTimer.AutoReset = false;
         _debounceTimer.Elapsed += (_, _) =>
         {
-            var folder = _pendingPlanFolder;
-            _pendingPlanFolder = null;
+            string? folder;
+            lock (_debounceLock)
+            {
+                folder = _pendingPlanFolder;
+                _pendingPlanFolder = null;
+            }
+
+            // Raised outside the lock: subscribers do real work (the database sync queues, views
+            // refresh), and holding the lock across them would stall every NotifyChanged behind it.
             RaisePlansChanged(folder);
         };
 
@@ -98,7 +118,14 @@ public class PlanWatcherService : IPlanWatcherService
     {
         _pollTimer?.Dispose();
         _watcher?.Dispose();
-        _debounceTimer.Dispose();
+
+        // Under the same lock as ScheduleDebounce: an FSW callback already queued on a thread pool
+        // thread would otherwise reach Start() on the disposed timer and throw there.
+        lock (_debounceLock)
+        {
+            _disposed = true;
+            _debounceTimer.Dispose();
+        }
 
         lock (_selfHealLock)
         {
@@ -109,15 +136,16 @@ public class PlanWatcherService : IPlanWatcherService
     }
 
     /// <summary>
-    ///     Schedules a short burst of full re-scans after a top-level folder event. A brand-new
-    ///     plan folder fires the FSW while still empty; its plan.yaml / first revision land a
-    ///     moment later, and those writes (inside the folder) don't re-trigger the watcher. These
-    ///     staggered re-scans pick up the completed folder within seconds rather than waiting for
-    ///     the 30s poll.
+    ///     Schedules a couple of full re-scans after a top-level folder event. A brand-new plan
+    ///     folder fires the FSW while still empty; its plan.yaml / first revision land a moment
+    ///     later, and those writes (inside the folder) don't re-trigger the watcher. These re-scans
+    ///     pick up the completed folder within seconds rather than waiting for the 30s poll.
     ///     <para>
-    ///     Trade-off: a single folder event now yields up to N+1 full re-scans (the debounce plus
-    ///     one per delay) instead of one. Plan-folder events are infrequent and each new event
-    ///     replaces the prior burst, so the extra I/O is bounded and acceptable.
+    ///     Each delay goes through <see cref="ScheduleDebounce" /> rather than raising directly, so
+    ///     the whole burst is subject to the same coalescing as everything else: a folder event
+    ///     costs one fire per delay at most, and timers that land together cost one between them.
+    ///     Two delays are enough because <c>PlanDatabaseSyncService</c> reruns once after the pass
+    ///     in flight, which already covers content that landed during a rescan (#2571).
     ///     </para>
     /// </summary>
     private void ScheduleSelfHeal()
@@ -125,10 +153,7 @@ public class PlanWatcherService : IPlanWatcherService
         var newTimers = new List<System.Threading.Timer>(_selfHealDelaysMs.Length);
         foreach (var delayMs in _selfHealDelaysMs)
         {
-            // Fire an independent full rescan at each delay rather than routing through the
-            // debounce (which would coalesce the staggered timers into a single fire). Each
-            // rescan is a fresh chance to pick up content that landed after the last one.
-            var timer = new System.Threading.Timer(_ => RaisePlansChanged(null),
+            var timer = new System.Threading.Timer(_ => ScheduleDebounce(null),
                 null, delayMs, Timeout.Infinite);
             newTimers.Add(timer);
         }
@@ -167,17 +192,22 @@ public class PlanWatcherService : IPlanWatcherService
 
     private void ScheduleDebounce(string? planFolder)
     {
-        // If we already have a pending folder and a different one arrives, escalate to full rescan
-        if (_pendingPlanFolder != null && planFolder != null
-                                       && !string.Equals(_pendingPlanFolder, planFolder,
-                                           StringComparison.OrdinalIgnoreCase))
-            _pendingPlanFolder = null; // null = full rescan
-        else if (_pendingPlanFolder == null && planFolder != null && !_debounceTimer.Enabled)
-            _pendingPlanFolder = planFolder;
-        // If planFolder is null (full rescan requested), override any specific folder
-        else if (planFolder == null) _pendingPlanFolder = null;
+        lock (_debounceLock)
+        {
+            if (_disposed) return;
 
-        _debounceTimer.Stop();
-        _debounceTimer.Start();
+            // If we already have a pending folder and a different one arrives, escalate to full rescan
+            if (_pendingPlanFolder != null && planFolder != null
+                                           && !string.Equals(_pendingPlanFolder, planFolder,
+                                               StringComparison.OrdinalIgnoreCase))
+                _pendingPlanFolder = null; // null = full rescan
+            else if (_pendingPlanFolder == null && planFolder != null && !_debounceTimer.Enabled)
+                _pendingPlanFolder = planFolder;
+            // If planFolder is null (full rescan requested), override any specific folder
+            else if (planFolder == null) _pendingPlanFolder = null;
+
+            _debounceTimer.Stop();
+            _debounceTimer.Start();
+        }
     }
 }


### PR DESCRIPTION
﻿Fixes #2571

# Plan 00408 â€” Stop the Workspace Freezing on Bursts of Plan Closes and Job Exits

Issue [#2571](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/2571). Branch
`tendril/00408-StopTheWorkspaceFreezing`, five commits on base `4b00fee4`.

## Changes

**1. The plan-database sync runs off the raising thread and coalesces (`1be2bc06`).**
`PlanDatabaseSyncService.OnPlansChanged` used to call `SyncAllPlans()` inline, so N plan events meant
N sequential full rescans on the thread that raised them â€” the UI dispatch thread, for a plan close.
It now records the request and writes a wake-up to a channel drained by one long-running worker. A
pending full rescan supersedes queued single-folder syncs; a second full-rescan request while one is
running collapses into a single follow-up. A burst of 20 events costs at most two rescans. `Dispose`
completes the channel and waits 5s, so shutdown cannot hang behind a rescan.

**2. A rescan is much cheaper, and stops starving readers (`1be2bc06`).** One rescan on the reporting
machine's store globbed `<TendrilHome>/Jobs` (6607 files) once per plan and took roughly 644 separate
write locks. `JobLogPaths.LogsByPlanId` now enumerates that directory once per rescan and groups by
plan id, and the whole per-plan loop runs inside one write lock and one SQLite transaction via the new
`IPlanDatabaseService.BeginBatch()`. Single-folder syncs still use the per-plan glob and their own
transaction, unchanged.

**3. The three uncoalesced refresh subscriptions are coalesced (`a5740b29`).** Review `ContentView`
now debounces `PlansChanged` through a 400ms `RefreshCoalescer` and ignores events for a plan other
than the selected one (its rebuild shells out to git and evaluates review-action conditions).
`JobsApp`'s job-change hook gates on `ComputeStructuralSignature` â€” the gate its 5s interval already
used â€” and routes the surviving refresh through a coalescer, so ten jobs exiting at once is one
rebuild. `DashboardApp` shares one coalescer between the job hook and the process-status stream, which
fire ~300ms apart for the same job exit. Both `UseInterval` backstops are untouched.

**4. `PlanWatcherService` is burst-safe (`21c3988c`).** `_pendingPlanFolder` and the debounce timer's
`Stop()`/`Start()` pair are now guarded by a dedicated lock, so concurrent `NotifyChanged` calls can
no longer lose the escalation to a full rescan or drop the pending fire; `Dispose` closes the same
lock so a timer firing during shutdown cannot restart a disposed timer. The self-heal ladder routes
through the debounce and is two delays (1s, 4s) instead of three uncoalesced direct fires â€” the sync
worker's rerun-after-in-flight now covers late-arriving content.

**5. The job-start flush is bounded (`192010af`).** `StartJobInternal` blocked on
`FlushPendingWritesAsync().GetAwaiter().GetResult()`, and a queued write can sit in
`PlanFileLock.Acquire` for up to 5s behind a CLI process. It now waits `PlanWriteFlushTimeout`
(`PlanFileLock.AcquireBudget` + 1s) and, past that, logs a warning and starts the job anyway: the
agent re-reads `plan.yaml`, so a stale read is recoverable where a frozen workspace is not.

**6. Notification bursts are summarized (`acdcb063`).** A wave of job exits raised one toast each.
Notifications are now buffered 300ms; past three they collapse into one summary toast ("6 jobs
finished, 1 failed"), with failures still shown individually. The buffer is closed by the first
notification in it plus the window rather than a repeating timer, so an idle shell schedules nothing.

## API Changes

- `IPlanDatabaseService.BeginBatch()` â€” new member, a default interface method returning a no-op
  scope, so existing implementations (including the test fakes) compile unchanged.
  `PlanDatabaseService` overrides it with one write lock plus one transaction, committed on dispose.
- `PlanFileLock.AcquireBudget` â€” new public property (5s), so callers that block on a plan write can
  size their timeout from the lock's own budget.
- `JobsApp.JobChangeHookDisposable` â€” two overloads now: `(IJobService, RefreshToken, Func<string>?)`
  and `(IJobService, RefreshCoalescer, Func<string>?)`. The previous
  `(IJobService, RefreshToken)` call shape still compiles.
- `JobsApp.JobRefreshWindow` â€” new `internal static` (400ms), shared by `JobsApp` and `DashboardApp`.
- `JobLogPaths.LogsByPlanId(string tendrilHome)` â€” new `internal static`. `LogsForPlanId` unchanged.
- `PlanDatabaseSyncService` â€” `OnPlansChanged` is now `internal` (was private); new internal seams
  `DrainAsync`, `RecordPending`, `TakeWork`, `SyncPlanDetails`, `SyncCount`, `SinglePlanSyncCount`,
  `LastSyncThreadId`.
- `JobService.PlanWriteFlushTimeout` â€” new `internal` property.
- `Review.ContentView.ShouldRefreshFor(string?, string?)` â€” new `internal static` predicate.
- `NotificationBurstSummarizer` â€” new `internal sealed` class in `Ivy.Tendril.AppShell`.

No public behaviour of the CLI, the HTTP API or `plan.yaml` changed.

## Files Modified

Production (`src/Ivy.Tendril`):

- `Services/Plans/PlanDatabaseSyncService.cs` â€” worker, coalescing, `SyncPlanDetails`
- `Services/Plans/PlanDatabaseService.cs` â€” recursion-aware lock handles, `BatchScope`
- `Services/Plans/IPlanDatabaseService.cs` â€” `BeginBatch` + `NullBatch`
- `Services/Plans/PlanWatcherService.cs` â€” debounce lock, self-heal via debounce, shorter ladder
- `Services/Jobs/JobService.cs` â€” `FlushPendingPlanWrites`, `PlanWriteFlushTimeout`
- `Helpers/JobLogPaths.cs` â€” `LogsByPlanId`
- `Helpers/PlanFileLock.cs` â€” `AcquireBudget`
- `Apps/Review/ContentView.cs` â€” coalescer + `ShouldRefreshFor`
- `Apps/Jobs/JobsApp.Hooks.cs`, `Apps/Jobs/JobsApp.cs` â€” signature gate + coalescer
- `Apps/DashboardApp.cs` â€” one shared coalescer for both signals
- `AppShell/NotificationBurstSummarizer.cs` (new), `AppShell/TendrilAppShell.cs` â€” burst summary

Tests (`src/Ivy.Tendril.Test`):

- `PlanDatabaseSyncServiceTests.cs` (+6), `PlanWatcherServiceTests.cs` (+1, 1 updated),
  `Agents/JobLogPathsTests.cs` (+3), `JobsAppRefreshGatingTests.cs` (+2, 2 updated),
  `Apps/ReviewContentViewRefreshTests.cs` (new, 6), `AppShell/AppShellNotificationTests.cs` (+8),
  `Services/JobServiceSettingsTests.cs` (+1), `FakePlanReaderService.cs` (settable `FlushTask`)

## Manual Testing

Not performed: reproducing the freeze needs the reporter's store (339 plan folders, 6607 job log
files) and a running desktop workspace, neither of which exists in this worktree. What was verified
instead:

- `dotnet format --verify-no-changes`, `dotnet build --warnaserror` (0 warnings, both projects), and
  the plan's test filter: 134 passed, 0 failed.
- The whole unit project: 3654 passed, 18 failed, all 18 reproduced on the base commit `4b00fee4` and
  unrelated to this plan (cost-CSV/question/revision expectations that trail production, plus three
  `ProjectSyncTests` that depend on the machine's `init.defaultBranch`). Detail in
  `Verification/DotnetTest.md`.
- The behaviours that need timing are covered deterministically rather than by hand: `TestScheduler`
  for the coalescer and the notification summarizer, `DrainAsync` plus the `SyncCount` seams for the
  sync worker, parallel `NotifyChanged` callers for the watcher race, and a never-completing flush
  task with a shortened timeout for the job-start bound.

Worth a look on the reporting machine once this ships: close three plans in a row and watch that the
workspace stays responsive, and confirm a batch of job exits produces one summary toast.

---

## Commits

- `1be2bc06` Plan 00408: Sync the plan database off the raising thread and in one batch
- `21c3988c` Plan 00408: Make PlanWatcherService burst-safe
- `a5740b29` Plan 00408: Coalesce the three uncoalesced refresh subscriptions
- `192010af` Bound the job-start plan write flush, for plan 00408
- `acdcb063` Summarize notification bursts in the shell, for plan 00408

---
Created using [Ivy Tendril](https://ivy.app).