### PR TITLE
[00425] Remove the Unused IAgentRunner Parameter From ChatLauncher

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatLauncherTests.cs
@@ -45,7 +45,7 @@ public class ChatLauncherTests
             var config = Config(ChatModes.Chat, tempDir);
             var chats = new ChatHistoryService(config);
 
-            var (app, args) = ChatLauncher.NewSessionTarget(config, chats, TestAgentRunner.Create());
+            var (app, args) = ChatLauncher.NewSessionTarget(config, chats);
 
             Assert.Equal(typeof(ChatApp), app);
             var chatArgs = Assert.IsType<ChatAppArgs>(args);
@@ -70,7 +70,7 @@ public class ChatLauncherTests
             var chats = new ChatHistoryService(config);
             var abandoned = chats.CreateSession("codex", "default", kind: ChatSessionKinds.Chat);
 
-            ChatLauncher.NewSessionTarget(config, chats, TestAgentRunner.Create());
+            ChatLauncher.NewSessionTarget(config, chats);
 
             Assert.Null(chats.GetSession(abandoned.Id));
         }
@@ -124,7 +124,7 @@ public class ChatLauncherTests
             var config = Config(ChatModes.Terminal, tempDir);
             var chats = new ChatHistoryService(config);
 
-            var (app, args) = ChatLauncher.NewSessionTarget(config, chats, TestAgentRunner.Create());
+            var (app, args) = ChatLauncher.NewSessionTarget(config, chats);
 
             Assert.Equal(typeof(AgentApp), app);
             var agentArgs = Assert.IsType<AgentAppArgs>(args);

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -948,7 +948,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             OpenApp(new NavigateArgs(AgentAppId, resumed != null ? new AgentAppArgs(SessionId: resumed) : null));
         }
 
-        void StartNewChat() => ChatLauncher.StartNew(navigator, config, chatService, agentRunner);
+        void StartNewChat() => ChatLauncher.StartNew(navigator, config, chatService);
 
         // Plan search is always reachable from the sidebar: apps without a list (and lists
         // with no rows) get the section's full-width Search button in place of the title.

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -126,7 +126,7 @@ public class AgentApp : ViewBase
                 sessionVersion.Set(v => v + 1);
             })
             .OnDeleteSession(id => deletingSessionId.Set(id))
