### PR TITLE
[00450] Treat an Empty Issue Url as Absent in ResolveIssueUrl

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/InboxChatPromptTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/InboxChatPromptTests.cs
@@ -134,4 +134,29 @@ public class InboxChatPromptTests
 
         Assert.Null(InboxApp.ResolveIssueUrl(Issue(repository: null, url: null)));
     }
+
+    [Fact]
+    public void ResolveIssueUrl_TreatsBlankUrlAndRepositoryAsAbsent()
+    {
+        Assert.Equal(
+            "https://github.com/acme/widgets/issues/12",
+            InboxApp.ResolveIssueUrl(Issue(number: 12, repository: "acme/widgets", url: "")));
+
+        Assert.Equal(
+            "https://github.com/acme/widgets/issues/12",
+            InboxApp.ResolveIssueUrl(Issue(number: 12, repository: "acme/widgets", url: "   ")));
+
+        Assert.Null(InboxApp.ResolveIssueUrl(Issue(repository: "", url: "")));
+        Assert.Null(InboxApp.ResolveIssueUrl(Issue(repository: "   ", url: "")));
+        Assert.Null(InboxApp.ResolveIssueUrl(Issue(repository: null, url: "")));
+    }
+
+    [Fact]
+    public void Build_BlankUrl_DerivesUrlLineInsteadOfEmittingABareLabel()
+    {
+        var prompt = InboxChatPrompt.Build([Issue(url: "")]);
+
+        Assert.Contains("URL: https://github.com/owner/repo/issues/4766", prompt);
+        Assert.DoesNotContain("URL: \n", prompt);
+    }
 }

--- a/src/Ivy.Tendril.Test/Services/Inbox/AssignedIssuesAutoImportServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/Inbox/AssignedIssuesAutoImportServiceTests.cs
@@ -95,6 +95,34 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RunSyncAsync_WithBlankIssueUrl_WritesDerivedLink()
+    {
+        var config = CreateConfigService(autoAccept: true);
+        var github = new TestGithubService
+        {
+            IssuesToReturn =
+            [
+                new GitHubIssue(101, "Fix login bug", "Login fails with 500 error", ["bug"], ["user1"], "owner/repo", "")
+            ]
+        };
+        var planReader = new FakePlanReaderService();
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, new FakeQueryService());
+
+        await service.RunSyncAsync();
+
+        var inboxPath = Path.Combine(_tempDir.Path, "Inbox");
+        var files = Directory.GetFiles(inboxPath, "101-*.md");
+        Assert.Single(files);
+
+        var content = await File.ReadAllTextAsync(files[0]);
+        Assert.Contains("[GitHub Issue #101](https://github.com/owner/repo/issues/101)", content);
+        Assert.DoesNotContain("# Issue #101:", content);
+    }
+
+    [Fact]
     public async Task RunSyncAsync_ResolvesProjectOrDefaultsToAuto()
     {
         var config = CreateConfigService(autoAccept: true);
@@ -227,6 +255,60 @@ public class AssignedIssuesAutoImportServiceTests : IDisposable
 
         var files402 = Directory.GetFiles(inboxPath, "402-*.md");
         Assert.Single(files402);
+    }
+
+    [Fact]
+    public async Task RunSyncAsync_WithBlankIssueUrl_StillSkipsPlannedIssues()
+    {
+        var config = CreateConfigService(autoAccept: true);
+
+        var existingPlan = new PlanFile(
+            new PlanMetadata(
+                Id: 1,
+                Project: "Test",
+                Level: "Feature",
+                Title: "Already Planned",
+                State: PlanStatus.Draft,
+                Repos: [],
+                Commits: [],
+                Prs: [],
+                Verifications: [],
+                RelatedPlans: [],
+                DependsOn: [],
+                Created: DateTime.UtcNow,
+                Updated: DateTime.UtcNow,
+                InitialPrompt: null,
+                SourceUrl: "https://github.com/owner/repo/issues/401"
+            ),
+            "",
+            Path.Combine(_tempDir.Path, "Plans", "00001-AlreadyPlanned"),
+            ""
+        );
+
+        var planReader = new FakePlanReaderService
+        {
+            Plans = [existingPlan]
+        };
+
+        var github = new TestGithubService
+        {
+            IssuesToReturn =
+            [
+                new GitHubIssue(401, "Planned issue", "Body 401", [], ["user1"], "owner/repo", ""),
+                new GitHubIssue(402, "Unplanned issue", "Body 402", [], ["user1"], "owner/repo", "")
+            ]
+        };
+
+        var jobService = new TestJobService();
+        var logger = NullLogger<AssignedIssuesAutoImportService>.Instance;
+
+        var service = new AssignedIssuesAutoImportService(config, github, planReader, jobService, logger, new FakeQueryService());
+
+        await service.RunSyncAsync();
+
+        var inboxPath = Path.Combine(_tempDir.Path, "Inbox");
+        Assert.Empty(Directory.GetFiles(inboxPath, "401-*.md"));
+        Assert.Single(Directory.GetFiles(inboxPath, "402-*.md"));
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
@@ -295,9 +295,11 @@ public class InboxApp : ViewBase
     }
 
     public static string? ResolveIssueUrl(GitHubIssue issue) =>
