### PR TITLE
[00436] Remove the Hidden LastOutputTimestamp Column From the Jobs Table

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs
@@ -16,7 +16,6 @@ public class JobsTableColumnLabelTests
         { nameof(JobItemRow.Timer), "Timer" },
         { nameof(JobItemRow.Timestamp), "Timestamp" },
         { nameof(JobItemRow.AgentOutput), "Agent Output" },
-        { nameof(JobItemRow.LastOutputTimestamp), "Last Output Timestamp" },
         { nameof(JobItemRow.Cost), "Cost" },
         { nameof(JobItemRow.Tokens), "Tokens" },
         { nameof(JobItemRow.StatusMessage), "Status Message" },

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -31,7 +31,6 @@ public partial class JobsApp
                 Cost = FormatJobCost(j),
                 Tokens = j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : "",
                 AgentOutput = JobsApp.FormatAgentOutput(j),
-                LastOutputTimestamp = j.LastOutputAt,
                 StatusMessage = JobsApp.GetStatusMessage(j),
                 ErrorContext = j.Status is JobStatus.Failed or JobStatus.Timeout
                     ? JobsApp.GetErrorContext(j)

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -98,10 +98,8 @@ public partial class JobsApp
             .Renderer(t => t.Prompt, new TextDisplayRenderer())
             .Renderer(t => t.StatusMessage, new TextDisplayRenderer())
             .Hidden(t => t.Id)
-            .Hidden(t => t.LastOutputTimestamp)
             .Hidden(t => t.ErrorContext)
             .Filterable(t => t.Id, false)
-            .Filterable(t => t.LastOutputTimestamp, false)
             .Filterable(t => t.ErrorContext, false)
             .SortDirection(t => t.Id, SortDirection.Descending)
             .Config(c =>

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -365,7 +365,6 @@ public record JobItemRow
     /// </summary>
     public string Timestamp { get; init; } = "";
     public string AgentOutput { get; init; } = "";
-    public DateTime? LastOutputTimestamp { get; init; }
     public string Cost { get; init; } = "";
     public string Tokens { get; init; } = "";
     public string StatusMessage { get; init; } = "";


### PR DESCRIPTION
# Summary

## Changes

Removed `JobItemRow.LastOutputTimestamp`, a `DateTime?` that was hidden and unfilterable in the Jobs data
table and read by nothing. The information it carried (`JobItem.LastOutputAt`) already reaches the user
as elapsed-since-last-output through the visible Agent Output column, so the removal costs no
information. Five deletions across four files, no replacements.

The plan's optional question `last-output-column-fate` was unanswered, so its `recommended` option
(remove, rather than surface it as a real column) was taken.

## API Changes

- **Removed:** `Ivy.Tendril.Models.JobItemRow.LastOutputTimestamp` (`DateTime?`). `JobItemRow` is now
  all-`string` apart from the nullable `ErrorContext`.
- **Unchanged:** `JobItem.LastOutputAt` stays exactly as it was. It remains the stale-output anchor for
  the job watchdog and the input to `FormatAgentOutput`.

## Files Modified

**Model**
- `src/Ivy.Tendril/Models/JobModels.cs` - deleted the `LastOutputTimestamp` property.

**Jobs app**
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs` - dropped the `LastOutputTimestamp = j.LastOutputAt`
  initializer from `BuildJobRows`.
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs` - dropped the `.Hidden(...)` and
  `.Filterable(..., false)` lines for the column.

**Tests**
- `src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs` - dropped the `ExpectedLabels` entry the
  label guard forced. The guard itself is unchanged and is what proves the removal is consistent.

## Manual Testing

The change has no user-visible surface of its own, but it is worth confirming nothing regressed in the
table it touches:

1. Run the app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`.
2. Open the **Jobs** app.
3. Confirm the table renders with the same visible columns as before (Status, Plan Id, Prompt, Type,
   Project, Timer, Timestamp, Agent Output, Cost, Tokens, Status Message) and that the **Agent Output**
   column still shows elapsed-since-last-output for a running job, updating live.
4. Open the column filter dropdown and confirm no "Last Output Timestamp" entry appears (it never did:
   the column was hidden and explicitly non-filterable, which is what made it dead weight).

---

## Commits

- 57844506 Remove the hidden LastOutputTimestamp column from the Jobs table (plan 00436)

---
Created using [Ivy Tendril](https://ivy.app).