### PR TITLE
[00461] Guard Hidden DataTable Columns Against Staying Filterable

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/HiddenColumnsAreNotFilterableTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/HiddenColumnsAreNotFilterableTests.cs
@@ -1,0 +1,103 @@
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Test.TestHelpers;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps;
+
+/// <summary>
+///     <c>Hidden</c> and <c>Filterable</c> are independent settings on an Ivy <c>DataTable</c> column: the
+///     frontend builds the filter dropdown from <c>filterable</c> alone and never consults <c>hidden</c>, and
+///     <c>Filterable</c> defaults to <c>true</c>. So a column that is only hidden is still offered as a filter
+///     target the user cannot see. Every hidden column therefore needs a matching
+///     <c>.Filterable(t =&gt; t.X, false)</c>, and this test fails when one is added without it.
+///     Pinned as source text because the columns live in a private dictionary of a private nested type inside
+///     the Ivy builder and are only surfaced from <c>Build()</c>, which needs a view <c>Context</c>.
+/// </summary>
+public class HiddenColumnsAreNotFilterableTests
+{
+    private static readonly Regex HiddenCall = new(@"\.Hidden\((?<args>[^)]*)\)", RegexOptions.Compiled);
+    private static readonly Regex Selector = new(@"(?<p>\w+)\s*=>\s*\k<p>\.(?<prop>\w+)", RegexOptions.Compiled);
+
+    private static readonly Regex NonFilterable =
+        new(@"\.Filterable\(\s*(?<p>\w+)\s*=>\s*\k<p>\.(?<prop>\w+)\s*,\s*false\s*\)", RegexOptions.Compiled);
+
+    [Fact]
+    public void EveryHiddenColumnIsAlsoNonFilterable()
+    {
+        var offenders = new List<string>();
+
+        foreach (var (relativePath, columns) in Census())
+        {
+            foreach (var property in columns.Hidden.Except(columns.NonFilterable).OrderBy(p => p, StringComparer.Ordinal))
+            {
+                offenders.Add($"{relativePath}: {property}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Hidden DataTable column(s) with no matching Filterable(..., false):\n"
+            + string.Join("\n", offenders.Select(o => "  " + o)) + "\n"
+            + "A hidden column stays filterable, so it appears in the filter dropdown as a column the user\n"
+            + "cannot see. Add .Filterable(t => t.X, false) beside each .Hidden(t => t.X).");
+    }
+
+    [Fact]
+    public void TheAuditActuallySeesTheJobsTableColumns()
+    {
+        // Without this, a regex that stops matching makes the fact above pass vacuously.
+        var census = Census();
+        const string jobsTable = "src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs";
+
+        Assert.True(census.TryGetValue(jobsTable, out var columns),
+            $"The census found no hidden columns in {jobsTable}. Its .Hidden(...) calls, or the regexes in "
+            + "this test, have changed - the guard above is now vacuous.");
+
+        Assert.Contains("Id", columns!.Hidden);
+        Assert.Contains("ErrorContext", columns.Hidden);
+        Assert.Contains("Id", columns.NonFilterable);
+        Assert.Contains("ErrorContext", columns.NonFilterable);
+    }
+
+    /// <summary>
+    ///     Hidden and explicitly-non-filterable column names per source file, keyed by repo-relative path with
+    ///     forward slashes. Files declaring no hidden column are omitted. Paired per file rather than per
+    ///     builder chain: a chain has no delimiter in source text, and the property names of two tables in one
+    ///     file do not collide in a way that matters here.
+    /// </summary>
+    private static Dictionary<string, Columns> Census()
+    {
+        var repoRoot = RepoRoot.Find();
+        var productDir = Path.Combine(repoRoot, "src", "Ivy.Tendril");
+        var census = new Dictionary<string, Columns>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in Directory.EnumerateFiles(productDir, "*.cs", SearchOption.AllDirectories)
+                     .Where(f => !f.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar) &&
+                                 !f.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+                     .OrderBy(f => f, StringComparer.OrdinalIgnoreCase))
+        {
+            var source = File.ReadAllText(file);
+
+            // Hidden takes params, so the selector list has to be parsed rather than assumed to be single.
+            var hidden = HiddenCall.Matches(source)
+                .SelectMany(m => Selector.Matches(m.Groups["args"].Value))
+                .Select(m => m.Groups["prop"].Value)
+                .ToHashSet(StringComparer.Ordinal);
+
+            if (hidden.Count == 0)
+            {
+                continue;
+            }
+
+            var nonFilterable = NonFilterable.Matches(source)
+                .Select(m => m.Groups["prop"].Value)
+                .ToHashSet(StringComparer.Ordinal);
+
+            var relativePath = Path.GetRelativePath(repoRoot, file).Replace(Path.DirectorySeparatorChar, '/');
+            census[relativePath] = new Columns(hidden, nonFilterable);
+        }
+
+        return census;
+    }
+
+    private sealed record Columns(HashSet<string> Hidden, HashSet<string> NonFilterable);
+}

--- a/src/Ivy.Tendril.Test/PlansChangedSubscriberAuditTests.cs
+++ b/src/Ivy.Tendril.Test/PlansChangedSubscriberAuditTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Ivy.Tendril.Test.TestHelpers;
 
 namespace Ivy.Tendril.Test;
 
@@ -40,7 +41,7 @@ public class PlansChangedSubscriberAuditTests
     [Fact]
     public void EveryPlansChangedSubscriber_IsAudited()
     {
-        var repoRoot = FindRepoRoot();
+        var repoRoot = RepoRoot.Find();
         var found = FindSubscriberFiles(repoRoot);
 
         var unaudited = found.Except(AuditedSubscribers.Keys, StringComparer.OrdinalIgnoreCase).ToList();
@@ -60,7 +61,7 @@ public class PlansChangedSubscriberAuditTests
     {
         // The other direction: an entry left behind after its subscription is removed makes the audit
         // read as broader than it is.
-        var repoRoot = FindRepoRoot();
+        var repoRoot = RepoRoot.Find();
         var found = FindSubscriberFiles(repoRoot);
 
         var stale = AuditedSubscribers.Keys.Except(found, StringComparer.OrdinalIgnoreCase).ToList();
@@ -75,7 +76,7 @@ public class PlansChangedSubscriberAuditTests
     {
         // The census above cannot see whether a view still gates, only that it subscribes - so assert the
         // gate itself for the two views that render one plan.
-        var repoRoot = FindRepoRoot();
+        var repoRoot = RepoRoot.Find();
 
         foreach (var relative in SinglePlanViews)
         {
@@ -93,7 +94,7 @@ public class PlansChangedSubscriberAuditTests
         // open plan's content stayed as it was first read. Pinned as source text because the repo has no
         // way to render a view in a test - the coalescing behaviour itself is covered at the hook seam in
         // PlansContentViewRefreshTests.
-        var repoRoot = FindRepoRoot();
+        var repoRoot = RepoRoot.Find();
         var source = File.ReadAllText(
             Path.Combine(repoRoot, "src", "Ivy.Tendril", "Apps", "Plans", "ContentView.cs"));
 
@@ -113,19 +114,5 @@ public class PlansChangedSubscriberAuditTests
             .Select(f => Path.GetRelativePath(repoRoot, f).Replace(Path.DirectorySeparatorChar, '/'))
             .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
             .ToList();
-    }
-
-    private static string FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "src", "Ivy.Tendril", "Ivy.Tendril.slnx")))
-            {
-                return dir.FullName;
-            }
-            dir = dir.Parent;
-        }
-        throw new DirectoryNotFoundException("Could not locate repository root from BaseDirectory: " + AppDomain.CurrentDomain.BaseDirectory);
     }
 }

