### PR TITLE
[00439] Name the Jobs Cell Stream Test for Its Invariant Not Its Count

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsAppPromptDisplayTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsAppPromptDisplayTests.cs
@@ -1,7 +1,7 @@
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Models;
 
-namespace Ivy.Tendril.Test;
+namespace Ivy.Tendril.Test.Apps.Jobs;
 
 public class JobsAppPromptDisplayTests
 {

--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsAppRefreshGatingTests.cs
@@ -6,7 +6,7 @@ using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Microsoft.Reactive.Testing;
 
-namespace Ivy.Tendril.Test;
+namespace Ivy.Tendril.Test.Apps.Jobs;
 
 public class JobsAppRefreshGatingTests
 {

--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -10,6 +10,20 @@ namespace Ivy.Tendril.Test;
 
 public class JobsAppRefreshGatingTests
 {
+    /// <summary>
+    ///     Every column <see cref="JobsApp.BuildDataTableUpdates" /> streams per candidate job. Adding a
+    ///     streamed cell is a one-line change here; the test name deliberately does not carry the count.
+    /// </summary>
+    private static readonly string[] StreamedColumns =
+    [
+        nameof(JobItemRow.Timer),
+        nameof(JobItemRow.Cost),
+        nameof(JobItemRow.Tokens),
+        nameof(JobItemRow.AgentOutput),
+        nameof(JobItemRow.Status),
+        nameof(JobItemRow.StatusMessage)
+    ];
+
     private static (RefreshToken Token, Func<int> RefreshCount) CreateRefreshToken()
     {
         var state = new State<(Guid, object?, bool)>((Guid.NewGuid(), null, false));
@@ -80,7 +94,7 @@ public class JobsAppRefreshGatingTests
     }
 
     [Fact]
-    public void BuildDataTableUpdates_FirstCall_ReturnsAllSixCells()
+    public void BuildDataTableUpdates_FirstCall_ReturnsEveryStreamedCell()
     {
         var jobService = new FakeJobService();
         jobService.Jobs.Add(MakeJob("job-1", JobStatus.Running));
@@ -88,7 +102,7 @@ public class JobsAppRefreshGatingTests
 
         var updates = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
 
-        Assert.Equal(6, updates.Count);
+        Assert.Equal(StreamedColumns, updates.Select(u => u.ColumnName).ToArray());
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -181,21 +181,6 @@ public partial class JobsApp
                     showCost(id);
                 return ValueTask.CompletedTask;
             })
-            /*
-            .OnCellAction(t => t.StatusMessage, e =>
-            {
-                var id = e.Value.RowId?.ToString();
-                if (!string.IsNullOrEmpty(id))
-                {
-                    var job = jobs.FirstOrDefault(j => j.Id == id);
-                    if (job?.Status is JobStatus.Failed or JobStatus.Timeout)
-                    {
-                        showOutput.Set(id);
-                    }
-                }
-                return ValueTask.CompletedTask;
-            })
-            */
             .OnCellAction(t => t.Prompt, e =>
             {
                 var id = e.Value.RowId?.ToString();


### PR DESCRIPTION
# Summary

## Changes

`BuildDataTableUpdates_FirstCall_ReturnsAllSixCells` is now
`BuildDataTableUpdates_FirstCall_ReturnsEveryStreamedCell`, and it asserts the actual streamed column
names against a single `StreamedColumns` list instead of a bare count of 6, so adding a seventh streamed
cell is a one-line edit with no test rename. The two Jobs-app test classes that sat at the test project
root moved into the mirrored `Apps/Jobs/` folder, and the dead commented-out `StatusMessage` cell action
was deleted. No behaviour changes.

## API Changes

None public. One test-internal rename:
`JobsAppRefreshGatingTests.BuildDataTableUpdates_FirstCall_ReturnsAllSixCells` →
`BuildDataTableUpdates_FirstCall_ReturnsEveryStreamedCell`, and its namespace moved from
`Ivy.Tendril.Test` to `Ivy.Tendril.Test.Apps.Jobs` (as did `JobsAppPromptDisplayTests`). Anything
filtering tests by those fully-qualified names needs updating; nothing in the repo did.

## Files Modified

**Tests** (`src/Ivy.Tendril.Test/`)

- `Apps/Jobs/JobsAppRefreshGatingTests.cs` - moved from the project root; added the `StreamedColumns`
  field; renamed the first-call test and replaced its count assertion with an ordered column-set
  assertion. Every other test in the file is untouched.
- `Apps/Jobs/JobsAppPromptDisplayTests.cs` - moved from the project root; namespace only.

**App** (`src/Ivy.Tendril/`)

- `Apps/Jobs/JobsApp.DataTable.cs` - deleted the 15-line commented-out
  `OnCellAction(t => t.StatusMessage, ...)` block. It called `showOutput.Set(id)` while `showOutput` is
  an `Action<string>`, so it could never have compiled, and the live `AgentOutput` handler above it
  already calls `showOutput(id)`.

## Manual Testing

N/A - internal change with no user-facing behavior. The deleted block was commented out, so the Jobs
table behaves exactly as before; the rest is a test rename, a strengthened assertion and a file move.

To confirm the test side from a terminal:

```bash
dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj \
  --filter "FullyQualifiedName~JobsAppRefreshGatingTests|FullyQualifiedName~JobsAppPromptDisplayTests|FullyQualifiedName~JobsTableColumnLabelTests|FullyQualifiedName~JobsTableFilterTests"
```

Expect `Passed! - Failed: 0, Passed: 51`. Note the project path rather than `Ivy.Tendril.slnx`: the
solution file references a sibling `Ivy-Framework` checkout and cannot restore from a worktree.


---

## Commits

- 8d6af2cc Assert the streamed column set instead of the cell count (00439)
- 377babb9 Move the root-level Jobs-app test classes into Apps/Jobs (00439)
- b01ec024 Delete the dead commented StatusMessage cell action (00439)

---
Created using [Ivy Tendril](https://ivy.app).