### PR TITLE
[00451] Extract the Duplicated Inbox File Content Builder onto InboxApp

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/InboxAppTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/InboxAppTests.cs
@@ -425,6 +425,101 @@ public class InboxAppTests
             $"InboxApp.ResolveIssueUrl in {expectedFile}, but it was found at {hits[0]}.");
     }
 
+    [Fact]
+    public void BuildInboxFileContent_LinksTheIssueWhenAUrlResolves()
+    {
+        var issue = new GitHubIssue(101, "Fix login bug", "Login fails", [], [], "owner/repo", "https://github.com/owner/repo/issues/101");
+
+        var content = InboxApp.BuildInboxFileContent(issue, "Auto");
+
+        Assert.Equal(
+            "---\n" +
+            "project: Auto\n" +
+            "---\n" +
+            "[GitHub Issue #101](https://github.com/owner/repo/issues/101)\n" +
+            "\n" +
+            "Login fails",
+            content);
+    }
+
+    [Fact]
+    public void BuildInboxFileContent_DerivesTheUrlFromTheRepository()
+    {
+        var issue = new GitHubIssue(101, "Fix login bug", "Login fails", [], [], "acme/widgets");
+
+        var content = InboxApp.BuildInboxFileContent(issue, "Auto");
+
+        Assert.Equal(
+            "---\n" +
+            "project: Auto\n" +
+            "---\n" +
+            "[GitHub Issue #101](https://github.com/acme/widgets/issues/101)\n" +
+            "\n" +
+            "Login fails",
+            content);
+    }
+
+    [Fact]
+    public void BuildInboxFileContent_FallsBackToAPlainHeadingWhenNoUrlResolves()
+    {
+        var issue = new GitHubIssue(12, "Fix login bug", "Login fails", [], [], Repository: null, Url: null);
+
+        var content = InboxApp.BuildInboxFileContent(issue, "Tendril");
+
+        Assert.Equal(
+            "---\n" +
+            "project: Tendril\n" +
+            "---\n" +
+            "# Issue #12: Fix login bug\n" +
+            "\n" +
+            "Login fails",
+            content);
+        Assert.DoesNotContain("](", content);
+    }
+
+    [Fact]
+    public void InboxFileContentTemplate_LivesOnlyInBuildInboxFileContent()
+    {
+        var repoRoot = FindRepoRoot();
+        var productionDir = Path.Combine(repoRoot, "src", "Ivy.Tendril");
+
+        // This test file lives under src/Ivy.Tendril.Test, which is a sibling of the scanned
+        // directory, so the needle below cannot match the guard itself.
+        const string issueLinkTemplate = "[GitHub Issue #{issue.Number}](";
+
+        var hits = new List<string>();
+
+        var csFiles = Directory.EnumerateFiles(productionDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar) &&
+                        !f.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar));
+
+        foreach (var file in csFiles)
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].Contains(issueLinkTemplate, StringComparison.Ordinal))
+                {
+                    hits.Add($"{Path.GetRelativePath(repoRoot, file)}:{i + 1}");
+                }
+            }
+        }
+
+        var expectedFile = Path.Combine("src", "Ivy.Tendril", "Apps", "Inbox", "InboxApp.cs");
+
+        Assert.True(
+            hits.Count == 1,
+            $"Expected exactly one inline inbox issue-link template in {expectedFile} (the body of " +
+            $"InboxApp.BuildInboxFileContent), but found {hits.Count}: {string.Join(", ", hits)}. Call " +
+            "InboxApp.BuildInboxFileContent(issue, targetProject) instead of spelling out the inbox " +
+            "file template inline.");
+
+        Assert.True(
+            hits[0].StartsWith(expectedFile + ":", StringComparison.Ordinal),
+            $"The single inline inbox issue-link template should be the body of " +
+            $"InboxApp.BuildInboxFileContent in {expectedFile}, but it was found at {hits[0]}.");
+    }
+
     private static string FindRepoRoot()
     {
         var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);

--- a/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
@@ -172,16 +172,7 @@ public class InboxApp : ViewBase
                         ? selectedProject.Value
                         : (issue.Repository != null ? githubService.FindProjectForGithubRepo(issue.Repository)?.Name : null) ?? "Auto";
 
-                    var issueUrl = ResolveIssueUrl(issue) ?? "";
-
-                    var content = $"""
-                                   ---
-                                   project: {targetProject}
-                                   ---
-                                   {(string.IsNullOrEmpty(issueUrl) ? $"# Issue #{issue.Number}: {issue.Title}" : $"[GitHub Issue #{issue.Number}]({issueUrl})")}
-
-                                   {issue.Body}
-                                   """;
+                    var content = BuildInboxFileContent(issue, targetProject);
 
                     await FileHelper.WriteAllTextAsync(filePath, content);
                     importedCount++;
@@ -298,6 +289,29 @@ public class InboxApp : ViewBase
         issue.Url ?? (issue.Repository != null
             ? $"https://github.com/{issue.Repository}/issues/{issue.Number}"
             : null);