-            .OnCreateSession(() => ChatLauncher.StartNew(navigator, configService, chatService, agentRunner))
+            .OnCreateSession(() => ChatLauncher.StartNew(navigator, configService, chatService))
             .OnReviewJobs(() => ptyHandle.HandleInput(ReviewJobsPrompt + "\r"))
             .OnOpenPlan(planId =>
             {

--- a/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatLauncher.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Services;
 
@@ -19,11 +18,8 @@ internal static class ChatLauncher
         navigator.Navigate(app, args);
     }
 
-    // runner is unused now that neither mode creates a session here, but it stays in the signature
-    // so the call sites and their tests keep compiling.
-    public static (Type App, object? Args) NewSessionTarget(IConfigService config, IChatHistoryService chats, IAgentRunner runner)
+    public static (Type App, object? Args) NewSessionTarget(IConfigService config, IChatHistoryService chats)
     {
-        _ = runner;
         if (UsesTerminal(config)) return (typeof(AgentApp), new AgentAppArgs());
 
         // Both modes defer creation: the chat page creates its session when the first message is
@@ -32,9 +28,9 @@ internal static class ChatLauncher
         return (typeof(ChatApp), new ChatAppArgs(NewChat: true));
     }
 
-    public static void StartNew(INavigator navigator, IConfigService config, IChatHistoryService chats, IAgentRunner runner)
+    public static void StartNew(INavigator navigator, IConfigService config, IChatHistoryService chats)
     {
-        var (app, args) = NewSessionTarget(config, chats, runner);
+        var (app, args) = NewSessionTarget(config, chats);
         navigator.Navigate(app, args);
     }
 


### PR DESCRIPTION
﻿# Remove the Unused IAgentRunner Parameter From ChatLauncher

Plan 00425, job 01971. Branch `tendril/00425-RemoveTheUnusedIAgentRun`, one commit `f9cb445b` on base
`2e6b507f`. Four files, +8 / -12. No behaviour change.

## What changed

Plan 00410 stopped `ChatLauncher.NewSessionTarget` from creating a chat session, which left its
`IAgentRunner runner` parameter unused, kept alive only by a `_ = runner;` discard and a comment
explaining that the parameter existed so call sites would keep compiling. This removes it.

- **`ChatLauncher.cs`**: `IAgentRunner runner` dropped from `NewSessionTarget` and from `StartNew`, along
  with the discard, the two-line comment that justified the parameter, and the now-unneeded
  `using Ivy.Tendril.Agents.Abstractions;`. `IAgentRunner` was the only name the file took from that
  namespace, so the file now has zero references to either. `chats` and the `PruneEmptySessions()` call
  stay; the comment explaining deferred creation stays, because it is still true.
- **`AgentApp.cs:129`** and **`TendrilAppShell.cs:951`**: the argument comes off the `StartNew` call.
- **`ChatLauncherTests.cs`** lines 48, 73, 127: the third argument comes off. Assertions untouched.

## The plan's open question, answered

The plan asked whether `agentRunner` could be dropped from the two callers entirely. **No.** It has 12
live references across those two files: `GetCommandLine`, `AgentLaunchHelper.GetWorkDir` /
`GetActivityPatterns` / `ResolveModel`, `AgentBranding.For` in `AgentApp`, and `BuildMenuItems` plus
`AgentBranding.For` in `TendrilAppShell`. Neither `UseService<IAgentRunner>()` was touched.
`src/Ivy.Tendril.Test/TestAgentRunner.cs` also stays: roughly 60 other call sites depend on it.

## Verification

| Check | Status |
|---|---|
| PreExecution | Pass |
| DotnetFormat | Pass |
| DotnetBuild | Pass |
| DotnetTest | Pass |
| CheckResult | Pass |

`--warnaserror` build clean across all four `Ivy.Tendril*` test projects, 0 warnings / 0 errors. Tests
7/7 on the plan's `ChatLauncherTests` filter and 67/67 on a widened Chat / Agent / AgentLaunchHelper /
AgentBranding scope. `dotnet format --verify-no-changes` clean on both owning projects. The build is the
real gate here: a missed call site on a signature change is a compile error, not a test failure, and
`ChatLauncher` is `internal static` with `InternalsVisibleTo` granted only to `Ivy.Tendril.Test`, so
those two assemblies are the complete consumer set. The post-edit caller audit found nothing left
passing a third argument.

## Things a reviewer should know

**The plan's commands do not run as written.** Every one targets `src/Ivy.Tendril/Ivy.Tendril.slnx`, which
cannot be restored from a worktree: it unconditionally lists `../../../Ivy-Framework` projects that do not
exist beside a worktree, so restore dies with `MSB3202`. Each `.csproj` was named explicitly instead. No
reference path was edited, no symlink created. Known issue, Pending on plan 00046.

**Worktree builds compile against the pinned `Ivy` NuGet package, not Ivy-Framework sources** (in a
worktree `Directory.Build.props` resolves `IvySource=false`, unlike the main checkout and CI). A green
worktree build is not proof of a green CI build. For a signature change to an `internal` type the risk is
negligible, but CI is the authority.

**Two projects were excluded from the build, with cause and neither able to observe this change:**
`Ivy.Tendril.Widgets.Samples` (already red under `--warnaserror` with IVYHOOK errors, Pending on plan
00407, does not reference `Ivy.Tendril`) and `Ivy.Tendril.Docs` (cannot build in any worktree, Pending on
plan 00046).

**The full test suite was not run.** `Ivy.Tendril.Test` is known red on `development` with 18 pre-existing
failures unrelated to `ChatLauncher` (Pending on plan 00407). Scope was widened to 67 tests around the
touched surface instead of running a suite whose baseline is red.

**A rebase was made and then undone.** `origin/development` advanced from `2e6b507f` to `9a146b71`
mid-run (9 commits, plans 00415 and 00417, no overlap with these four files). The branch was rebased onto
it, which orphaned the already-recorded `f9cb445b`, and since `tendril plan` has no `remove-commit` the
rebase was discarded and the branch reset back. `plan.yaml` records one commit, it is reachable, and it is
the branch tip. The detour produced one useful measurement, kept in the reports: build and the 67-test
scope are green at both bases, which matters because plan 00417 changed `ChatHistoryService`
session-persistence next to the `PruneEmptySessions()` call this code still makes.

**The base then moved again, to 18 ahead, and this time one commit overlaps.** Plan 00408 (`acdcb063`,
PR #2615) edits `TendrilAppShell.cs`, one of these four files. The risk that matters is a new
`ChatLauncher.StartNew` caller landing upstream while this branch removes the parameter, which no single
side would catch; it was checked and did not happen. `git grep` at `origin/development` returns the same
six sites, all still 4-argument, with `StartNewChat` merely shifted from line 951 to 975.
`git merge-tree --write-tree` reports the merge clean, and the merged tree was inspected: every call site
is 3-argument and `ChatLauncher.cs` has zero `IAgentRunner` references. No merge commit was created. The
merged tree was verified by probe rather than compiled, so PR CI closes that last gap. Details in
`Verification/CheckResult.md` under "Correction".

**The Tendril server was absent for this whole job** (`.master` missing), so no status was reportable and
`Jobs\01971-00425-ExecutePlan.md` is still its one-line launch stub. Plan state is derived server-side, so
00425 will stay in `Executing` with four `Pass` verification rows until something moves it.
Recommendation filed.

## Recommendations filed

1. Add `tendril plan remove-commit` as the repair half of `add-commit` (Small).
2. Investigate the Tendril server vanishing mid-job and leaving the job log at its launch stub (Medium).

---

## Commits

- `f9cb445b` Remove the unused IAgentRunner parameter from ChatLauncher (plan 00425)

---
Created using [Ivy Tendril](https://ivy.app).