### PR TITLE
[00426] Adopt ResolveIssueUrl at the Inline Issue Url Derivation Sites

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/InboxAppTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/InboxAppTests.cs
@@ -381,6 +381,65 @@ public class InboxAppTests
         Assert.Equal(initialToken, refreshToken.Token);
     }
 
+    [Fact]
+    public void IssueUrlDerivation_LivesOnlyInResolveIssueUrl()
+    {
+        var repoRoot = FindRepoRoot();
+        var productionDir = Path.Combine(repoRoot, "src", "Ivy.Tendril");
+
+        // This test file lives under src/Ivy.Tendril.Test, which is a sibling of the scanned
+        // directory, so the needles below cannot match the guard itself.
+        const string interpolatedGithubPrefix = "$\"https://github.com/{";
+        const string issuePathSegment = "/issues/{";
+
+        var hits = new List<string>();
+
+        var csFiles = Directory.EnumerateFiles(productionDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar) &&
+                        !f.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar));
+
+        foreach (var file in csFiles)
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].Contains(interpolatedGithubPrefix, StringComparison.Ordinal) &&
+                    lines[i].Contains(issuePathSegment, StringComparison.Ordinal))
+                {
+                    hits.Add($"{Path.GetRelativePath(repoRoot, file)}:{i + 1}");
+                }
+            }
+        }
+
+        var expectedFile = Path.Combine("src", "Ivy.Tendril", "Apps", "Inbox", "InboxApp.cs");
+
+        Assert.True(
+            hits.Count == 1,
+            $"Expected exactly one inline GitHub issue url derivation in {expectedFile} (the body of " +
+            $"InboxApp.ResolveIssueUrl), but found {hits.Count}: {string.Join(", ", hits)}. Call " +
+            "InboxApp.ResolveIssueUrl(issue) instead of spelling out the issue.Url fallback inline.");
+
+        Assert.True(
+            hits[0].StartsWith(expectedFile + ":", StringComparison.Ordinal),
+            $"The single inline GitHub issue url derivation should be the body of " +
+            $"InboxApp.ResolveIssueUrl in {expectedFile}, but it was found at {hits[0]}.");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "src", "Ivy.Tendril", "Ivy.Tendril.slnx")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate the repository root from the test base directory.");
+    }
+
     private sealed class StubGithubService(ProjectConfig? projectToReturn = null) : IGithubService
     {
         public int MyAssignedIssuesCallCount { get; private set; }

--- a/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
@@ -124,9 +124,7 @@ public class ContentView(
         {
             if (!isOpen.Value || issue == null) return null;
 
-            var issueUrl = issue.Url ?? (issue.Repository != null
-                ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
-                : null);
+            var issueUrl = InboxApp.ResolveIssueUrl(issue);
 
             var sheetHeader = Layout.Vertical().Width(Size.Full())
                 | (Layout.Horizontal().Height(Size.Auto()).AlignContent(Align.SpaceBetween).Width(Size.Full())
@@ -619,9 +617,7 @@ public class IssuesTableView(
                         }
                         else if (tag == "open-github")
                         {
-                            var url = raw.Url ?? (raw.Repository != null
-                                ? $"https://github.com/{raw.Repository}/issues/{raw.Number}"
-                                : null);
+                            var url = InboxApp.ResolveIssueUrl(raw);
                             if (url != null) client.OpenUrl(url);
                         }
                     }

--- a/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
@@ -172,9 +172,7 @@ public class InboxApp : ViewBase
                         ? selectedProject.Value
                         : (issue.Repository != null ? githubService.FindProjectForGithubRepo(issue.Repository)?.Name : null) ?? "Auto";
 
-                    var issueUrl = issue.Url ?? (issue.Repository != null
-                        ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
-                        : "");
+                    var issueUrl = ResolveIssueUrl(issue) ?? "";
 
                     var content = $"""
                                    ---

--- a/src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs
+++ b/src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs
@@ -124,9 +124,7 @@ public class AssignedIssuesAutoImportService : IStartable, IDisposable
                 }
 
                 // 3. Check if an existing plan already references this issue URL or issue
-                var issueUrl = issue.Url ?? (issue.Repository != null
-                    ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
-                    : null);
+                var issueUrl = InboxApp.ResolveIssueUrl(issue);
 
                 var hasExistingPlan = existingPlans.Any(p =>
                 {
@@ -161,9 +159,7 @@ public class AssignedIssuesAutoImportService : IStartable, IDisposable
                 var fileName = $"{issue.Number}-{safeName}.md";
                 var filePath = Path.Combine(inboxPath, fileName);
 
-                var resolvedUrl = issue.Url ?? (issue.Repository != null
-                    ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
-                    : "");
+                var resolvedUrl = InboxApp.ResolveIssueUrl(issue) ?? "";
 
                 var content = $"""
                                ---


### PR DESCRIPTION
# Summary

## Changes

Replaced all five inline copies of the `issue.Url ?? "https://github.com/{Repository}/issues/{Number}"`
fallback with calls to the existing `InboxApp.ResolveIssueUrl` helper: three in `Apps/Inbox/` (the detail
sheet header, the row action `open-github` branch, the fire-off file writer) and two in
`Services/Inbox/AssignedIssuesAutoImportService.cs` that the originating recommendation had missed. The
two file writers keep an explicit `?? ""` so the `string.IsNullOrEmpty` branch below each of them behaves
identically, including for a non-null but empty `issue.Url`. A guard test now asserts the literal survives
in exactly one place, the body of `ResolveIssueUrl`.

## API Changes

None. `InboxApp.ResolveIssueUrl(GitHubIssue)` already existed and is unchanged; this plan only adds call
sites. No signatures, types, endpoints, CLI commands or config keys changed.

## Files Modified

**Production (behaviour preserving)**
- `src/Ivy.Tendril/Apps/Inbox/ContentView.cs` - detail sheet header `issueUrl`, row action `open-github` `url`
- `src/Ivy.Tendril/Apps/Inbox/InboxApp.cs` - fire-off inbox file writer `issueUrl` (local, unqualified call)
- `src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs` - existing-plan match `issueUrl`, auto-import writer `resolvedUrl`

**Tests**
- `src/Ivy.Tendril.Test/Apps/InboxAppTests.cs` - adds `IssueUrlDerivation_LivesOnlyInResolveIssueUrl` and a local `FindRepoRoot()`

## Manual Testing

The change is behaviour preserving, so the point of the manual pass is to confirm nothing moved.

1. Run the app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Open the **Inbox** app with GitHub issues loaded (My Issues or a project category).
3. On an issue row, open the row menu and click **Open on GitHub**. The correct issue page should open,
   the same as before, both for an issue whose `url` came back from `gh` and for one where it did not.
4. Click **View details** on a row. The sheet header's **GitHub** button should be present and point at the
   issue, and should be absent for an issue with neither a url nor a repository.
5. Select an issue and click **Fire off**. Open the written file under `$TENDRIL_HOME/Inbox/`: the first
   body line should still be `[GitHub Issue #N](url)` when a url resolves, and `# Issue #N: Title` when
   none does.
6. If assigned-issue auto-import is enabled in Settings, let a sync run and check a newly written inbox
   file has the same first line, and that re-running does not re-import an issue an existing plan already
   references.

Automated coverage: `dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~Ivy.Tendril.Test.Apps.InboxAppTests|FullyQualifiedName~Ivy.Tendril.Test.Apps.InboxChatPromptTests|FullyQualifiedName~Ivy.Tendril.Test.Services.Inbox.AssignedIssuesAutoImportServiceTests"` (45 passed).

---
## Commits

- 99045f70 [00426] Guard against the inline issue url derivation coming back
- 293400be [00426] Use InboxApp.ResolveIssueUrl at the five inline derivation sites

---
Created using [Ivy Tendril](https://ivy.app).