+
+    /// <summary>
+    ///     Builds the markdown document written to the Tendril inbox for a GitHub issue: the project
+    ///     front matter, a link to the issue (or a plain heading when no url resolves) and the issue
+    ///     body. Shared by the interactive fire-off path and the background auto-import service so the
+    ///     inbox file format lives in exactly one place.
+    /// </summary>
+    public static string BuildInboxFileContent(GitHubIssue issue, string targetProject)
+    {
+        var issueUrl = ResolveIssueUrl(issue);
+        var heading = string.IsNullOrEmpty(issueUrl)
+            ? $"# Issue #{issue.Number}: {issue.Title}"
+            : $"[GitHub Issue #{issue.Number}]({issueUrl})";
+
+        return $"""
+                ---
+                project: {targetProject}
+                ---
+                {heading}
+
+                {issue.Body}
+                """;
+    }
 
     public static string TruncateBody(string? body, int maxLength = 500)
     {

--- a/src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs
+++ b/src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs
@@ -159,16 +159,7 @@ public class AssignedIssuesAutoImportService : IStartable, IDisposable
                 var fileName = $"{issue.Number}-{safeName}.md";
                 var filePath = Path.Combine(inboxPath, fileName);
 
-                var resolvedUrl = InboxApp.ResolveIssueUrl(issue) ?? "";
-
-                var content = $"""
-                               ---
-                               project: {targetProject}
-                               ---
-                               {(string.IsNullOrEmpty(resolvedUrl) ? $"# Issue #{issue.Number}: {issue.Title}" : $"[GitHub Issue #{issue.Number}]({resolvedUrl})")}
-
-                               {issue.Body}
-                               """;
+                var content = InboxApp.BuildInboxFileContent(issue, targetProject);
 
                 await FileHelper.WriteAllTextAsync(filePath, content);
                 _logger.LogInformation("Auto-imported assigned issue #{Number} into Inbox for project {Project}.", issue.Number, targetProject);


### PR DESCRIPTION
# Summary

## Changes

The two inbox file writers (the interactive fire-off path in `InboxApp` and the background
`AssignedIssuesAutoImportService`) built byte-identical markdown documents from the same three pieces,
differing only in a local variable name. The template now lives once, as
`InboxApp.BuildInboxFileContent`, which resolves the issue url itself so the `?? ""` fallback disappears
from both callers. No behaviour change: the same bytes are written by the same two paths.

## API Changes

- **New:** `public static string InboxApp.BuildInboxFileContent(GitHubIssue issue, string targetProject)`
  - returns the inbox markdown document: `---` / `project: {targetProject}` / `---`, then either
  `[GitHub Issue #{n}]({url})` or `# Issue #{n}: {title}` when no url resolves, a blank line, and the
  issue body. No trailing newline. Calls `ResolveIssueUrl` internally, so callers pass the raw issue.
- No signatures were changed or removed. `ResolveIssueUrl`, `SanitizeFileName`, `TruncateBody` are
  untouched.

## Files Modified

**Production**
- `src/Ivy.Tendril/Apps/Inbox/InboxApp.cs` - added `BuildInboxFileContent` beside `ResolveIssueUrl`;
  the fire-off loop now calls it.
- `src/Ivy.Tendril/Services/Inbox/AssignedIssuesAutoImportService.cs` - the auto-import writer now calls
  `InboxApp.BuildInboxFileContent`. Its unrelated `issueUrl` for the duplicate-plan lookup is unchanged.

**Tests**
- `src/Ivy.Tendril.Test/Apps/InboxAppTests.cs` - three exact-document tests (explicit url, url derived
  from the repository, plain-heading fallback) plus
  `InboxFileContentTemplate_LivesOnlyInBuildInboxFileContent`, a duplication guard that asserts the
  issue-link template appears exactly once under `src/Ivy.Tendril`. The guard was proved to fail (2 hits)
  when a second inline copy is reintroduced.

Explicitly left alone, as the plan directed: `Mcp/Tools/PlanTools.cs` and `Services/Jobs/JobService.cs`
both write inbox front matter but neither writes a `GitHubIssue`, so neither can use the helper.

## Manual Testing

The change is a refactor with no intended user-facing difference, but it is observable, so it can be
checked end to end:

1. Run Tendril (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`)
   and open the **Inbox** app.
2. Select one or more issues under **My Issues** and click **Fire off**.
3. Open the created file under `%TENDRIL_HOME%\Inbox\{number}-{slug}.md`. It should read exactly as
   before: `---`, `project: <project>`, `---`, a `[GitHub Issue #N](https://github.com/...)` line, a
   blank line, then the issue body.
4. For the background path, enable assigned-issues auto-import and let a sync run (or rely on
   `RunSyncAsync_WhenEnabled_ImportsNewAssignedIssues`, which asserts on the written file). The document
   must be identical to the one produced in step 3 for the same issue.


---

## Commits

- `38aa3005` [00451] Extract InboxApp.BuildInboxFileContent and use it in both writers
- `c83bd9c4` [00451] Pin the inbox file format and guard against the template returning

---
Created using [Ivy Tendril](https://ivy.app).