### PR TITLE
[00424] Replace the UpdateMessage Flag Tail With an Options Record

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -38,7 +38,7 @@ public class DeleteSessionDialogTests
         {
             return new ChatMessageModel(Guid.NewGuid().ToString(), role, content, DateTimeOffset.UtcNow, agentId, modelId, rawStream, effort);
         }
-        public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true, bool markCompleted = false) => null;
+        public ChatMessageModel? UpdateMessage(string sessionId, string messageId, ChatMessageUpdate update) => null;
         public void FlushSession(string sessionId) { }
         public void SetSessionGenerating(string sessionId, bool isGenerating)
         {

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -356,7 +356,7 @@ public class ChatHistoryServiceTests
             var initialMsg = service.AddMessage(session.Id, "assistant", "initial content", "claude", "sonnet");
             Assert.NotNull(initialMsg);
 
-            var updatedMsg = service.UpdateMessage(session.Id, initialMsg.Id, "updated response", rawStream: "{\"kind\":\"text\",\"text\":\"updated response\"}");
+            var updatedMsg = service.UpdateMessage(session.Id, initialMsg.Id, new ChatMessageUpdate("updated response", RawStream: "{\"kind\":\"text\",\"text\":\"updated response\"}"));
             Assert.NotNull(updatedMsg);
             Assert.Equal("updated response", updatedMsg.Content);
             Assert.Equal("{\"kind\":\"text\",\"text\":\"updated response\"}", updatedMsg.RawStream);
@@ -396,7 +396,7 @@ public class ChatHistoryServiceTests
             Assert.Null(initialMsg.CompletedAt);
 
             var beforeUpdate = DateTimeOffset.UtcNow;
-            var updatedMsg = service.UpdateMessage(session.Id, initialMsg.Id, "final response", rawStream: "{\"kind\":\"result\"}", markCompleted: true);
+            var updatedMsg = service.UpdateMessage(session.Id, initialMsg.Id, new ChatMessageUpdate("final response", RawStream: "{\"kind\":\"result\"}", MarkCompleted: true));
             var afterUpdate = DateTimeOffset.UtcNow;
 
             Assert.NotNull(updatedMsg);
@@ -430,7 +430,7 @@ public class ChatHistoryServiceTests
             Assert.NotNull(initialMsg);
             Assert.Null(initialMsg.CompletedAt);
 
-            var updatedMsg = service.UpdateMessage(session.Id, initialMsg.Id, "streaming update", rawStream: "{\"kind\":\"text\",\"delta\":true}", flushImmediately: false, touchUpdatedAt: false);
+            var updatedMsg = service.UpdateMessage(session.Id, initialMsg.Id, new ChatMessageUpdate("streaming update", RawStream: "{\"kind\":\"text\",\"delta\":true}", FlushImmediately: false, TouchUpdatedAt: false));
             Assert.NotNull(updatedMsg);
             Assert.Null(updatedMsg.CompletedAt);
         }
@@ -451,12 +451,12 @@ public class ChatHistoryServiceTests
             var initialMsg = service.AddMessage(session.Id, "assistant", "initial content", "claude", "sonnet");
             Assert.NotNull(initialMsg);
 
-            var completedMsg = service.UpdateMessage(session.Id, initialMsg.Id, "completed response", rawStream: "{\"kind\":\"result\"}", markCompleted: true);
+            var completedMsg = service.UpdateMessage(session.Id, initialMsg.Id, new ChatMessageUpdate("completed response", RawStream: "{\"kind\":\"result\"}", MarkCompleted: true));
             Assert.NotNull(completedMsg);
             Assert.NotNull(completedMsg.CompletedAt);
             var originalCompletedAt = completedMsg.CompletedAt;
 
