### PR TITLE
[00428] Hoist Ivy Hooks to the Top of Build in Widget Samples

### DIFF
--- a/src/Ivy.Tendril.Widgets/.samples/Apps/PlanWorkspace/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/PlanWorkspace/DemoApp.cs
@@ -96,6 +96,9 @@ class DemoApp : ViewBase
         var buildChecked = UseState(true);
         var testChecked = UseState(false);
         var lintChecked = UseState(true);
+        var planDraft = UseState(Plan);
+        var screenshotChecked = UseState(true);
+        var checkResultsChecked = UseState(true);
 
         UseEffect(() =>
         {
@@ -161,7 +164,7 @@ class DemoApp : ViewBase
         {
             "plan" when editing.Value => Layout.Vertical().Scroll(Scroll.Vertical).Width(Size.Full()).Height(Size.Full())
                 | (Layout.Vertical().Padding(8, 6, 8, 4).Width(Size.Full().Max(Size.Units(200)))
-                    | UseState(Plan).ToCodeInput().Language(Languages.Markdown).Width(Size.Full())),
+                    | planDraft.ToCodeInput().Language(Languages.Markdown).Width(Size.Full())),
             "plan" => new PlanMarkdown(Plan)
                 .Article()
                 .Height(Size.Full())
@@ -184,10 +187,10 @@ class DemoApp : ViewBase
             | lintChecked.ToBoolInput("Lint")
             | testChecked.ToBoolInput("Test").Invalid("This verification is required according to project settings")
             | (Layout.Horizontal().Gap(2).Width(Size.Full())
-                | UseState(true).ToBoolInput("Screenshot", true)
+                | screenshotChecked.ToBoolInput("Screenshot", true)
                 | new Badge("Pass").Variant(BadgeVariant.Success))
             | (Layout.Horizontal().Gap(2).Width(Size.Full())
-                | UseState(true).ToBoolInput("CheckResults", true)
+                | checkResultsChecked.ToBoolInput("CheckResults", true)
                 | new Badge("Fail").Variant(BadgeVariant.Destructive));
 
         var questions = Layout.Vertical().Gap(2).Width(Size.Full())

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/WebViewer/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/WebViewer/DemoApp.cs
@@ -13,13 +13,13 @@ namespace WidgetSamples.Apps.WebViewer;
 [App(title: "Inspector", icon: Icons.Globe, group: ["WebViewer"])]
 public class DemoApp : ViewBase
 {
+    private const string Home = "https://ivy.app";
+
     public override object Build()
     {
-        const string home = "https://ivy.app";
-
         var commands = UseStream<WebViewerCommand>();
-        var address = UseState(home);   // editable address-bar text
-        var currentUrl = UseState(home); // value bound to the widget's Url prop
+        var address = UseState(Home);   // editable address-bar text
+        var currentUrl = UseState(Home); // value bound to the widget's Url prop
         var device = UseState(WebViewerDevice.Desktop);
         var events = UseState(ImmutableList<WebViewerEvent>.Empty);
         // Comments are the one event stream that is not append-only: a pin can be edited or

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/WebViewer/SideBySideApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/WebViewer/SideBySideApp.cs
@@ -24,12 +24,12 @@ public class SideBySideApp : ViewBase
 {
     private record Pin(string Id, int Number, string Comment);
 
+    private const string Home = "https://ivy.app";
+
     public override object Build()
     {
-        const string home = "https://ivy.app";
-
-        var address = UseState(home);
-        var url = UseState(home);
+        var address = UseState(Home);
+        var url = UseState(Home);
 
         var leftCommands = UseStream<WebViewerCommand>();
         var leftPins = UseState(ImmutableList<Pin>.Empty);

--- a/src/Ivy.Tendril.Widgets/.samples/Ivy.Tendril.Widgets.Samples.csproj
+++ b/src/Ivy.Tendril.Widgets/.samples/Ivy.Tendril.Widgets.Samples.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>WidgetSamples</RootNamespace>
-    <IvySource>true</IvySource>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ivy.Tendril.Widgets.csproj" />


### PR DESCRIPTION
# Hoist Ivy Hooks to the Top of Build in Widget Samples

`backend-checks.yml` builds with `--warnaserror`, and `Ivy.Tendril.Widgets.Samples` was emitting 29
`IVYHOOK005`/`IVYHOOK007` diagnostics, so the workflow could not go green. All 29 came from three demo
apps. They are now gone, without suppressing anything.

## What changed

**Both WebViewer samples** declared `const string home = "https://ivy.app";` as the first statement of
`Build()`, ahead of the hooks. A statement before the hook block is exactly what IVYHOOK005 objects to,
so the constant moved out of the method and became a class-level `private const string Home`. That alone
cleared 23 of the 29.

**`PlanWorkspace/DemoApp.cs`** called `UseState` in three places away from the top block. Two were in the
`verifications` layout expression: late, but unconditional. The third, at line 164, was inside a `switch`
arm gated on `editing.Value`. Ivy hooks are positional, so a hook that runs on some renders and not
others shifts every hook declared after it. That one was a real defect and IVYHOOK007 was right about it;
the analyser was not being pedantic. All three are now `planDraft`, `screenshotChecked` and
`checkResultsChecked` in the top block, read at their original sites.

**The samples csproj** carried `<IvySource>true</IvySource>`, which `src/Directory.Build.props:7`
overrides to false whenever `GITHUB_ACTIONS=true`. It never had an effect in CI, and it has none in a
worktree either, so it went.

Four files, +14/-12, three commits.

## Evidence

`0 Warning(s) 0 Error(s)` in Release with `--warnaserror`, measured with `--no-incremental
-p:UseSharedCompilation=false` because an up-to-date build reports zero warnings without compiling
anything. 29 → 0, and no warning traded for a new unused-value one.

`dotnet format --verify-no-changes` exits 0, both project-wide and scoped to just the three changed files.

`Ivy.Tendril.Test` gives `Failed: 23, Passed: 3664, Skipped: 1, Total: 3688` on the branch and the
**identical line** on clean `development`, with the same 23 names compared as sorted sets. The matching
`Passed` and `Total` is the part that rules out a regression. `Ivy.Tendril.Agents.Test` is green outright
(1144/1144).

The Playwright suite required installing node modules and Chromium 1223 first; it is not routinely run
here. `web-viewer/inspector.spec.ts` is the one spec covering a changed file, and it covers the changed
line: 5/5 pass, including `no page errors on load`. The rest of the suite is inherited red and
reproduced identically on `development`: `draft-markdown/questions.spec.ts` does not even parse (unescaped
quotes at lines 97 and 100, which fails the entire run because Playwright loads all specs first), plus
nine `draft-markdown` failures. 29 passed / 9 failed on both sides.

## One claim left unsettled

The plan predicted a visible consequence, that the Plan tab's code editor now keeps its content across a
tab switch. A throwaway probe (written, run, deleted) showed the editor renders, accepts input and raises
no page errors, but it could not drive the tab strip: `aria-selected` never moved across either click, so
the probe passed on `development` too and discriminates nothing. Reported as unverified rather than
dressed up as a pass. The analyser is the plan's real assertion and it is silent.

## Worth knowing next time

`src/Ivy.Tendril/Ivy.Tendril.slnx` references `../../../Ivy-Framework/...` and cannot be restored from a
worktree, so the plan's build command had to become per-csproj builds. That is closer to CI, not further
from it: with no sibling checkout the worktree resolves Ivy from the 1.4.0 NuGet package, which is what
`GITHUB_ACTIONS=true` forces anyway.


---

## Commits

- `b76ddbf9` Drop the inert IvySource property from the samples csproj (plan 00428)
- `8439aebe` Hoist the PlanWorkspace demo's inline UseState calls into locals (plan 00428)
- `137844f6` Promote the WebViewer samples' home URL to a class constant (plan 00428)

---
Created using [Ivy Tendril](https://ivy.app).