### PR TITLE
[00455] Drop Redundant JobsApp Prefixes in JobsApp.Data.cs

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -14,7 +14,7 @@ public partial class JobsApp
     {
         return jobs.Select(j =>
         {
-            var planId = JobsApp.ExtractPlanId(j.PlanFile);
+            var planId = ExtractPlanId(j.PlanFile);
             if (string.IsNullOrEmpty(planId) && !string.IsNullOrEmpty(j.ReportedPlanId))
                 planId = j.ReportedPlanId;
 
@@ -23,17 +23,17 @@ public partial class JobsApp
                 Id = j.Id,
                 Status = j.Status.ToString(),
                 PlanId = planId,
-                Prompt = JobsApp.GetPromptDisplay(j, planService),
+                Prompt = GetPromptDisplay(j, planService),
                 Type = j.Type,
                 Project = string.Join(", ", ProjectHelper.ParseProjects(j.Project)),
-                Timer = JobsApp.FormatTimer(j),
-                Timestamp = JobsApp.FormatTimestamp(j),
+                Timer = FormatTimer(j),
+                Timestamp = FormatTimestamp(j),
                 Cost = FormatJobCost(j),
                 Tokens = j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : "",
-                AgentOutput = JobsApp.FormatAgentOutput(j),
-                StatusMessage = JobsApp.GetStatusMessage(j),
+                AgentOutput = FormatAgentOutput(j),
+                StatusMessage = GetStatusMessage(j),
                 ErrorContext = j.Status is JobStatus.Failed or JobStatus.Timeout
-                    ? JobsApp.GetErrorContext(j)
+                    ? GetErrorContext(j)
                     : null
             };
         })
@@ -77,7 +77,7 @@ public partial class JobsApp
         var statusSegments = statusGroups
             .Select(g => new ProgressSegment(
                 g.Count,
-                JobsApp.GetStatusColor(g.Status),
+                GetStatusColor(g.Status),
                 g.Status.ToString()
             ))
             .ToArray();