-            var laterMsg = service.UpdateMessage(session.Id, initialMsg.Id, "edit after completion", flushImmediately: false, touchUpdatedAt: false);
+            var laterMsg = service.UpdateMessage(session.Id, initialMsg.Id, new ChatMessageUpdate("edit after completion", FlushImmediately: false, TouchUpdatedAt: false));
             Assert.NotNull(laterMsg);
             Assert.NotNull(laterMsg.CompletedAt);
             Assert.Equal(originalCompletedAt, laterMsg.CompletedAt);
@@ -615,7 +615,7 @@ public class ChatHistoryServiceTests
             var frozenUpdatedAt = beforeUpdate.UpdatedAt.AddMinutes(-5);
             service.SaveSession(beforeUpdate with { UpdatedAt = frozenUpdatedAt });
 
-            service.UpdateMessage(session.Id, msg.Id, "streamed chunk", flushImmediately: true, touchUpdatedAt: false);
+            service.UpdateMessage(session.Id, msg.Id, new ChatMessageUpdate("streamed chunk", FlushImmediately: true, TouchUpdatedAt: false));
 
             var updatedSession = service.GetSession(session.Id);
             Assert.NotNull(updatedSession);
@@ -641,7 +641,7 @@ public class ChatHistoryServiceTests
             var staleUpdatedAt = beforeUpdate.UpdatedAt.AddMinutes(-5);
             service.SaveSession(beforeUpdate with { UpdatedAt = staleUpdatedAt });
 
-            service.UpdateMessage(session.Id, msg.Id, "final content");
+            service.UpdateMessage(session.Id, msg.Id, new ChatMessageUpdate("final content"));
 
             var updatedSession = service.GetSession(session.Id);
             Assert.NotNull(updatedSession);
@@ -671,7 +671,7 @@ public class ChatHistoryServiceTests
 
             for (var i = 0; i < 3; i++)
             {
-                service.UpdateMessage(sessionA.Id, msgA.Id, $"streamed chunk {i}", flushImmediately: true, touchUpdatedAt: false);
+                service.UpdateMessage(sessionA.Id, msgA.Id, new ChatMessageUpdate($"streamed chunk {i}", FlushImmediately: true, TouchUpdatedAt: false));
             }
 
             var order = service.GetSessions();
@@ -699,7 +699,7 @@ public class ChatHistoryServiceTests
             service.SaveSession(service.GetSession(sessionA.Id)! with { UpdatedAt = baseTime });
             service.SaveSession(service.GetSession(sessionB.Id)! with { UpdatedAt = baseTime.AddSeconds(1) });
 
-            service.UpdateMessage(sessionA.Id, msgA.Id, "final content");
+            service.UpdateMessage(sessionA.Id, msgA.Id, new ChatMessageUpdate("final content"));
 
             var order = service.GetSessions();
             Assert.Equal(sessionA.Id, order[0].Id);

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -182,7 +182,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                 }
                 if (!string.IsNullOrEmpty(exec.AssistantMessageId))
                 {
-                    _chatService.UpdateMessage(sessionId, exec.AssistantMessageId, currentText ?? string.Empty, currentRaw, flushImmediately: false, touchUpdatedAt: false);
+                    _chatService.UpdateMessage(sessionId, exec.AssistantMessageId, new ChatMessageUpdate(currentText ?? string.Empty, currentRaw, FlushImmediately: false, TouchUpdatedAt: false));
                 }
             }
         }
@@ -589,7 +589,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                                     currentText = activeExec.LastText;
                                     currentRaw = activeExec.RawLines.Count > 0 ? string.Join("\n", activeExec.RawLines) : null;
                                 }
-                                _chatService.UpdateMessage(sessionId, assistantMessageId, currentText ?? string.Empty, currentRaw, flushImmediately: false, touchUpdatedAt: false);
+                                _chatService.UpdateMessage(sessionId, assistantMessageId, new ChatMessageUpdate(currentText ?? string.Empty, currentRaw, FlushImmediately: false, TouchUpdatedAt: false));
                             }
                         }
                     }
