### PR TITLE
[00453] Isolate The Ivy Tendril Test Suite From The Live Tendril Home

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/PromptwareReadMemoryCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareReadMemoryCommandTests.cs
@@ -18,7 +18,7 @@ public class PromptwareReadMemoryCommandTests : IDisposable
 
     public void Dispose()
     {
-        Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
+        TendrilHomeIsolation.Apply();
         if (Directory.Exists(_tempHome))
         {
             try { Directory.Delete(_tempHome, true); } catch { }

--- a/src/Ivy.Tendril.Test/DoctorChecksTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorChecksTests.cs
@@ -40,14 +40,13 @@ public class DoctorChecksTests : IDisposable
         }
         finally
         {
-            Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
+            TendrilHomeIsolation.Apply();
         }
     }
 
     [Fact]
     public async Task EnvironmentCheck_UnsetTendrilHome_ResolvesDefault()
     {
-        var originalEnv = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
 
         try
@@ -62,7 +61,7 @@ public class DoctorChecksTests : IDisposable
         }
         finally
         {
-            Environment.SetEnvironmentVariable("TENDRIL_HOME", originalEnv);
+            TendrilHomeIsolation.Apply();
         }
     }
 

--- a/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test;
 
+[Collection("TendrilHome")]
 public class OnboardingSetupServiceTests : IDisposable
 {
     private readonly TempDirectoryFixture _tempDir = new("ivy-onboarding-test");
@@ -55,7 +56,6 @@ public class OnboardingSetupServiceTests : IDisposable
     [Fact]
     public async Task BootstrapTendrilHomeAsync_Should_Skip_Shell_And_Pointer_When_TendrilE2E_Set()
     {
-        var originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         var originalE2E = Environment.GetEnvironmentVariable("TENDRIL_E2E");
         var tendrilHome = Path.Combine(_tempDir.Path, "bootstrap-home-e2e");
         var logger = new TestLogger<OnboardingSetupService>();
@@ -96,7 +96,7 @@ public class OnboardingSetupServiceTests : IDisposable
         }
         finally
         {
-            Environment.SetEnvironmentVariable("TENDRIL_HOME", originalTendrilHome);
+            TendrilHomeIsolation.Apply();
             Environment.SetEnvironmentVariable("TENDRIL_E2E", originalE2E);
         }
     }
@@ -106,7 +106,6 @@ public class OnboardingSetupServiceTests : IDisposable
     [InlineData("TENDRIL_NO_PERSIST_SHELL")]
     public async Task BootstrapTendrilHomeAsync_Should_Skip_Shell_And_Pointer_When_Test_Env_Vars_Set(string envVarName)
     {
-        var originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         var originalVal = Environment.GetEnvironmentVariable(envVarName);
         var tendrilHome = Path.Combine(_tempDir.Path, $"bootstrap-home-{envVarName.ToLowerInvariant()}");
         var logger = new TestLogger<OnboardingSetupService>();
@@ -147,7 +146,7 @@ public class OnboardingSetupServiceTests : IDisposable
         }
         finally
         {
-            Environment.SetEnvironmentVariable("TENDRIL_HOME", originalTendrilHome);
+            TendrilHomeIsolation.Apply();
             Environment.SetEnvironmentVariable(envVarName, originalVal);
         }
     }