-        issue.Url ?? (issue.Repository != null
-            ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
-            : null);
+        !string.IsNullOrWhiteSpace(issue.Url)
+            ? issue.Url
+            : (!string.IsNullOrWhiteSpace(issue.Repository)
+                ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
+                : null);
 
     public static string TruncateBody(string? body, int maxLength = 500)
     {


### PR DESCRIPTION
# Summary

## Changes

`InboxApp.ResolveIssueUrl` now treats a blank (empty or whitespace) `Url` and a blank `Repository` as
absent instead of only `null`. A blank url no longer short-circuits the
`https://github.com/{Repository}/issues/{Number}` derivation, and a blank repository no longer derives
the nonsense url `https://github.com//issues/N` - the helper returns `null` when both are blank. All
five call sites are fixed by this single change; none of them needed editing.

## API Changes

`InboxApp.ResolveIssueUrl(GitHubIssue)` - signature unchanged, **behaviour changed**:

| Input | Before | After |
| --- | --- | --- |
| `Url = ""`, `Repository = "acme/widgets"`, `Number = 12` | `""` | `"https://github.com/acme/widgets/issues/12"` |
| `Url = "   "`, `Repository = "acme/widgets"` | `"   "` | `"https://github.com/acme/widgets/issues/12"` |
| `Url = ""`, `Repository = ""` | `"https://github.com//issues/12"` | `null` |
| `Url = ""`, `Repository = null` | `""` | `null` |

No other public API changed.

## Files Modified

Production:

- `src/Ivy.Tendril/Apps/Inbox/InboxApp.cs` - the `ResolveIssueUrl` body (the only production change).

Tests:

- `src/Ivy.Tendril.Test/Apps/InboxChatPromptTests.cs` - `ResolveIssueUrl_TreatsBlankUrlAndRepositoryAsAbsent`
  covers the helper directly; `Build_BlankUrl_DerivesUrlLineInsteadOfEmittingABareLabel` covers the
  chat-prompt caller no longer emitting a bare `URL: ` line.
- `src/Ivy.Tendril.Test/Services/Inbox/AssignedIssuesAutoImportServiceTests.cs` -
  `RunSyncAsync_WithBlankIssueUrl_WritesDerivedLink` covers the auto-import writer now writing a link
  instead of a plain heading; `RunSyncAsync_WithBlankIssueUrl_StillSkipsPlannedIssues` covers
  de-duplication still matching an existing plan by url.

Deliberately untouched, per the plan: the parse at `src/Ivy.Tendril/Services/Git/GithubService.cs:177`,
and the two `?? ""` writer lines that the `BuildInboxFileContent` extraction (plan 00426's first
accepted recommendation) will own.

## Manual Testing

The trigger is a GitHub issue whose `url` comes back blank from `gh`, which you cannot easily produce
on demand, so the observable behaviour is best driven from the chat-prompt path:

1. Run the app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Open the **Inbox** app and select one or more assigned GitHub issues.
3. Click **Open Chat** and read the generated prompt. Each issue block should carry a
   `URL: https://github.com/<owner>/<repo>/issues/<number>` line, and no block should show a bare
   `URL:` with nothing after it.
4. Open an issue's detail sheet and use the GitHub button / the `open-github` row action. It should open
   the real issue page, never a blank tab.

Regression risk is confined to issues that already had a good `Url`, and those are unaffected: a
non-blank url is still returned verbatim. The four new tests are the real coverage for the blank case.


---
## Commits

- 6dd85030 Treat a blank issue url as absent in ResolveIssueUrl (plan 00450)

---
Created using [Ivy Tendril](https://ivy.app).