@@ -635,7 +635,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                         ? (result.IsSuccess ? collectedText : $"{collectedText}\n\n{failureText}")
                         : (result.IsSuccess ? "Task completed successfully." : failureText);
 
-                _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true, markCompleted: true);
+                _chatService.UpdateMessage(sessionId, assistantMessageId, new ChatMessageUpdate(responseContent, fullRawStream, FlushImmediately: true, MarkCompleted: true));
             }
             catch (OperationCanceledException)
             {
@@ -686,7 +686,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                     ? $"{collectedText}\n\n{abortText}"
                     : abortText;
 
-                _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true, markCompleted: true);
+                _chatService.UpdateMessage(sessionId, assistantMessageId, new ChatMessageUpdate(responseContent, fullRawStream, FlushImmediately: true, MarkCompleted: true));
             }
             catch (Exception ex)
             {
@@ -734,7 +734,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                     ? $"{collectedText}\n\nError executing request: {ex.Message}"
                     : $"Error executing request: {ex.Message}";
 
-                _chatService.UpdateMessage(sessionId, assistantMessageId, responseContent, rawStream: fullRawStream, flushImmediately: true, markCompleted: true);
+                _chatService.UpdateMessage(sessionId, assistantMessageId, new ChatMessageUpdate(responseContent, fullRawStream, FlushImmediately: true, MarkCompleted: true));
             }
             finally
             {
@@ -1200,7 +1200,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                 ? collectedText
                 : (fallbackMessage ?? string.Empty);
 
-            _chatService.UpdateMessage(sessionId, exec.AssistantMessageId, content, rawStream: fullRawStream, flushImmediately: true);
+            _chatService.UpdateMessage(sessionId, exec.AssistantMessageId, new ChatMessageUpdate(content, fullRawStream, FlushImmediately: true));
         }
         catch (Exception ex)
         {

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -677,7 +677,7 @@ public class ChatHistoryService : IChatHistoryService
         return false;
     }
 
-    public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true, bool markCompleted = false)
+    public ChatMessageModel? UpdateMessage(string sessionId, string messageId, ChatMessageUpdate update)
     {
         if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(messageId)) return null;
 
@@ -695,9 +695,9 @@ public class ChatHistoryService : IChatHistoryService
             var existingMsg = session.Messages[msgIndex];
             updatedMsg = existingMsg with
             {
-                Content = content,
-                RawStream = rawStream ?? existingMsg.RawStream,
-                CompletedAt = markCompleted ? DateTimeOffset.UtcNow : existingMsg.CompletedAt
+                Content = update.Content,
+                RawStream = update.RawStream ?? existingMsg.RawStream,
+                CompletedAt = update.MarkCompleted ? DateTimeOffset.UtcNow : existingMsg.CompletedAt
             };
 
             var newMessages = new List<ChatMessageModel>(session.Messages);
@@ -705,7 +705,7 @@ public class ChatHistoryService : IChatHistoryService
 
             updatedSession = session with
             {
-                UpdatedAt = touchUpdatedAt ? DateTimeOffset.UtcNow : session.UpdatedAt,
+                UpdatedAt = update.TouchUpdatedAt ? DateTimeOffset.UtcNow : session.UpdatedAt,
                 Messages = newMessages
             };
 