--- a/src/Ivy.Tendril.Test/TestHelpers/RepoRoot.cs
+++ b/src/Ivy.Tendril.Test/TestHelpers/RepoRoot.cs
@@ -1,0 +1,20 @@
+namespace Ivy.Tendril.Test.TestHelpers;
+
+/// <summary>Locates the repo root from the test binary, for tests that audit source text.</summary>
+internal static class RepoRoot
+{
+    public static string Find()
+    {
+        var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "src", "Ivy.Tendril", "Ivy.Tendril.slnx")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate repository root from BaseDirectory: " + AppDomain.CurrentDomain.BaseDirectory);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
@@ -326,6 +326,8 @@ public class ContentView(
             .Renderer(t => t.Repository, new LabelsDisplayRenderer())
             .Hidden(t => t.Id)
             .Hidden(t => t.Number)
+            .Filterable(t => t.Id, false)
+            .Filterable(t => t.Number, false)
             .Config(c =>
             {
                 c.AllowSorting = true;
@@ -369,7 +371,9 @@ public class ContentView(
 
         if (rows.All(r => string.IsNullOrEmpty(r.Branch)))
         {
-            dataTable = dataTable.Hidden(t => t.Branch);
+            dataTable = dataTable
+                .Hidden(t => t.Branch)
+                .Filterable(t => t.Branch, false);
         }
 
         return Layout.Vertical().Height(Size.Full())
@@ -559,6 +563,8 @@ public class IssuesTableView(
             .Renderer(t => t.Repository, new LabelsDisplayRenderer())
             .Hidden(t => t.Id)
             .Hidden(t => t.Number)
+            .Filterable(t => t.Id, false)
+            .Filterable(t => t.Number, false)
             .Config(c =>
             {
                 c.AllowSorting = true;

--- a/src/Ivy.Tendril/Apps/PullRequest/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequest/PullRequestApp.cs
@@ -150,6 +150,9 @@ public class PullRequestApp : ViewBase
             .Hidden(t => t.Id)
             .Hidden(t => t.PlanId)
             .Hidden(t => t.PlanFolderPath)
+            .Filterable(t => t.Id, false)
+            .Filterable(t => t.PlanId, false)
+            .Filterable(t => t.PlanFolderPath, false)
             .Config(c =>
             {
                 c.AllowSorting = true;

--- a/src/Ivy.Tendril/Apps/Views/PlanJobsDataTableView.cs
+++ b/src/Ivy.Tendril/Apps/Views/PlanJobsDataTableView.cs
@@ -53,6 +53,7 @@ public class PlanJobsDataTableView(List<JobItem> jobs, Action<string> showDebug,
             })
             .Renderer(t => t.StatusMessage, new TextDisplayRenderer())
             .Hidden(t => t.Id)
+            .Filterable(t => t.Id, false)
             .Config(c =>
             {
                 c.AllowSorting = false;


### PR DESCRIPTION
# Summary

## Changes

Added a source-text guard test that fails when a `DataTable` column is marked `.Hidden(...)` without a
matching `.Filterable(..., false)`, so a hidden column can no longer be silently offered in the filter
dropdown as a column the user cannot see. The guard runs repo-wide over `src/Ivy.Tendril` and found
seven such columns already live in the Inbox, PullRequest and PlanJobs tables, all of which are now
fixed. The repo-root walk-up that source-text audits need was extracted from
`PlansChangedSubscriberAuditTests` into a shared test helper rather than copied.

## API Changes

None. `RepoRoot` is `internal` to `Ivy.Tendril.Test`; the rest is column configuration on existing
views.

## Files Modified

**New tests / helper**

- `src/Ivy.Tendril.Test/Apps/HiddenColumnsAreNotFilterableTests.cs` - the guard.
  `EveryHiddenColumnIsAlsoNonFilterable` censuses every `.cs` file under `src/Ivy.Tendril` and asserts
  the hidden set is a subset of the explicitly-non-filterable set, naming file, property and fix on
  failure. `TheAuditActuallySeesTheJobsTableColumns` pins the Jobs table's `Id` / `ErrorContext` so the
  first fact cannot pass vacuously if a regex stops matching.
- `src/Ivy.Tendril.Test/TestHelpers/RepoRoot.cs` - `RepoRoot.Find()`, the walk-up to the repo root.
- `src/Ivy.Tendril.Test/PlansChangedSubscriberAuditTests.cs` - private `FindRepoRoot` deleted, its
  four call sites now use `RepoRoot.Find()`.

**Filter fixes (behaviour change: these columns leave the filter dropdown)**

- `src/Ivy.Tendril/Apps/Inbox/ContentView.cs` - reviews table `Id`, `Number`; issues table `Id`,
  `Number`; `Branch` inside the `if (rows.All(...))` block so a visible Branch column keeps its filter.
- `src/Ivy.Tendril/Apps/PullRequest/PullRequestApp.cs` - `Id`, `PlanId`, `PlanFolderPath`.
- `src/Ivy.Tendril/Apps/Views/PlanJobsDataTableView.cs` - `Id` (redundant today since that table sets
  `AllowFiltering = false`, kept so the rule stays uniform and the guard stays dumb).

## Manual Testing

1. Run the app: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`.
2. Open the **Inbox** app, pick the pull-request review list, and open the table's filter dropdown.
   Observe that `Id` and `Number` are no longer offered as filter columns; `Repository`, `Review`,
   `Updated` still are. If every row has an empty branch (so the Branch column is hidden), `Branch` is
   absent from the dropdown too; if branches are shown, `Branch` is still filterable.
3. Switch to the Inbox issues list and open its filter dropdown: `Id` and `Number` are gone there as
   well.
4. Open the **Pull Requests** app and open its filter dropdown: `Id`, `Plan Id` and `Plan Folder Path`
   are gone. Confirm the table is still sorted by Plan Id descending, i.e. hiding the filter did not
   break sorting on a hidden column.
5. Open the **Jobs** app filter dropdown and confirm it is unchanged (`Id` and `ErrorContext` were
   already excluded, this plan did not touch them).

---

## Commits

- baa61b5c [00461] Extract the repo-root walk-up into a shared test helper
- 5cf0c206 [00461] Stop offering filters on hidden columns in Inbox, PullRequest and PlanJobs
- d2131d0f [00461] Guard hidden DataTable columns against staying filterable

---
Created using [Ivy Tendril](https://ivy.app).