--- a/src/Ivy.Tendril.Test/PromptwareCommandsTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareCommandsTests.cs
@@ -22,18 +22,22 @@ public class PromptwareCommandsTests
     [Fact]
     public void Handle_MatchesUpdatePromptwaresCommand()
     {
-        var prev = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        // An empty home rather than an unset TENDRIL_HOME: this dispatches into the real
+        // update-promptwares handler, and with no home set it would resolve (and write to) the
+        // machine's live Tendril home. See TendrilHomeIsolation.
+        var emptyHome = Path.Combine(TendrilHomeIsolation.Root, $"promptware-dispatch-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(emptyHome);
         var originalOut = Console.Out;
         try
         {
-            Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", emptyHome);
             Console.SetOut(new StringWriter());
             var result = PromptwareCommands.Handle(new[] { "update-promptwares" });
             Assert.NotEqual(-1, result);
         }
         finally
         {
-            Environment.SetEnvironmentVariable("TENDRIL_HOME", prev);
+            TendrilHomeIsolation.Apply();
             Console.SetOut(originalOut);
         }
     }

--- a/src/Ivy.Tendril.Test/TendrilHomeIsolation.cs
+++ b/src/Ivy.Tendril.Test/TendrilHomeIsolation.cs
@@ -1,0 +1,234 @@
+using System.Runtime.CompilerServices;
+using Ivy.Tendril.Helpers;
+using CrashLog = Ivy.Helpers.CrashLog;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+///     Pins the whole test assembly to a private, per-run Tendril home under the temp directory, so
+///     that nothing the suite does can reach the developer's (or CI runner's) live Tendril home.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This has to happen process-wide and before any test code runs, because
+///         <see cref="CrashLog.Path" /> is a <c>Lazy&lt;string&gt;</c> built once from the process
+///         <c>TENDRIL_HOME</c> environment variable and cached for the life of the process. A per-test
+///         fixture is therefore too late: whichever test first raises an exception through
+///         <c>JobLauncher</c> fixes the crash log location for every test after it. A
+///         <see cref="ModuleInitializerAttribute" /> runs before the first access to anything in this
+///         assembly, which is early enough.
+///     </para>
+///     <para>
+///         The initializer also forces <see cref="CrashLog.Path" /> while the isolated home is
+///         installed, so a later test that clears <c>TENDRIL_HOME</c> cannot move the crash log back
+///         onto the live home, and asserts the resulting paths really are isolated. The assertion
+///         throws, which fails the whole assembly loudly rather than silently polluting live state.
+///     </para>
+/// </remarks>
+public static class TendrilHomeIsolation
+{
+    private static string? _root;
+
+    /// <summary>The isolated Tendril home this test run is pinned to.</summary>
+    public static string Root => _root ?? throw new InvalidOperationException(
+        "TendrilHomeIsolation was never initialized; the module initializer should have run first.");
+
+    /// <summary>The <c>Plans</c> directory inside <see cref="Root" />.</summary>
+    public static string PlansRoot => Path.Combine(Root, "Plans");
+
+    /// <summary>The <c>crash.log</c> path the process resolved at startup.</summary>
+    public static string CrashLogPath { get; private set; } = "";
+
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        if (_root is not null) return;
+
+        var root = Path.Combine(Path.GetTempPath(), "ivy-tendril-test", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(Path.Combine(root, "Plans"));
+        _root = root;
+
+        Apply();
+
+        // Force CrashLog's cached Lazy<string> now, while the isolated home is installed.
+        CrashLogPath = CrashLog.Path;
+
+        AssertIsolated();
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => Cleanup();
+    }
+
+    /// <summary>
+    ///     (Re-)installs the isolated home. A test that installs its own temporary home should call this
+    ///     when tearing down, instead of restoring the <c>TENDRIL_HOME</c> value it captured or clearing
+    ///     the variable: clearing it hands the rest of the run back to the machine's real home.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Isolation is installed at exactly one layer: the process <c>TENDRIL_HOME</c> variable.
+    ///         That is the lowest layer that still shadows every source of live state
+    ///         <see cref="PathHelper.GetDefaultTendrilHome" /> would otherwise fall through to (the
+    ///         User-scope <c>TENDRIL_HOME</c> variable and the <c>~/.tendril_location</c> pointer file).
+    ///     </para>
+    ///     <para>
+    ///         <see cref="PathHelper.DefaultTendrilHomeOverride" /> is deliberately left <c>null</c>.
+    ///         It outranks <c>TENDRIL_HOME</c>, so pinning it assembly-wide would not just isolate the
+    ///         suite from the live home, it would also outrank the per-test temporary homes that most
+    ///         tests install through <c>TENDRIL_HOME</c>, and they would all read and write the shared
+    ///         root instead. The highest-priority hook has to stay free for per-test use.
+    ///     </para>
+    ///     <para>
+    ///         <c>TENDRIL_PLANS</c> is cleared for the same reason, in the other direction: a developer
+    ///         shell usually exports it pointing at the live <c>Plans</c> directory, and
+    ///         <see cref="PlanCommandHelpers.GetPlansDirectory" /> prefers it over the resolved home, so
+    ///         it must not be inherited. Pinning it to <see cref="PlansRoot" /> would again outrank the
+    ///         per-test homes. Clearing it makes the resolved home the single source of truth.
+    ///     </para>
+    /// </remarks>
+    public static void Apply()
+    {
+        PathHelper.DefaultTendrilHomeOverride = null;
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", Root);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
+    }
+
+    /// <summary>
+    ///     The Tendril homes configured on this machine, from the sources
+    ///     <see cref="PathHelper.GetDefaultTendrilHome" /> consults after the process environment:
+    ///     the User-scope <c>TENDRIL_HOME</c> variable and the <c>~/.tendril_location</c> pointer file.
+    /// </summary>
+    public static IReadOnlyList<string> GetMachineTendrilHomes()
+    {
+        var homes = new List<string>();
+
+        if (OperatingSystem.IsWindows())
+            try
+            {
+                var userHome = Environment.GetEnvironmentVariable("TENDRIL_HOME", EnvironmentVariableTarget.User)?.Trim();
+                if (!string.IsNullOrEmpty(userHome))
+                {
+                    if (userHome.StartsWith('"') && userHome.EndsWith('"'))
+                        userHome = userHome[1..^1];
+                    homes.Add(userHome);
+                }
+            }
+            catch
+            {
+                /* reading User-scope variables can be denied; not a reason to fail */
+            }
+
+        try
+        {
+            var pointerFile = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril_location");
+            if (File.Exists(pointerFile))
+            {
+                var location = File.ReadAllText(pointerFile).Trim();
+                if (!string.IsNullOrEmpty(location)) homes.Add(location);
+            }
+        }
+        catch
+        {
+            /* best effort */
+        }
+
+        return homes
+            .Select(NormalizePath)
+            .Where(h => h.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>Whether <paramref name="path" /> is <see cref="Root" /> or lives under it.</summary>
+    public static bool IsInsideRoot(string? path) => IsInside(path, Root);
+
+    /// <summary>Whether <paramref name="path" /> is <paramref name="directory" /> or lives under it.</summary>
+    public static bool IsInside(string? path, string directory)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return false;
+        var normalized = NormalizePath(path);
+        var parent = NormalizePath(directory);
+        return normalized.Equals(parent, StringComparison.OrdinalIgnoreCase)
+               || normalized.StartsWith(parent + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AssertIsolated()
+    {
+        var resolvedHome = PathHelper.GetDefaultTendrilHome();
+        var crashLogDir = Path.GetDirectoryName(CrashLogPath) ?? "";
+
+        // Effect-level checks: it is not enough that the override is set, the values the suite will
+        // actually write through have to land inside the isolated root.
+        if (!IsInsideRoot(resolvedHome))
+            throw new InvalidOperationException(Message(
+                $"PathHelper.GetDefaultTendrilHome() resolved to '{resolvedHome}'"));
+
+        if (!IsInsideRoot(crashLogDir))
+            throw new InvalidOperationException(Message(
+                $"Ivy.Helpers.CrashLog resolved to '{CrashLogPath}'"));
+
+        // Named explicitly so the failure message says which live home was about to be written to.
+        foreach (var machineHome in GetMachineTendrilHomes())
+        {
+            if (IsInside(resolvedHome, machineHome))
+                throw new InvalidOperationException(Message(
+                    $"PathHelper.GetDefaultTendrilHome() resolved to the machine's live Tendril home '{machineHome}'"));
+
+            if (IsInside(crashLogDir, machineHome))
+                throw new InvalidOperationException(Message(
+                    $"Ivy.Helpers.CrashLog resolved into the machine's live Tendril home '{machineHome}'"));
+        }
+
+        string Message(string detail) =>
+            $"Tendril home isolation failed: {detail}, which is not inside the test root '{Root}'. " +
+            "The test suite must never resolve the machine's real Tendril home - it would write " +
+            "crash.log entries and plan state into live data. See TendrilHomeIsolation.";
+    }
+
+    private static string NormalizePath(string path)
+    {
+        try
+        {
+            return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+        }
+        catch
+        {
+            return path.Trim();
+        }
+    }
+
+    private static void Cleanup()
+    {
+        var root = _root;
+        if (string.IsNullOrEmpty(root) || !Directory.Exists(root)) return;
+
+        try
+        {
+            foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+                try
+                {
+                    var attrs = File.GetAttributes(file);
+                    if ((attrs & FileAttributes.ReadOnly) != 0)
+                        File.SetAttributes(file, attrs & ~FileAttributes.ReadOnly);
+                }
+                catch
+                {
+                    /* best effort */
+                }
+        }
+        catch
+        {
+            /* best effort */
+        }
+
+        try
+        {
+            Directory.Delete(root, true);
+        }
+        catch
+        {
+            /* best effort cleanup; a leftover temp directory is harmless */
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test/TendrilHomeIsolationTests.cs
+++ b/src/Ivy.Tendril.Test/TendrilHomeIsolationTests.cs
@@ -1,0 +1,141 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+///     Guards <see cref="TendrilHomeIsolation" />. These assert the *effect* (where a write actually
+///     lands) rather than merely that the override property is set, because the defect being guarded
+///     against is production state being written to, not a property being unassigned.
+/// </summary>
+[Collection("TendrilHome")]
+public class TendrilHomeIsolationTests
+{
+    [Fact]
+    public void Root_IsAFreshDirectoryUnderTheTempPath()
+    {
+        Assert.True(Directory.Exists(TendrilHomeIsolation.Root));
+        Assert.True(Directory.Exists(TendrilHomeIsolation.PlansRoot));
+        Assert.StartsWith(
+            Path.GetFullPath(Path.Combine(Path.GetTempPath(), "ivy-tendril-test")),
+            Path.GetFullPath(TendrilHomeIsolation.Root),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolvedTendrilHome_IsInsideTheIsolatedRoot()
+    {
+        Assert.True(
+            TendrilHomeIsolation.IsInsideRoot(PathHelper.GetDefaultTendrilHome()),
+            $"GetDefaultTendrilHome() returned '{PathHelper.GetDefaultTendrilHome()}', " +
+            $"which is outside '{TendrilHomeIsolation.Root}'.");
+    }
+
+    [Fact]
+    public void ProcessEnvironment_NeverPointsAtTheMachinesLiveTendrilHome()
+    {
+        var home = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        Assert.True(
+            TendrilHomeIsolation.IsInsideRoot(home),
+            $"TENDRIL_HOME is '{home}', which is outside '{TendrilHomeIsolation.Root}'.");
+
+        foreach (var name in new[] { "TENDRIL_HOME", "TENDRIL_PLANS" })
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(value)) continue;
+
+            foreach (var machineHome in TendrilHomeIsolation.GetMachineTendrilHomes())
+                Assert.False(
+                    TendrilHomeIsolation.IsInside(value, machineHome),
+                    $"{name} is '{value}', which is inside the machine's live Tendril home '{machineHome}'.");
+        }
+    }
+
+    /// <summary>
+    ///     Isolation must not be installed at a layer that outranks the per-test temporary homes.
+    ///     <see cref="PathHelper.DefaultTendrilHomeOverride" /> beats <c>TENDRIL_HOME</c> and
+    ///     <c>TENDRIL_PLANS</c> beats the resolved home, so pinning either one assembly-wide would send
+    ///     every test that installs its own home through <c>TENDRIL_HOME</c> to the shared root instead.
+    /// </summary>
+    [Fact]
+    public void PerTestTendrilHome_StillOutranksTheAssemblyWideIsolation()
+    {
+        Assert.Null(PathHelper.DefaultTendrilHomeOverride);
+        Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TENDRIL_PLANS")));
+        Assert.Equal(TendrilHomeIsolation.PlansRoot, PlanCommandHelpers.GetPlansDirectory());
+
+        var perTestHome = Path.Combine(TendrilHomeIsolation.Root, "per-test-home");
+        Directory.CreateDirectory(Path.Combine(perTestHome, "Plans"));
+        try
+        {
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", perTestHome);
+            Assert.Equal(
+                Path.Combine(perTestHome, "Plans"),
+                PlanCommandHelpers.GetPlansDirectory());
+        }
+        finally
+        {
+            TendrilHomeIsolation.Apply();
+        }
+    }
+
+    [Fact]
+    public void ResolvedTendrilHome_IsNotTheMachinesLiveHome()
+    {
+        var resolved = Path.GetFullPath(PathHelper.GetDefaultTendrilHome());
+
+        foreach (var machineHome in TendrilHomeIsolation.GetMachineTendrilHomes())
+        {
+            Assert.False(
+                resolved.Equals(machineHome, StringComparison.OrdinalIgnoreCase),
+                $"The suite resolved the machine's live Tendril home '{machineHome}'.");
+            Assert.False(TendrilHomeIsolation.IsInsideRoot(machineHome));
+        }
+    }
+
+    [Fact]
+    public void CrashLogWrite_LandsInTheIsolatedRoot_AndNotInTheLiveHome()
+    {
+        var liveCrashLogs = TendrilHomeIsolation.GetMachineTendrilHomes()
+            .Select(home => Path.Combine(home, "crash.log"))
+            .ToDictionary(path => path, path => new FileInfo(path) is { Exists: true } fi ? fi.Length : -1L);
+
+        Assert.True(
+            TendrilHomeIsolation.IsInsideRoot(Path.GetDirectoryName(TendrilHomeIsolation.CrashLogPath)),
+            $"CrashLog resolved to '{TendrilHomeIsolation.CrashLogPath}', " +
+            $"which is outside '{TendrilHomeIsolation.Root}'.");
+
+        var marker = $"[TendrilHomeIsolationTests] {Guid.NewGuid():N}";
+        Ivy.Helpers.CrashLog.Write(marker);
+
+        Assert.True(File.Exists(TendrilHomeIsolation.CrashLogPath));
+        Assert.Contains(marker, File.ReadAllText(TendrilHomeIsolation.CrashLogPath));
+
+        foreach (var (path, lengthBefore) in liveCrashLogs)
+        {
+            var lengthAfter = new FileInfo(path) is { Exists: true } fi ? fi.Length : -1L;
+            Assert.Equal(lengthBefore, lengthAfter);
+        }
+    }
+
+    [Fact]
+    public void Apply_ReinstallsIsolationAfterATestClearsTheEnvironment()
+    {
+        try
+        {
+            PathHelper.DefaultTendrilHomeOverride = "D:\\live";
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
+            Environment.SetEnvironmentVariable("TENDRIL_PLANS", "D:\\live\\Plans");
+
+            TendrilHomeIsolation.Apply();
+
+            Assert.Null(PathHelper.DefaultTendrilHomeOverride);
+            Assert.Equal(TendrilHomeIsolation.Root, Environment.GetEnvironmentVariable("TENDRIL_HOME"));
+            Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TENDRIL_PLANS")));
+            Assert.True(TendrilHomeIsolation.IsInsideRoot(PathHelper.GetDefaultTendrilHome()));
+        }
+        finally
+        {
+            TendrilHomeIsolation.Apply();
+        }
+    }
+}


### PR DESCRIPTION
# Summary

`Ivy.Tendril.Test` no longer runs against the developer's live Tendril home. The assembly is pinned to
a private per-run home under the temp directory before any home resolution happens, and a guard fails
the suite loudly if that ever stops being true.

## What changed

**`src/Ivy.Tendril.Test/TendrilHomeIsolation.cs`** (new). A `[ModuleInitializer]` creates
`%TEMP%/ivy-tendril-test/<guid>` plus its `Plans` subfolder and installs it as the process
`TENDRIL_HOME`. It then forces `Ivy.Helpers.CrashLog.Path` while the isolated home is installed, runs
the guard, and registers a tolerant recursive cleanup on `ProcessExit`.

The module initializer is not a stylistic choice. `CrashLog` builds its path once from `TENDRIL_HOME`
into a `Lazy<string>` and caches it for the life of the process, so whichever test first raises through
`JobLauncher` would otherwise fix the crash log location for the entire run. A per-test fixture is too
late by construction.

**`src/Ivy.Tendril.Test/TendrilHomeIsolationTests.cs`** (new, 7 tests). These assert the *effect*
rather than that a property is assigned, since the defect is production state being written to. The
central one writes a unique marker through the real `CrashLog.Write`, reads it back out of the isolated
file, and asserts the live crash log is byte-for-byte unchanged.

**Four test files fixed.** `PromptwareReadMemoryCommandTests`, `DoctorChecksTests`,
`OnboardingSetupServiceTests` and `PromptwareCommandsTests` each handed the run back to the live home
on teardown. `OnboardingSetupServiceTests` also joined the `TendrilHome` collection; it was the one
`TENDRIL_HOME` mutating class still racing the classes that serialise on it.

## Result

| | Baseline (`e15ad782`) | After |
|---|---|---|
| Failed / Passed / Total | 23 / 3696 / 3720 | 23 / 3703 / 3727 |
| `D:\.tendril\crash.log` growth | **+4736 bytes** | **0 bytes** |

The 23 failures are the same tests, matched by name, that fail on the unmodified base commit. The
total grew by exactly the 7 tests added.

## Two findings worth carrying forward

**Isolation belongs at exactly one layer.** The plan asked for `DefaultTendrilHomeOverride`,
`TENDRIL_HOME` and `TENDRIL_PLANS` to all be pinned. Doing that broke 287 tests, because the override
outranks `TENDRIL_HOME` and `TENDRIL_PLANS` outranks the resolved home, so pinning them assembly-wide
also outranks the per-test temporary homes that ~38 classes install. Only `TENDRIL_HOME` is set now:
the lowest layer that still shadows all live-state fallbacks, leaving the higher hooks free for tests.
`PerTestTendrilHome_StillOutranksTheAssemblyWideIsolation` locks this in.

**`GetDefaultTendrilHome()` writes the live home back into the process environment**
(`PathHelper.cs:50`, `:66`). A teardown that clears `TENDRIL_HOME` therefore does not merely unset it,
it arms the next call to re-poison the process for every later test. This is what made the leak
survive, and it is why the guard found it when inspection alone had not. Removing that write-back is
the durable fix and is explicitly out of scope here; see `recommendations.md`.

---

## Commits

- 93bb5c3a [00453] Pin the test assembly to a private Tendril home before any home resolution
- 9cfb22f8 [00453] Stop four tests from handing the run back to the machine's live Tendril home

---
Created using [Ivy Tendril](https://ivy.app).