@@ -714,7 +714,7 @@ public class ChatHistoryService : IChatHistoryService
 
         if (updatedSession != null)
         {
-            if (flushImmediately)
+            if (update.FlushImmediately)
             {
                 CancelPendingPersist(sessionId);
                 _lastPersistTimes[sessionId] = DateTimeOffset.UtcNow;

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -23,6 +23,14 @@ public record ChatMessageModel(
     DateTimeOffset? CompletedAt = null
 );
 
+public sealed record ChatMessageUpdate(
+    string Content,
+    string? RawStream = null,
+    bool FlushImmediately = true,
+    bool TouchUpdatedAt = true,
+    bool MarkCompleted = false
+);
+
 public record ChatSessionModel(
     string Id,
     string Title,
@@ -57,7 +65,7 @@ public interface IChatHistoryService
     void DeleteSession(string id);
     void RenameSession(string id, string newTitle);
     ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null, string? effort = null);
-    ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true, bool markCompleted = false);
+    ChatMessageModel? UpdateMessage(string sessionId, string messageId, ChatMessageUpdate update);
     void FlushSession(string sessionId);
     void SetSessionGenerating(string sessionId, bool isGenerating);
     void ClearAllGeneratingSessions();


### PR DESCRIPTION
﻿# Summary

## Changes

Replaced the tail of defaulted booleans on `IChatHistoryService.UpdateMessage` with a single
`ChatMessageUpdate` options record, so a future write-varying flag becomes a defaulted property on
that record instead of a parameter that has to be repeated in the interface, the implementation and
the hand-written test fake. All 15 call sites and both implementers were converted verbatim, so the
change is behaviour preserving.

The coordination ask this plan came from (a predicted merge conflict between plans 00410 and 00411 at
the `FakeChatHistoryService.UpdateMessage` stub) was verified already discharged before any code was
written: 00410 never touched that file, no flag was lost in either merge, and there was nothing to
repair. Details in `Verification/PreExecution.md` and `Verification/CheckResult.md`.

## API Changes

**Added**

- `public sealed record ChatMessageUpdate(string Content, string? RawStream = null, bool FlushImmediately = true, bool TouchUpdatedAt = true, bool MarkCompleted = false)` in `Ivy.Tendril.Services`.

**Changed (breaking)**

- `IChatHistoryService.UpdateMessage` and `ChatHistoryService.UpdateMessage`:
  - was `ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true, bool markCompleted = false)`
  - now `ChatMessageModel? UpdateMessage(string sessionId, string messageId, ChatMessageUpdate update)`
  - `sessionId` and `messageId` stay positional: they are required identity, not options. The record's
    defaults are copied from the old parameter defaults, so a caller that omitted a flag before gets
    the same behaviour now.

**Unchanged**

- `IChatHistoryService.AddMessage` keeps its four optional arguments. Folding those in as well was the
  wider option offered by the plan's `residue-scope` question and was deliberately not taken; filed as
  a recommendation instead.

## Files Modified

Production (`src/Ivy.Tendril/Services/`)

- `IChatHistoryService.cs` - added the `ChatMessageUpdate` record, narrowed the interface member.
- `ChatHistoryService.cs` - signature plus the five places that read the old parameters.
- `ChatExecutionService.cs` - six call sites.

Tests (`src/Ivy.Tendril.Test/`)

- `Apps/Chat/DeleteSessionDialogTests.cs` - the `FakeChatHistoryService` stub, now a one-line
  `=> null` that no longer tracks flag changes. This is the line the originating recommendation was
  worried about.
- `ChatHistoryServiceTests.cs` - nine call sites. Assertions untouched, which is the point: the six
  tests that pin the three defaults still pass unmodified.

No new tests. The plan specified none, because the three defaults this refactor could silently break
are already pinned by existing tests, all of which pass.

## Manual Testing

N/A - internal refactor with no user-facing behaviour. Every call site keeps the exact flag values it
had before, including `FlushExecution` at `ChatExecutionService.cs:1203`, which still does not set
`MarkCompleted`.

If you want to exercise it anyway: run the app, open a chat session, send a prompt, and confirm the
assistant turn still streams in place and then settles with a completion timestamp; then cancel a turn
mid-stream and confirm the partial text is still persisted. Both paths run through the converted call
sites.

---

## Commits

- 36871ad0 [00424] Replace the UpdateMessage flag tail with a ChatMessageUpdate record

---
Created using [Ivy Tendril](https://ivy.app).