### PR TITLE
[00458] Fix Nested Double Quotes That Break the Widget Playwright Suite

### DIFF
--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
@@ -94,32 +94,32 @@ test.describe("DraftMarkdown Questions", () => {
     // This sample persists: it feeds every event through QuestionAnswers.Apply and hands the widget
     // the updated markdown, so a selection has to survive the round trip and come back rendered.
     const callout = blockFor(page, "retry-scope");
-    await expect(callout.locator(".tq-option[data-selected="true"]")).toHaveCount(0);
+    await expect(callout.locator('.tq-option[data-selected="true"]')).toHaveCount(0);
 
     await callout.locator(".tq-option-input").first().click();
-    await expect(callout.locator(".tq-option[data-selected="true"]")).toHaveCount(1, { timeout: 15_000 });
+    await expect(callout.locator('.tq-option[data-selected="true"]')).toHaveCount(1, { timeout: 15_000 });
 
     // Single-select, so the second choice replaces the first rather than joining it.
     await callout.locator(".tq-option-input").nth(1).click();
-    await expect(callout.locator(".tq-option[data-selected="true"]")).toHaveCount(1, { timeout: 15_000 });
+    await expect(callout.locator('.tq-option[data-selected="true"]')).toHaveCount(1, { timeout: 15_000 });
     await expect(callout.locator(".tq-option").nth(1)).toHaveAttribute("data-selected", "true");
 
     await stepScreenshot("answer-merged");
 
     // Clear takes the answer key back out, so nothing is selected again.
     await callout.locator(".tq-clear").click();
-    await expect(callout.locator(".tq-option[data-selected="true"]")).toHaveCount(0, { timeout: 15_000 });
+    await expect(callout.locator('.tq-option[data-selected="true"]')).toHaveCount(0, { timeout: 15_000 });
   });
 
   test("a multi-select answer accumulates", async ({ page }) => {
     const callout = blockFor(page, "launch-channels");
 
     await callout.locator(".tq-option-input").first().click();
-    await expect(callout.locator(".tq-option[data-selected="true"]")).toHaveCount(1, { timeout: 15_000 });
+    await expect(callout.locator('.tq-option[data-selected="true"]')).toHaveCount(1, { timeout: 15_000 });
 
     // multiple: true, so the second option joins the first instead of replacing it.
     await callout.locator(".tq-option-input").nth(1).click();
-    await expect(callout.locator(".tq-option[data-selected="true"]")).toHaveCount(2, { timeout: 15_000 });
+    await expect(callout.locator('.tq-option[data-selected="true"]')).toHaveCount(2, { timeout: 15_000 });
   });
 
   test("both questions of a block are on screen at once", async ({ page, stepScreenshot }) => {


### PR DESCRIPTION
# Summary

## Changes

Requoted six assertions in `src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts`
that nested double quotes inside a double-quoted string (`".tq-option[data-selected="true"]"`), which
made the file unparseable and, because Playwright loads every spec before running any, took the entire
widget test suite down. The outer quotes are now single and the CSS selector text is byte-identical.
`npx playwright test --list` goes from exiting 1 with a Babel `SyntaxError` and listing nothing, to
exiting 0 and listing 49 tests across all six spec files.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts` - six lines (97, 100, 104,
  111, 118, 122), outer string quotes only. No other file in the repository was touched.

## Manual Testing

```powershell
cd src/Ivy.Tendril.Widgets/.tests
npx --prefer-offline -y pnpm@10.33.0 install     # ~300ms, 3 packages
npx playwright install chromium                   # no-op if the pinned build is cached
npx playwright test --list                        # the actual gate
```

Expect exit 0 and `Total: 49 tests in 6 files`, with tests listed from `annotations`, `collapsible`,
`questions`, `rendering`, `sticky-content` and `web-viewer/inspector`. On `development` the same command
dies with `SyntaxError: ... Unexpected token, expected "," (97:60)` and lists nothing at all.

Optionally run the specs this unblocks (~8 minutes; `global-setup.ts` builds `.samples` and spawns its
own server):

```powershell
npx playwright test widgets/draft-markdown
```

Expect **29 passed / 15 failed**. All 15 are pre-existing behaviour problems, none caused by this
change: 9 are the inherited `annotations` / `collapsible` / `rendering` failures already tracked on plan
00428, and 6 are in `questions.spec.ts` itself, which had never executed before this repair. The 6 are
filed as recommendations on this plan and were deliberately left unrepaired, per the plan's instruction
not to rewrite assertions to match current DOM behaviour. See
[CheckResult.md](file:///D:/.tendril/Plans/00458-FixNestedDoubleQuotesTha/Verification/CheckResult.md)
for the per-test attribution.

---

## Commits

- 7ed914c9381a1cc7d3052408097dbe4092a05d1c [00458] Requote the data-selected selectors so the widget suite parses

---
Created using [Ivy Tendril](https://ivy.app).