@@ -106,12 +106,12 @@ public partial class JobsApp
                          && DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromMinutes(1)))
             .SelectMany(j => new[]
             {
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Timer), JobsApp.FormatTimer(j)),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Timer), FormatTimer(j)),
                 new DataTableCellUpdate(j.Id, nameof(JobItemRow.Cost), FormatJobCost(j)),
                 new DataTableCellUpdate(j.Id, nameof(JobItemRow.Tokens), j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : ""),
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.AgentOutput), JobsApp.FormatAgentOutput(j)),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.AgentOutput), FormatAgentOutput(j)),
                 new DataTableCellUpdate(j.Id, nameof(JobItemRow.Status), j.Status.ToString()),
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.StatusMessage), JobsApp.GetStatusMessage(j))
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.StatusMessage), GetStatusMessage(j))
             });
 
         foreach (var update in candidates)

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -116,7 +116,7 @@ public partial class JobsApp
                 var planId = e.Value.CellValue?.ToString();
                 if (!string.IsNullOrEmpty(planId))
                 {
-                    var job = jobs.FirstOrDefault(j => JobsApp.ExtractPlanId(j.PlanFile) == planId);
+                    var job = jobs.FirstOrDefault(j => ExtractPlanId(j.PlanFile) == planId);
                     if (job != null && !string.IsNullOrEmpty(job.PlanFile))
                     {
                         var fullPath = Path.Combine(planService.PlansDirectory, job.PlanFile);
@@ -187,7 +187,7 @@ public partial class JobsApp
                     var job = jobs.FirstOrDefault(j => j.Id == id);
                     if (job != null)
                     {
-                        var fullPrompt = JobsApp.GetFullPrompt(job, planService);
+                        var fullPrompt = GetFullPrompt(job, planService);
                         if (!string.IsNullOrEmpty(fullPrompt))
                             showPrompt(fullPrompt);
                     }

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -40,7 +40,7 @@ public partial class JobsApp : ViewBase
         {
             if (!isOpen.Value) return null;
             var job = jobService.GetJob(jobId);
-            var title = job is not null ? $"{job.Type} {JobsApp.ExtractPlanId(job.PlanFile)}" : "Job Output";
+            var title = job is not null ? $"{job.Type} {ExtractPlanId(job.PlanFile)}" : "Job Output";
             return new Sheet(
                 () => isOpen.Set(false),
                 new OutputSheet(jobId, jobService),
@@ -91,25 +91,25 @@ public partial class JobsApp : ViewBase
 
         // Gated on the same signature the interval below compares, so a burst of job exits that leaves
         // the table looking identical costs no rebuild at all.
-        UseEffect(() => JobsApp.JobChangeHookDisposable(jobService, refreshToken, () => renderedSignature.Value));
+        UseEffect(() => JobChangeHookDisposable(jobService, refreshToken, () => renderedSignature.Value));
         UseInterval(() =>
         {
-            if (JobsApp.ComputeStructuralSignature(jobService.GetJobs()) == renderedSignature.Value) return;
+            if (ComputeStructuralSignature(jobService.GetJobs()) == renderedSignature.Value) return;
             refreshToken.Refresh();
         }, TimeSpan.FromSeconds(5));
 
         var sentCells = UseRef(new Dictionary<string, string>(StringComparer.Ordinal));
         var updateStream = UseDataTableUpdates(
             Observable.Interval(TimeSpan.FromSeconds(1))
-                .SelectMany(_ => JobsApp.BuildDataTableUpdates(jobService, sentCells.Value)));
+                .SelectMany(_ => BuildDataTableUpdates(jobService, sentCells.Value)));
 
         var jobs = jobService.GetJobs();
-        renderedSignature.Value = JobsApp.ComputeStructuralSignature(jobs);
+        renderedSignature.Value = ComputeStructuralSignature(jobs);
         var projectColors = BuildProjectColorMapping(config);
         var rows = BuildJobRows(jobs, planService);
         var jobsProgress = jobs.Count > 0 ? BuildStatusProgress(jobs, config) : null;
 
-        var dataTable = JobsApp.BuildDataTable(nav, rows, refreshToken, updateStream, config, planService,
+        var dataTable = BuildDataTable(nav, rows, refreshToken, updateStream, config, planService,
             jobService, client, showPlan, showOutput, showPrompt, showDebug, showCost, showRerun, jobs, projectColors,
             jobsProgress, confirmDeleteOpen, deleteJobId, confirmStopQueuedOpen, confirmStopAllOpen);
 


### PR DESCRIPTION
# Summary

## Changes

Removed the redundant `JobsApp.` qualifier from all 19 self-references across three partials of `JobsApp`, which had been applied inconsistently inside the type that declares the members. The diff is 19 insertions and 19 deletions: every changed line drops one token and nothing else. The plan's `sibling-partials-scope` question was answered `all-partials`, so `JobsApp.cs` (6 sites) and `JobsApp.DataTable.cs` (2 sites) were cleaned alongside the 11 in `JobsApp.Data.cs`.

## API Changes

None. No signature, accessibility, ordering or behaviour changed. The 13 distinct methods involved are all `static` members of the same partial type, so unqualified lookup binds to exactly the same members; the compiler confirms this by building clean. Calls from *outside* the type keep their prefix, including `RerunJobDialog.cs:107`, which is now the only `JobsApp.` left in `Apps/Jobs`.

## Files Modified

All under `src/Ivy.Tendril/Apps/Jobs/`:

- `JobsApp.Data.cs` - 11 sites: `ExtractPlanId`, `GetPromptDisplay`, `FormatTimer` (x2), `FormatTimestamp`, `FormatAgentOutput` (x2), `GetStatusMessage` (x2), `GetErrorContext`, `GetStatusColor`
- `JobsApp.cs` - 6 sites: `ExtractPlanId`, `JobChangeHookDisposable`, `ComputeStructuralSignature` (x2), `BuildDataTableUpdates`, `BuildDataTable`
- `JobsApp.DataTable.cs` - 2 sites: `ExtractPlanId`, `GetFullPrompt`

No test files changed: the plan specifies no new tests, since a no-op refactor has no new behaviour to pin and the compiler already proves the binding.

## Manual Testing

N/A - internal change with no user-facing behaviour. The Jobs table renders identically; the edit deletes a type name from calls to the enclosing type's own static helpers.

If you want a smoke check anyway: run `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`, open the Jobs app, and confirm the Status, PlanId, Prompt, Timer, Timestamp, Cost, Tokens, AgentOutput and StatusMessage columns populate and that the Timer/Cost/Tokens/StatusMessage cells still tick live once a second. Clicking a PlanId cell and a Prompt cell exercises the two `JobsApp.DataTable.cs` sites.

## Verification

| verification | result |
|---|---|
| DotnetFormat | Pass - `--verify-no-changes` exit 0, no reformatting needed |
| DotnetBuild | Pass - 0 warnings, 0 errors with `--warnaserror -t:Rebuild` on both consuming projects |
| DotnetTest | Pass - 47/47 in the three named classes; 23 whole-project failures identical by name to the base |
| CheckResult | Pass - diff matches the plan's table exactly, all four exclusions held |

Base: `development` `da4fd342`. Solution-scoped `dotnet` commands were replaced with per-`.csproj` ones because `Ivy.Tendril.slnx` cannot restore in a worktree.


---
## Commits

- `a2db6df4` [00455] Drop the redundant JobsApp prefix from JobsApp.Data.cs
- `7d8c9a13` [00455] Drop the same prefix from the sibling JobsApp partials

---
Created using [Ivy Tendril](https://ivy.app).