### PR TITLE
[00460] Key the Jobs Cell Cache on a Tuple Instead of a Joined String

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsAppRefreshGatingTests.cs
@@ -98,7 +98,7 @@ public class JobsAppRefreshGatingTests
     {
         var jobService = new FakeJobService();
         jobService.Jobs.Add(MakeJob("job-1", JobStatus.Running));
-        var cache = new Dictionary<string, string>();
+        var cache = new Dictionary<(string, string), string>();
 
         var updates = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
 
@@ -110,7 +110,7 @@ public class JobsAppRefreshGatingTests
     {
         var jobService = new FakeJobService();
         jobService.Jobs.Add(MakeJob("job-1", JobStatus.Running));
-        var cache = new Dictionary<string, string>();
+        var cache = new Dictionary<(string, string), string>();
 
         JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
         var second = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
@@ -124,7 +124,7 @@ public class JobsAppRefreshGatingTests
         var jobService = new FakeJobService();
         var job = MakeJob("job-1", JobStatus.Running);
         jobService.Jobs.Add(job);
-        var cache = new Dictionary<string, string>();
+        var cache = new Dictionary<(string, string), string>();
         JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
 
         job.Cost = 4.56m;
@@ -141,7 +141,7 @@ public class JobsAppRefreshGatingTests
         var job = MakeJob("job-1", JobStatus.Blocked);
         job.StatusMessage = "Waiting for Dep A";
         jobService.Jobs.Add(job);
-        var cache = new Dictionary<string, string>();
+        var cache = new Dictionary<(string, string), string>();
 
         JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
 
@@ -158,7 +158,7 @@ public class JobsAppRefreshGatingTests
     {
         var jobService = new FakeJobService();
         jobService.Jobs.Add(MakeJob("job-1", JobStatus.Running));
-        var cache = new Dictionary<string, string>();
+        var cache = new Dictionary<(string, string), string>();
         JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
         Assert.NotEmpty(cache);
 
@@ -166,6 +166,28 @@ public class JobsAppRefreshGatingTests
         JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
 
         Assert.Empty(cache);
+    }
+
+    /// <summary>
+    ///     What the (RowId, ColumnName) key buys over a "{rowId} {columnName}" string: the pruning
+    ///     predicate compares the job id itself, not the text before the first space. Under the joined key
+    ///     a *live* job whose id contains a space had its "job 1 x Timer" key split back to "job", which
+    ///     matches no live job id, so every one of its entries was pruned on every tick - silently
+    ///     defeating the cache and re-sending all six cells each second. Pruning a job that really is gone
+    ///     is unaffected either way and is covered by the test above.
+    /// </summary>
+    [Fact]
+    public void BuildDataTableUpdates_KeepsCacheForLiveJobWhoseIdContainsASpace()
+    {
+        var jobService = new FakeJobService();
+        jobService.Jobs.Add(MakeJob("job 1 x", JobStatus.Running));
+        var cache = new Dictionary<(string, string), string>();
+
+        JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+        var second = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+
+        Assert.Empty(second);
+        Assert.Equal(StreamedColumns.Length, cache.Count);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableFilterTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableFilterTests.cs
@@ -49,7 +49,7 @@ public class JobsTableFilterTests
         jobService.Jobs.Add(runningJob);
         jobService.Jobs.Add(timeoutJob);
 
-        var cache = new Dictionary<string, string>();
+        var cache = new Dictionary<(string, string), string>();
         var updates = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
 
         var statusUpdates = updates
@@ -141,7 +141,7 @@ public class JobsTableFilterTests
         var jobService = new FilterTestFakeJobService();
         jobService.Jobs.Add(MakeJob("job-running", JobStatus.Running));
 
-        var updates = JobsApp.BuildDataTableUpdates(jobService, new Dictionary<string, string>()).ToList();
+        var updates = JobsApp.BuildDataTableUpdates(jobService, new Dictionary<(string, string), string>()).ToList();
 
         // The value only changes on a terminal transition, which already forces a full rebuild through
         // BuildJobRows. A seventh cell here would be dead weight.

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -87,16 +87,17 @@ public partial class JobsApp
 
     /// <summary>
     /// Builds the candidate cell set exactly as before, then keeps only cells whose value actually
-    /// changed since the previous tick, per <paramref name="lastSent"/> (keyed by "{jobId} {columnName}",
-    /// owned by the caller so it survives across ticks). Keys for jobs no longer returned by the
-    /// service are pruned so the cache cannot grow without bound as jobs are evicted.
+    /// changed since the previous tick, per <paramref name="lastSent"/> (keyed by the
+    /// (jobId, columnName) pair, owned by the caller so it survives across ticks). Keys for jobs no
+    /// longer returned by the service are pruned so the cache cannot grow without bound as jobs are
+    /// evicted.
     /// </summary>
     internal static IEnumerable<DataTableCellUpdate> BuildDataTableUpdates(
-        IJobService jobService, Dictionary<string, string> lastSent)
+        IJobService jobService, Dictionary<(string RowId, string ColumnName), string> lastSent)
     {
         var currentJobs = jobService.GetJobs();
         var currentJobIds = currentJobs.Select(j => j.Id).ToHashSet(StringComparer.Ordinal);
-        foreach (var staleKey in lastSent.Keys.Where(k => !currentJobIds.Contains(k.Split(' ')[0])).ToList())
+        foreach (var staleKey in lastSent.Keys.Where(k => !currentJobIds.Contains(k.RowId)).ToList())
             lastSent.Remove(staleKey);
 
         var candidates = currentJobs
@@ -116,7 +117,9 @@ public partial class JobsApp
 
         foreach (var update in candidates)
         {
-            var key = $"{update.RowId} {update.ColumnName}";
+            // A hard cast, not a ToString(): every candidate above is built from j.Id, a string, so a
+            // failure here means that invariant broke and should say so loudly.
+            var key = ((string)update.RowId, update.ColumnName);
             var value = update.Value as string ?? update.Value?.ToString() ?? "";
             if (lastSent.TryGetValue(key, out var previous) && previous == value) continue;
             lastSent[key] = value;

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -98,7 +98,7 @@ public partial class JobsApp : ViewBase
             refreshToken.Refresh();
         }, TimeSpan.FromSeconds(5));
 
-        var sentCells = UseRef(new Dictionary<string, string>(StringComparer.Ordinal));
+        var sentCells = UseRef(new Dictionary<(string RowId, string ColumnName), string>());
         var updateStream = UseDataTableUpdates(
             Observable.Interval(TimeSpan.FromSeconds(1))
                 .SelectMany(_ => JobsApp.BuildDataTableUpdates(jobService, sentCells.Value)));


### PR DESCRIPTION
# Summary

## Changes

`JobsApp.BuildDataTableUpdates` now keys its already-sent cell cache on a
`(string RowId, string ColumnName)` tuple instead of the two values joined with a space, so the
`Split(' ')[0]` parse that recovered the job id when pruning is gone and the pruning predicate
compares the job id itself. No behaviour change for the ids in use today (numeric stems), and the
`StringComparer.Ordinal` argument on the caller's dictionary drops out because the default comparer
for `ValueTuple<string, string>` is already ordinal.

## API Changes

- `JobsApp.BuildDataTableUpdates(IJobService, Dictionary<string, string>)` becomes
  `JobsApp.BuildDataTableUpdates(IJobService, Dictionary<(string RowId, string ColumnName), string>)`.
  `internal static`, so the only callers are the Jobs app and its two test classes, all updated.

## Files Modified

Production:
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs` - signature, pruning predicate, key construction (a hard
  `(string)update.RowId` cast, deliberately loud if the "RowId is always `j.Id`" invariant ever breaks),
  and the doc comment that documented the old key shape.
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.cs` - the single production caller's `UseRef` dictionary.

Tests:
- `src/Ivy.Tendril.Test/Apps/Jobs/JobsAppRefreshGatingTests.cs` - five cache declarations retyped, plus
  a new `BuildDataTableUpdates_KeepsCacheForLiveJobWhoseIdContainsASpace`.
- `src/Ivy.Tendril.Test/Apps/Jobs/JobsTableFilterTests.cs` - two cache declarations retyped.

## Deviation from the plan

The regression test the plan specified does not discriminate between the old and new implementations,
because the plan's account of the defect inverts the pruning predicate. A test that does discriminate
was written instead, and verified failing against the old predicate. Full reasoning is in
`Verification/CheckResult.md`.

## Manual Testing

N/A - internal refactor with no user-facing behaviour change. The observable behaviour of the Jobs
table (live Timer / Cost / Tokens / AgentOutput / Status / StatusMessage cells updating once per
second, and only when their value changed) is identical, and is covered by the 21 tests in
`JobsAppRefreshGatingTests` and `JobsTableFilterTests`.

If you want to eyeball it anyway: run
`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`, open the Jobs
app, start any job, and watch the Timer and Cost cells tick without the table flickering or
re-ordering.


---

## Commits

- 12df69bb Key the Jobs cell cache on a (RowId, ColumnName) tuple
- 24a64874 Update Jobs cell cache tests for the tuple key

---
Created using [Ivy Tendril](https://ivy.app).