### PR TITLE
[00447] Gate Every PlansChanged Subscriber On The Changed Plan Folder

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/PlansContentViewRefreshTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/PlansContentViewRefreshTests.cs
@@ -1,0 +1,179 @@
+using System.Reactive.Linq;
+using Ivy.Core.Hooks;
+using Ivy.Tendril.Hooks;
+using Ivy.Tendril.Services.Plans;
+using Microsoft.Reactive.Testing;
+using PlansContentView = Ivy.Tendril.Apps.Plans.ContentView;
+
+namespace Ivy.Tendril.Test.Apps;
+
+/// <summary>
+///     The Plans content view never revalidated its content query at all: the query key is the selected
+///     plan's folder path, so while a plan stayed open its commits, git changes and artifacts were served
+///     from cache forever, including while a job was executing it. Adding the subscription reintroduces
+///     the cost #2571 was about unless it is gated on the changed plan folder and coalesced, so these
+///     tests assert the gate and the coalescing at the seam that drives the revalidate.
+/// </summary>
+public class PlansContentViewRefreshTests
+{
+    // RefreshToken wraps an IState<(Guid, object?, bool)> and has no test-friendly constructor, so we
+    // back it with a real State<T> and count emissions after the initial replayed value. Each emission
+    // is one refresh, which is what makes the view call planContentQuery.Mutator.Revalidate().
+    private static (RefreshToken Token, Func<int> RefreshCount) CreateRefreshToken()
+    {
+        var state = new State<(Guid, object?, bool)>((Guid.NewGuid(), null, false));
+        var count = 0;
+        state.Skip(1).Subscribe(_ => count++);
+        return (new RefreshToken(state), () => count);
+    }
+
+    [Theory]
+    // A different plan is the case that must not cost anything.
+    [InlineData("00408-StopTheFreezing", "00420-SomethingElse", 0)]
+    [InlineData(@"D:\.tendril\Plans\00408-StopTheFreezing", "00420-SomethingElse", 0)]
+    // A null or empty changed folder is a full rescan: anything may have changed, the open plan included.
+    [InlineData(null, "00420-SomethingElse", 1)]
+    [InlineData("", "00420-SomethingElse", 1)]
+    // Nothing selected has nothing to compare against.
+    [InlineData("00408-StopTheFreezing", null, 1)]
+    [InlineData("00408-StopTheFreezing", "", 1)]
+    // The watcher raises a full path, NotifyChanged callers raise a bare folder name, and both name the
+    // plan on screen.
+    [InlineData("00408-StopTheFreezing", "00408-StopTheFreezing", 1)]
+    [InlineData(@"D:\.tendril\Plans\00408-StopTheFreezing", "00408-StopTheFreezing", 1)]
+    [InlineData("D:/.tendril/Plans/00408-StopTheFreezing/", "00408-StopTheFreezing", 1)]
+    [InlineData("00408-stopthefreezing", "00408-StopTheFreezing", 1)]
+    public void PlanChangeHookDisposable_RefreshesOnlyForTheSelectedPlan(
+        string? changedFolder, string? selectedFolder, int expectedRefreshes)
+    {
+        var scheduler = new TestScheduler();
+        var watcher = new FakePlanWatcherService();
+        var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, PlansContentView.PlanRefreshWindow, scheduler);
+
+        using var hook = PlansContentView.PlanChangeHookDisposable(watcher, coalescer, () => selectedFolder);
+
+        watcher.NotifyChanged(changedFolder);
+        scheduler.AdvanceBy(PlansContentView.PlanRefreshWindow.Ticks);
+
+        Assert.Equal(expectedRefreshes, refreshCount());
+    }
+
+    [Fact]
+    public void PlanChangeHookDisposable_BurstNamingTheSelectedPlan_RefreshesOnce()
+    {
+        var scheduler = new TestScheduler();
+        var watcher = new FakePlanWatcherService();
+        var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, PlansContentView.PlanRefreshWindow, scheduler);
+
+        using var hook = PlansContentView.PlanChangeHookDisposable(watcher, coalescer, () => "00408-StopTheFreezing");
+
+        // One plan mutation raises several events (plan.yaml, a revision, a verification report), and a
+        // rebuild shells out to git each time. Ten events inside the window must cost one.
+        for (var i = 0; i < 10; i++)
+        {
+            watcher.NotifyChanged("00408-StopTheFreezing");
+            scheduler.AdvanceBy(TimeSpan.FromMilliseconds(10).Ticks);
+        }
+
+        scheduler.AdvanceBy(PlansContentView.PlanRefreshWindow.Ticks);
+
+        Assert.Equal(1, refreshCount());
+    }
+
+    [Fact]
+    public void PlanChangeHookDisposable_ChangesInSuccessiveWindows_RefreshEach()
+    {
+        var scheduler = new TestScheduler();
+        var watcher = new FakePlanWatcherService();
+        var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, PlansContentView.PlanRefreshWindow, scheduler);
+
+        using var hook = PlansContentView.PlanChangeHookDisposable(watcher, coalescer, () => "00408-StopTheFreezing");
+
+        watcher.NotifyChanged("00408-StopTheFreezing");
+        scheduler.AdvanceBy(PlansContentView.PlanRefreshWindow.Ticks);
+        Assert.Equal(1, refreshCount());
+
+        // Coalescing must not degrade into serving the cache forever, which is the defect being fixed.
+        watcher.NotifyChanged("00408-StopTheFreezing");
+        scheduler.AdvanceBy(PlansContentView.PlanRefreshWindow.Ticks);
+        Assert.Equal(2, refreshCount());
+    }
+
+    [Fact]
+    public void PlanChangeHookDisposable_ReadsTheSelectionPerEvent()
+    {
+        var scheduler = new TestScheduler();
+        var watcher = new FakePlanWatcherService();
+        var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, PlansContentView.PlanRefreshWindow, scheduler);
+
+        // The subscription outlives the selection, so a captured folder name would gate on whichever plan
+        // was open when the view first built.
+        var selected = "00408-StopTheFreezing";
+        using var hook = PlansContentView.PlanChangeHookDisposable(watcher, coalescer, () => selected);
+
+        selected = "00420-SomethingElse";
+        watcher.NotifyChanged("00408-StopTheFreezing");
+        scheduler.AdvanceBy(PlansContentView.PlanRefreshWindow.Ticks);
+        Assert.Equal(0, refreshCount());
+
+        watcher.NotifyChanged("00420-SomethingElse");
+        scheduler.AdvanceBy(PlansContentView.PlanRefreshWindow.Ticks);
+        Assert.Equal(1, refreshCount());
+    }
+
+    [Fact]
+    public void PlanChangeHookDisposable_Dispose_UnsubscribesPlansChanged()
+    {
+        var scheduler = new TestScheduler();
+        var watcher = new FakePlanWatcherService();
+        var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, PlansContentView.PlanRefreshWindow, scheduler);
+
+        var hook = PlansContentView.PlanChangeHookDisposable(watcher, coalescer, () => "00408-StopTheFreezing");
+        watcher.NotifyChanged("00408-StopTheFreezing");
+        scheduler.AdvanceBy(PlansContentView.PlanRefreshWindow.Ticks);
+        Assert.Equal(1, refreshCount());
+
+        hook.Dispose();
+        watcher.NotifyChanged("00408-StopTheFreezing");
+        scheduler.AdvanceBy(PlansContentView.PlanRefreshWindow.Ticks);
+
+        Assert.Equal(1, refreshCount());
+        Assert.False(watcher.HasSubscribers);
+    }
+
+    [Fact]
+    public void PlanChangeHookDisposable_RefreshTokenOverload_DisposesItsOwnCoalescer()
+    {
+        var watcher = new FakePlanWatcherService();
+        var (token, refreshCount) = CreateRefreshToken();
+
+        // The overload the view uses owns the coalescer, so disposing what UseEffect returns has to take
+        // both the subscription and the coalescer's timer with it.
+        var hook = PlansContentView.PlanChangeHookDisposable(watcher, token, () => "00408-StopTheFreezing");
+        hook.Dispose();
+
+        watcher.NotifyChanged("00408-StopTheFreezing");
+        Thread.Sleep(PlansContentView.PlanRefreshWindow + TimeSpan.FromMilliseconds(200));
+
+        Assert.Equal(0, refreshCount());
+        Assert.False(watcher.HasSubscribers);
+    }
+
+    private sealed class FakePlanWatcherService : IPlanWatcherService
+    {
+        public event Action<string?>? PlansChanged;
+
+        public bool HasSubscribers => PlansChanged != null;
+
+        public void NotifyChanged(string? changedPlanFolder = null) => PlansChanged?.Invoke(changedPlanFolder);
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test/Apps/ReviewContentViewRefreshTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/ReviewContentViewRefreshTests.cs
@@ -1,4 +1,6 @@
-using ReviewContentView = Ivy.Tendril.Apps.Review.ContentView;
+// ShouldRefreshFor now lives in the shared Ivy.Tendril.Hooks.PlanRefreshGate, which Review calls. What
+// these tests assert is the gate's behaviour, so the alias keeps every assertion below verbatim.
+using ReviewContentView = Ivy.Tendril.Hooks.PlanRefreshGate;
 
 namespace Ivy.Tendril.Test.Apps;
 

--- a/src/Ivy.Tendril.Test/PlansChangedSubscriberAuditTests.cs
+++ b/src/Ivy.Tendril.Test/PlansChangedSubscriberAuditTests.cs
@@ -1,0 +1,131 @@
+using System.Text.RegularExpressions;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+///     <c>IPlanWatcherService.PlansChanged</c> fires once per changed plan and several times per plan
+///     mutation. A subscriber that neither coalesces nor (for a view showing one plan) drops events naming
+///     another plan is how #2571 happened, and how it comes back. Every subscriber in the product has been
+///     audited against both rules; this test fails when one is added that has not been.
+/// </summary>
+public class PlansChangedSubscriberAuditTests
+{
+    /// <summary>
+    ///     Every file in <c>src/Ivy.Tendril</c> allowed to subscribe to <c>PlansChanged</c>, with how each
+    ///     one satisfies the two rules. Paths are relative to the repo root, with forward slashes.
+    /// </summary>
+    private static readonly Dictionary<string, string> AuditedSubscribers = new()
+    {
+        ["src/Ivy.Tendril/Apps/Review/ContentView.cs"] =
+            "Gates through PlanRefreshGate, coalesces through RefreshCoalescer (400ms).",
+        ["src/Ivy.Tendril/Apps/Plans/ContentView.cs"] =
+            "Gates through PlanRefreshGate, coalesces through RefreshCoalescer (PlanRefreshWindow).",
+        ["src/Ivy.Tendril/Hooks/UseInboxAutoRefresh.cs"] =
+            "Folder-blind by design (list views: membership and ordering change for plans not listed), "
+            + "coalesces through RefreshCoalescer (400ms).",
+        ["src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs"] =
+            "Syncs all plans, so no folder gate applies; queues off the raising thread and reruns once "
+            + "after the pass in flight.",
+        ["src/Ivy.Tendril/Services/Plans/TendrilProcessStatusService.cs"] =
+            "Counts span all plans, so no folder gate applies; 200ms debounce plus record-equality dedupe.",
+    };
+
+    /// <summary>Detail views: showing one plan, so the folder gate is not optional for them.</summary>
+    private static readonly string[] SinglePlanViews =
+    [
+        "src/Ivy.Tendril/Apps/Review/ContentView.cs",
+        "src/Ivy.Tendril/Apps/Plans/ContentView.cs",
+    ];
+
+    [Fact]
+    public void EveryPlansChangedSubscriber_IsAudited()
+    {
+        var repoRoot = FindRepoRoot();
+        var found = FindSubscriberFiles(repoRoot);
+
+        var unaudited = found.Except(AuditedSubscribers.Keys, StringComparer.OrdinalIgnoreCase).ToList();
+
+        Assert.True(unaudited.Count == 0,
+            $"New PlansChanged subscriber(s) not in the audit: {string.Join(", ", unaudited)}.\n"
+            + "PlansChanged fires once per changed plan and several times per plan mutation, so:\n"
+            + "  1. Coalesce - feed a RefreshCoalescer (or an equivalent debounce), never work inline.\n"
+            + "  2. Gate, if the subscriber renders a single plan - drop events naming another plan via\n"
+            + "     PlanRefreshGate.ShouldRefreshFor. A subscriber whose work spans all plans (a list, a\n"
+            + "     count, a full sync) is folder-blind by design and must not gate.\n"
+            + "Then add the file to AuditedSubscribers in this test with which of the two applies and why.");
+    }
+
+    [Fact]
+    public void AuditedSubscribers_AllStillSubscribe()
+    {
+        // The other direction: an entry left behind after its subscription is removed makes the audit
+        // read as broader than it is.
+        var repoRoot = FindRepoRoot();
+        var found = FindSubscriberFiles(repoRoot);
+
+        var stale = AuditedSubscribers.Keys.Except(found, StringComparer.OrdinalIgnoreCase).ToList();
+
+        Assert.True(stale.Count == 0,
+            $"Audited file(s) no longer subscribe to PlansChanged: {string.Join(", ", stale)}. "
+            + "Remove them from AuditedSubscribers in this test.");
+    }
+
+    [Fact]
+    public void SinglePlanViews_GateThroughPlanRefreshGate()
+    {
+        // The census above cannot see whether a view still gates, only that it subscribes - so assert the
+        // gate itself for the two views that render one plan.
+        var repoRoot = FindRepoRoot();
+
+        foreach (var relative in SinglePlanViews)
+        {
+            var source = File.ReadAllText(Path.Combine(repoRoot, relative.Replace('/', Path.DirectorySeparatorChar)));
+            Assert.Contains("PlanRefreshGate.ShouldRefreshFor", source);
+            Assert.Contains("RefreshCoalescer", source);
+        }
+    }
+
+    [Fact]
+    public void PlansContentView_QueryRevalidatesOnRefresh()
+    {
+        // The gate and the coalescer are worth nothing if nothing revalidates at the end of them: the
+        // Plans content query shipped subscribed to nothing at all, at the default server scope, so the
+        // open plan's content stayed as it was first read. Pinned as source text because the repo has no
+        // way to render a view in a test - the coalescing behaviour itself is covered at the hook seam in
+        // PlansContentViewRefreshTests.
+        var repoRoot = FindRepoRoot();
+        var source = File.ReadAllText(
+            Path.Combine(repoRoot, "src", "Ivy.Tendril", "Apps", "Plans", "ContentView.cs"));
+
+        Assert.Contains("QueryScope.View", source);
+        Assert.Contains("Revalidate()", source);
+    }
+
+    private static List<string> FindSubscriberFiles(string repoRoot)
+    {
+        var productDir = Path.Combine(repoRoot, "src", "Ivy.Tendril");
+        var subscription = new Regex(@"PlansChanged\s*\+=", RegexOptions.Compiled);
+
+        return Directory.EnumerateFiles(productDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar) &&
+                        !f.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+            .Where(f => subscription.IsMatch(File.ReadAllText(f)))
+            .Select(f => Path.GetRelativePath(repoRoot, f).Replace(Path.DirectorySeparatorChar, '/'))
+            .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "src", "Ivy.Tendril", "Ivy.Tendril.slnx")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate repository root from BaseDirectory: " + AppDomain.CurrentDomain.BaseDirectory);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -119,12 +119,31 @@ public class ContentView(
 
         var selectedPlanRef = UseRef(selectedPlan);
 
+        var planWatcher = UseService<Ivy.Tendril.Services.Plans.IPlanWatcherService>();
+        var localRefresh = UseRefreshToken();
+
         var planContentQuery = UseQuery<PlanContentData, string>(
             selectedPlan?.FolderPath ?? "",
             async (folderPath, ct) => await Task.Run(() => LoadPlanContent(folderPath), ct),
+            // The fetcher closes over this view's selectedPlan, so a server-scoped cache entry would be
+            // shared with every other session and hand one session another session's plan content.
+            options: QueryScope.View,
             initialValue: new PlanContentData(null,
                 new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(), new Dictionary<string, bool>(), null, new GitTabDataBuilder.GitTabData([], []))
         );
+
+        UseEffect(() => PlanChangeHookDisposable(planWatcher, localRefresh,
+            () => selectedPlanRef.Value?.FolderName));
+
+        UseEffect(() =>
+        {
+            // Without this the query key (the folder path) never changes while a plan is open, so the
+            // cached content - commits, git changes, artifacts - is served for the life of the view even
+            // while a job is executing the plan.
+            if (localRefresh.IsRefreshed)
+                planContentQuery.Mutator.Revalidate();
+            return Disposable.Empty;
+        }, [localRefresh]);
 
         // Authentication effects (was UseAuthenticationEffects)
         UseEffect(() =>
@@ -436,6 +455,55 @@ public class ContentView(
             return int.TryParse(idStr, out var id) ? $"#{id}" : idStr;
         }));
         return $"{meta} · Depends on {depIds}";
+    }
+
+    /// <summary>
+    ///     How long a burst of plan changes is collapsed over. The same window Review's content view and
+    ///     <c>UseInboxAutoRefresh</c> use, so a plan mutation that raises several events costs one rebuild.
+    /// </summary>
+    internal static readonly TimeSpan PlanRefreshWindow = TimeSpan.FromMilliseconds(400);
+
+    /// <summary>
+    ///     Revalidates the plan content when the plan on screen changes on disk, owning a coalescer on the
+    ///     caller's behalf. See the overload below for what is gated and why.
+    /// </summary>
+    internal static IDisposable PlanChangeHookDisposable(
+        Ivy.Tendril.Services.Plans.IPlanWatcherService planWatcher,
+        RefreshToken refreshToken,
+        Func<string?> selectedFolder)
+    {
+        var coalescer = new RefreshCoalescer(refreshToken, PlanRefreshWindow);
+        var hook = PlanChangeHookDisposable(planWatcher, coalescer, selectedFolder);
+        return Disposable.Create(() =>
+        {
+            hook.Dispose();
+            coalescer.Dispose();
+        });
+    }
+
+    /// <summary>
+    ///     Subscribes <paramref name="planWatcher" /> and feeds only the events naming the plan on screen
+    ///     into <paramref name="coalescer" />, per <see cref="PlanRefreshGate" />. Rebuilding for another
+    ///     plan means running git for commits, the git tab and the full change set of a plan nobody is
+    ///     looking at (#2571). Extracted so the gate and the coalescing are testable without an Ivy
+    ///     runtime, as <c>JobsApp.JobChangeHookDisposable</c> is.
+    /// </summary>
+    /// <param name="selectedFolder">
+    ///     Read per event rather than captured, since the selection changes while the subscription lives.
+    /// </param>
+    internal static IDisposable PlanChangeHookDisposable(
+        Ivy.Tendril.Services.Plans.IPlanWatcherService planWatcher,
+        RefreshCoalescer coalescer,
+        Func<string?> selectedFolder)
+    {
+        void OnChanged(string? changedFolder)
+        {
+            if (!PlanRefreshGate.ShouldRefreshFor(changedFolder, selectedFolder())) return;
+            coalescer.Request();
+        }
+
+        planWatcher.PlansChanged += OnChanged;
+        return Disposable.Create(() => planWatcher.PlansChanged -= OnChanged);
     }
 
     private object BuildNoSelectionView(object processView)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -42,31 +42,6 @@ public class ContentView(
     private const string ArtifactsTab = "artifacts";
     private const string RecommendationsTab = "recommendations";
 
-    /// <summary>
-    ///     Whether a <c>PlansChanged</c> naming <paramref name="changedFolder" /> should rebuild the
-    ///     content shown for <paramref name="selectedFolder" />. A rebuild runs git subprocesses and one
-    ///     PowerShell condition per configured review action, so doing it because some other plan changed
-    ///     is pure cost (#2571). A null changed folder is a full rescan and always refreshes, as does a
-    ///     view with nothing selected, which has nothing to compare against.
-    /// </summary>
-    /// <remarks>
-    ///     The event carries a full folder path from the watcher and a bare folder name from some
-    ///     <c>NotifyChanged</c> callers, so the two sides are compared on their last segment.
-    /// </remarks>
-    internal static bool ShouldRefreshFor(string? changedFolder, string? selectedFolder)
-    {
-        if (string.IsNullOrEmpty(changedFolder) || string.IsNullOrEmpty(selectedFolder)) return true;
-        return string.Equals(LeafName(changedFolder), LeafName(selectedFolder), StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>The last path segment, whichever separator the caller used.</summary>
-    private static string LeafName(string folder)
-    {
-        var trimmed = folder.TrimEnd('/', '\\');
-        var lastSeparator = trimmed.LastIndexOfAny(['/', '\\']);
-        return lastSeparator >= 0 ? trimmed[(lastSeparator + 1)..] : trimmed;
-    }
-
     public override object Build()
     {
         var client = UseService<IClientProvider>();
@@ -245,7 +220,7 @@ public class ContentView(
 
             void OnChanged(string? changedFolder)
             {
-                if (!ShouldRefreshFor(changedFolder, selectedPlanState.Value?.FolderName)) return;
+                if (!PlanRefreshGate.ShouldRefreshFor(changedFolder, selectedPlanState.Value?.FolderName)) return;
                 coalescer.Request();
             }
 

--- a/src/Ivy.Tendril/Hooks/PlanRefreshGate.cs
+++ b/src/Ivy.Tendril/Hooks/PlanRefreshGate.cs
@@ -1,0 +1,38 @@
+namespace Ivy.Tendril.Hooks;
+
+/// <summary>
+///     The folder gate every view that renders a <em>single</em> plan must put in front of
+///     <see cref="Services.Plans.IPlanWatcherService.PlansChanged" />. Lives here rather than in one
+///     app so the next subscriber can reuse it instead of rediscovering it (#2571).
+/// </summary>
+/// <remarks>
+///     List views are the exception and must not use this: see
+///     <see cref="UseInboxAutoRefreshExtensions.UseInboxAutoRefresh" />.
+/// </remarks>
+internal static class PlanRefreshGate
+{
+    /// <summary>
+    ///     Whether a <c>PlansChanged</c> naming <paramref name="changedFolder" /> should rebuild the
+    ///     content shown for <paramref name="selectedFolder" />. A rebuild runs git subprocesses and one
+    ///     PowerShell condition per configured review action, so doing it because some other plan changed
+    ///     is pure cost (#2571). A null changed folder is a full rescan and always refreshes, as does a
+    ///     view with nothing selected, which has nothing to compare against.
+    /// </summary>
+    /// <remarks>
+    ///     The event carries a full folder path from the watcher and a bare folder name from some
+    ///     <c>NotifyChanged</c> callers, so the two sides are compared on their last segment.
+    /// </remarks>
+    internal static bool ShouldRefreshFor(string? changedFolder, string? selectedFolder)
+    {
+        if (string.IsNullOrEmpty(changedFolder) || string.IsNullOrEmpty(selectedFolder)) return true;
+        return string.Equals(LeafName(changedFolder), LeafName(selectedFolder), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The last path segment, whichever separator the caller used.</summary>
+    private static string LeafName(string folder)
+    {
+        var trimmed = folder.TrimEnd('/', '\\');
+        var lastSeparator = trimmed.LastIndexOfAny(['/', '\\']);
+        return lastSeparator >= 0 ? trimmed[(lastSeparator + 1)..] : trimmed;
+    }
+}

--- a/src/Ivy.Tendril/Hooks/UseInboxAutoRefresh.cs
+++ b/src/Ivy.Tendril/Hooks/UseInboxAutoRefresh.cs
@@ -12,6 +12,19 @@ public static class UseInboxAutoRefreshExtensions
     ///     plus <see cref="IPlanWatcherService.PlansChanged" /> directly, which
     ///     covers content changes where the counts stay equal (Status dedupes by record equality).
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Deliberately <b>not</b> gated on the changed plan folder, unlike the detail views (see
+    ///         <see cref="PlanRefreshGate" />). Every caller here renders a <em>list</em> of plans, and a
+    ///         change to any plan can add it to that list, remove it from it, or reorder it - including a
+    ///         plan the list is not currently showing, which is exactly the case a folder gate would
+    ///         discard. Gating here would leave stale rows on screen.
+    ///     </para>
+    ///     <para>
+    ///         The coalescer is what keeps that affordable: folder-blind means every event arrives, so a
+    ///         burst must still cost one refresh (#2571).
+    ///     </para>
+    /// </remarks>
     public static void UseInboxAutoRefresh(this IViewContext context, RefreshToken refreshToken)
     {
         var statusService = context.UseService<ITendrilProcessStatusService>();

--- a/src/Ivy.Tendril/Services/Plans/IPlanWatcherService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanWatcherService.cs
@@ -6,6 +6,35 @@ public interface IPlanWatcherService : IDisposable
     ///     Raised when plan files change on disk. The string parameter is the changed plan folder
     ///     path (for incremental sync), or null when a full rescan is needed.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Two rules bind every subscriber, and #2571 is what happens when one ignores them. A single
+    ///         plan mutation can raise this several times, and a burst of plan mutations raises it once per
+    ///         plan, so:
+    ///     </para>
+    ///     <list type="number">
+    ///         <item>
+    ///             <description>
+    ///                 <b>Coalesce.</b> Never do the work inline. Feed a
+    ///                 <c>Ivy.Tendril.Hooks.RefreshCoalescer</c> (or an equivalent debounce) so a burst
+    ///                 costs one rebuild, not one per event.
+    ///             </description>
+    ///         </item>
+    ///         <item>
+    ///             <description>
+    ///                 <b>Gate, if you render one plan.</b> A subscriber showing a single plan must drop
+    ///                 events naming a different plan, via
+    ///                 <c>Ivy.Tendril.Hooks.PlanRefreshGate.ShouldRefreshFor</c>. A subscriber whose work
+    ///                 spans all plans (a list, a count, a full sync) is folder-blind by design and must
+    ///                 not gate - see <c>Ivy.Tendril.Hooks.UseInboxAutoRefreshExtensions.UseInboxAutoRefresh</c>.
+    ///             </description>
+    ///         </item>
+    ///     </list>
+    ///     <para>
+    ///         <c>PlansChangedSubscriberAuditTests</c> fails when a subscriber is added without being
+    ///         audited against both rules.
+    ///     </para>
+    /// </remarks>
     event Action<string?>? PlansChanged;
 
     void NotifyChanged(string? changedPlanFolder = null);


### PR DESCRIPTION
# Summary

## Changes

The folder gate that decides whether a `PlansChanged` event concerns the plan on screen moved out of
`Apps/Review/ContentView.cs` into a shared `Hooks/PlanRefreshGate.cs`, unchanged in behaviour, so the
other single-plan view can use it. That view, `Apps/Plans/ContentView.cs`, had the audit's one real
defect: its `planContentQuery` subscribed to nothing and ran at the default `QueryScope.Server`, so the
open plan's commits, git changes and artifacts were read once and then served from cache for the life of
the view (including while a job was executing that plan), out of a cache entry shared with every other
session. It now revalidates on `PlansChanged`, gated on the selected folder and coalesced over a 400ms
window, from a view-scoped cache entry.

The two rules for the event are now written where they are enforced: on the `PlansChanged` declaration
itself, and on `Hooks/UseInboxAutoRefresh.cs`, which ignores the folder on purpose because list
membership and ordering change for plans that are not currently listed. A guard test fails when a
subscriber is added that has not been audited against both rules.

## API Changes

- New `internal static class Ivy.Tendril.Hooks.PlanRefreshGate` with
  `ShouldRefreshFor(string? changedFolder, string? selectedFolder)`, moved verbatim from Review's private
  helper. Internal, so no public surface change.
- New `internal static` members on `Apps.Plans.ContentView`: `PlanRefreshWindow` and two
  `PlanChangeHookDisposable` overloads, mirroring `JobsApp.JobChangeHookDisposable`.
- `IPlanWatcherService.PlansChanged` gains documentation only; its signature is unchanged.

## Files Modified

**Production**
- `src/Ivy.Tendril/Hooks/PlanRefreshGate.cs` (new) - the shared gate
- `src/Ivy.Tendril/Apps/Plans/ContentView.cs` - view-scoped query, gated and coalesced revalidation
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` - local helper removed, calls the shared gate
- `src/Ivy.Tendril/Services/Plans/IPlanWatcherService.cs` - the event contract, documented
- `src/Ivy.Tendril/Hooks/UseInboxAutoRefresh.cs` - why it is deliberately folder-blind

**Tests**
- `src/Ivy.Tendril.Test/Apps/PlansContentViewRefreshTests.cs` (new) - gate cases, burst coalescing,
  successive windows, per-event selection reads, disposal
- `src/Ivy.Tendril.Test/PlansChangedSubscriberAuditTests.cs` (new) - the subscriber census plus the gate,
  coalescer and revalidation pins for the two detail views
- `src/Ivy.Tendril.Test/Apps/ReviewContentViewRefreshTests.cs` - `using` alias retargeted, assertions
  untouched

## Manual Testing

The Plans content view is the behaviour that changed, so drive it from disk.

1. Run the app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Open the **Plans** app and select a plan that has commits and a dirty worktree.
3. With that plan still open, change it from outside the app: commit in its worktree, or edit its
   `plan.yaml`. Within roughly half a second the Commits, Git and Artifacts content should update on its
   own. Before this change it stayed as first loaded until the app was reloaded.
4. Repeat while a job is executing the open plan; content should keep up with the job's commits.
5. Now touch a *different* plan (edit another plan's folder) while the first is still open. The open
   plan's content must not reload: no spinner, no flicker. That is the gate.
6. Save a file in the open plan's folder several times in quick succession. One reload, not one per save.
   That is the coalescer.
7. Open two browser sessions on different plans and reload content in each. Each must show its own plan;
   before this change they shared one cache entry.

Automated coverage, the plan's scoped command (29 passed):
`dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~PlansContentViewRefreshTests|FullyQualifiedName~ReviewContentViewRefreshTests|FullyQualifiedName~PlansChangedSubscriberAuditTests|FullyQualifiedName~PlanWatcherServiceTests"`


---

## Commits

- f0316887 [00447] Document the two PlansChanged rules and guard the subscriber census
- 133948be [00447] Refresh the Plans content view when its own plan changes
- e85f75c8 [00447] Extract the Review folder gate into PlanRefreshGate

---
Created using [Ivy Tendril](https://ivy.app).