### PR TITLE
[00438] Filter Job Events by Kind

### DIFF
--- a/extensions/vscode/src/jobs/jobRunner.ts
+++ b/extensions/vscode/src/jobs/jobRunner.ts
@@ -52,7 +52,8 @@ export interface IJobRunner {
   subscribeJobEvents(
     jobId: string,
     onEvent: (event: JobStreamEvent) => void,
-    cancellationToken?: vscode.CancellationToken
+    cancellationToken?: vscode.CancellationToken,
+    kinds?: string[]
   ): Promise<JobStatusResult>;
   listJobs(): Promise<JobListItem[]>;
   listProjects(): Promise<string[]>;
@@ -236,7 +237,8 @@ export class JobRunner implements IJobRunner {
   public async subscribeJobEvents(
     jobId: string,
     onEvent: (event: JobStreamEvent) => void,
-    cancellationToken?: vscode.CancellationToken
+    cancellationToken?: vscode.CancellationToken,
+    kinds?: string[]
   ): Promise<JobStatusResult> {
     let baseUrl: string | undefined;
     let apiKey: string | undefined;
@@ -272,7 +274,19 @@ export class JobRunner implements IJobRunner {
       }
     }
 
-    const url = `${baseUrl.replace(/\/+$/, '')}/api/jobs/${encodeURIComponent(jobId)}/events`;
+    let url = `${baseUrl.replace(/\/+$/, '')}/api/jobs/${encodeURIComponent(jobId)}/events`;
+    if (kinds && kinds.length > 0) {
+      const params = new URLSearchParams();
+      for (const k of kinds) {
+        if (k && k.trim().length > 0) {
+          params.append('kind', k.trim());
+        }
+      }
+      const queryString = params.toString();
+      if (queryString) {
+        url += `?${queryString}`;
+      }
+    }
     const headers: Record<string, string> = {
       Accept: 'text/event-stream'
     };

--- a/extensions/vscode/src/test/suite/jobs.test.ts
+++ b/extensions/vscode/src/test/suite/jobs.test.ts
@@ -156,5 +156,41 @@ describe('JobRunner Suite', () => {
       assert.strictEqual(result.id, '00418');
       assert.strictEqual(result.status, 'Running');
     });
+
+    it('should append kind query parameters when kinds are provided', async () => {
+      const mockServerManager: any = {
+        tendrilHome: '/mock/tendril',
+        getHealthInfo: async () => ({
+          isAlive: true,
+          baseUrl: 'http://localhost:5000',
+          port: 5000,
+          pid: 1234
+        })
+      };
+
+      let requestedUrl = '';
+
+      global.fetch = (async (url: string) => {
+        requestedUrl = url;
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('event: end\ndata: {"status":"Completed"}\n\n'));
+            controller.close();
+          }
+        });
+        return new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' }
+        });
+      }) as any;
+
+      const runner = new JobRunner(mockServerManager);
+      await runner.subscribeJobEvents('00438', () => {}, undefined, ['tool_call', 'tool_result']);
+
+      assert.strictEqual(
+        requestedUrl,
+        'http://localhost:5000/api/jobs/00438/events?kind=tool_call&kind=tool_result'
+      );
+    });
   });
 });

--- a/src/Ivy.Tendril.Test/JobControllerTests.cs
+++ b/src/Ivy.Tendril.Test/JobControllerTests.cs
@@ -93,6 +93,164 @@ public class JobControllerTests
         Assert.Equal(404, controller.Response.StatusCode);
     }
 
+    [Fact]
+    public async Task GetJobEvents_FiltersBufferedEventsByKind()
+    {
+        var job = new JobItem
+        {
+            Id = "00003",
+            Status = JobStatus.Completed
+        };
+        job.OutputLines.Enqueue("{\"kind\":\"text\",\"text\":\"hello\"}");
+        job.OutputLines.Enqueue("{\"kind\":\"tool_call\",\"tool_name\":\"read_file\"}");
+        job.OutputLines.Enqueue("{\"kind\":\"thinking\",\"content\":\"thinking...\"}");
+
+        var jobService = new StubJobService();
+        jobService.Jobs[job.Id] = job;
+
+        var controller = CreateController(jobService);
+        var bodyStream = new MemoryStream();
+        controller.ControllerContext.HttpContext.Response.Body = bodyStream;
+
+        await controller.GetJobEvents("00003", ["tool_call"], CancellationToken.None);
+
+        bodyStream.Position = 0;
+        using var reader = new StreamReader(bodyStream, Encoding.UTF8);
+        var content = await reader.ReadToEndAsync();
+
+        Assert.Contains("data: {\"kind\":\"tool_call\",\"tool_name\":\"read_file\"}\n\n", content);
+        Assert.DoesNotContain("hello", content);
+        Assert.DoesNotContain("thinking...", content);
+        Assert.Contains("event: end\ndata: {\"status\":\"Completed\"}\n\n", content);
+    }
+
+    [Fact]
+    public async Task GetJobEvents_FiltersLiveEventsByKind()
+    {
+        var job = new JobItem
+        {
+            Id = "00004",
+            Status = JobStatus.Running
+        };
+
+        var jobService = new StubJobService();
+        jobService.Jobs[job.Id] = job;
+
+        var controller = CreateController(jobService);
+        var bodyStream = new MemoryStream();
+        controller.ControllerContext.HttpContext.Response.Body = bodyStream;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var streamTask = controller.GetJobEvents("00004", ["tool_call"], cts.Token);
+
+        job.EnqueueOutput("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ignored live text\"}]}}");
+        job.EnqueueOutput("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"call_1\",\"name\":\"execute_cmd\",\"input\":{}}]}}");
+
+        job.Status = JobStatus.Completed;
+        job.DisposeResources();
+        jobService.NotifyJobFinished(job);
+
+        await streamTask;
+
+        bodyStream.Position = 0;
+        using var reader = new StreamReader(bodyStream, Encoding.UTF8);
+        var content = await reader.ReadToEndAsync();
+
+        Assert.Contains("data: {\"kind\":\"tool_call\",", content);
+        Assert.Contains("execute_cmd", content);
+        Assert.DoesNotContain("ignored live text", content);
+        Assert.Contains("event: end\ndata: {\"status\":\"Completed\"}\n\n", content);
+    }
+
+    [Fact]
+    public async Task GetJobEvents_SupportsCommaSeparatedKinds()
+    {
+        var job = new JobItem
+        {
+            Id = "00005",
+            Status = JobStatus.Completed
+        };
+        job.OutputLines.Enqueue("{\"kind\":\"text\",\"text\":\"message\"}");
+        job.OutputLines.Enqueue("{\"kind\":\"error\",\"message\":\"bad request\"}");
+        job.OutputLines.Enqueue("{\"kind\":\"tool_call\",\"tool_name\":\"grep\"}");
+
+        var jobService = new StubJobService();
+        jobService.Jobs[job.Id] = job;
+
+        var controller = CreateController(jobService);
+        var bodyStream = new MemoryStream();
+        controller.ControllerContext.HttpContext.Response.Body = bodyStream;
+
+        await controller.GetJobEvents("00005", ["text,error"], CancellationToken.None);
+
+        bodyStream.Position = 0;
+        using var reader = new StreamReader(bodyStream, Encoding.UTF8);
+        var content = await reader.ReadToEndAsync();
+
+        Assert.Contains("data: {\"kind\":\"text\",\"text\":\"message\"}\n\n", content);
+        Assert.Contains("data: {\"kind\":\"error\",\"message\":\"bad request\"}\n\n", content);
+        Assert.DoesNotContain("grep", content);
+        Assert.Contains("event: end\ndata: {\"status\":\"Completed\"}\n\n", content);
+    }
+
+    [Fact]
+    public async Task GetJobEvents_ExpandsToolUseAlias()
+    {
+        var job = new JobItem
+        {
+            Id = "00006",
+            Status = JobStatus.Completed
+        };
+        job.OutputLines.Enqueue("{\"kind\":\"text\",\"text\":\"hello\"}");
+        job.OutputLines.Enqueue("{\"kind\":\"tool_call\",\"tool_name\":\"execute\"}");
+        job.OutputLines.Enqueue("{\"kind\":\"tool_result\",\"output\":\"success\"}");
+
+        var jobService = new StubJobService();
+        jobService.Jobs[job.Id] = job;
+
+        var controller = CreateController(jobService);
+        var bodyStream = new MemoryStream();
+        controller.ControllerContext.HttpContext.Response.Body = bodyStream;
+
+        await controller.GetJobEvents("00006", ["tool_use"], CancellationToken.None);
+
+        bodyStream.Position = 0;
+        using var reader = new StreamReader(bodyStream, Encoding.UTF8);
+        var content = await reader.ReadToEndAsync();
+
+        Assert.Contains("data: {\"kind\":\"tool_call\",\"tool_name\":\"execute\"}\n\n", content);
+        Assert.Contains("data: {\"kind\":\"tool_result\",\"output\":\"success\"}\n\n", content);
+        Assert.DoesNotContain("hello", content);
+        Assert.Contains("event: end\ndata: {\"status\":\"Completed\"}\n\n", content);
+    }
+
+    [Fact]
+    public async Task GetJobEvents_AlwaysEmitsEndEventRegardlessOfFilter()
+    {
+        var job = new JobItem
+        {
+            Id = "00007",
+            Status = JobStatus.Completed
+        };
+        job.OutputLines.Enqueue("{\"kind\":\"text\",\"text\":\"hello\"}");
+
+        var jobService = new StubJobService();
+        jobService.Jobs[job.Id] = job;
+
+        var controller = CreateController(jobService);
+        var bodyStream = new MemoryStream();
+        controller.ControllerContext.HttpContext.Response.Body = bodyStream;
+
+        await controller.GetJobEvents("00007", ["tool_call"], CancellationToken.None);
+
+        bodyStream.Position = 0;
+        using var reader = new StreamReader(bodyStream, Encoding.UTF8);
+        var content = await reader.ReadToEndAsync();
+
+        Assert.DoesNotContain("hello", content);
+        Assert.Contains("event: end\ndata: {\"status\":\"Completed\"}\n\n", content);
+    }
+
     private static JobController CreateController(IJobService jobService)
     {
         var controller = new JobController(jobService, new StubConfigService());

--- a/src/Ivy.Tendril/Controllers/JobController.cs
+++ b/src/Ivy.Tendril/Controllers/JobController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -12,8 +13,15 @@ public class JobController(IJobService jobService, IConfigService configService)
 {
     private static string NormalizeJobId(string jobId) => Helpers.JobId.Normalize(jobId);
 
+    [NonAction]
+    public Task GetJobEvents(string jobId, CancellationToken cancellationToken) =>
+        GetJobEvents(jobId, null, cancellationToken);
+
     [HttpGet("{jobId}/events")]
-    public async Task GetJobEvents(string jobId, CancellationToken cancellationToken)
+    public async Task GetJobEvents(
+        string jobId,
+        [FromQuery] string[]? kind,
+        CancellationToken cancellationToken)
     {
         var id = NormalizeJobId(jobId);
         var job = jobService.GetJob(id);
@@ -23,6 +31,8 @@ public class JobController(IJobService jobService, IConfigService configService)
             await Response.WriteAsJsonAsync(new { error = "Job not found" }, cancellationToken);
             return;
         }
+
+        var allowedKinds = ParseAllowedKinds(kind);
 
         Response.ContentType = "text/event-stream";
         Response.Headers["Cache-Control"] = "no-cache";
@@ -34,6 +44,7 @@ public class JobController(IJobService jobService, IConfigService configService)
             foreach (var line in job.OutputLines)
             {
                 if (cancellationToken.IsCancellationRequested) return;
+                if (!MatchesKind(line, allowedKinds)) continue;
                 await WriteSseLineAsync(Response, line, cancellationToken);
             }
 
@@ -56,7 +67,13 @@ public class JobController(IJobService jobService, IConfigService configService)
             jobService.JobFinished += OnJobFinished;
 
             using var subscription = job.OutputObservable.Subscribe(
-                onNext: line => channel.Writer.TryWrite(line),
+                onNext: line =>
+                {
+                    if (MatchesKind(line, allowedKinds))
+                    {
+                        channel.Writer.TryWrite(line);
+                    }
+                },
                 onError: ex => channel.Writer.TryComplete(ex),
                 onCompleted: () => channel.Writer.TryComplete());
 
@@ -105,6 +122,50 @@ public class JobController(IJobService jobService, IConfigService configService)
     {
         await response.WriteAsync($"event: end\ndata: {{\"status\":\"{status}\"}}\n\n", cancellationToken);
         await response.Body.FlushAsync(cancellationToken);
+    }
+
+    private static HashSet<string> ParseAllowedKinds(string[]? kinds)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (kinds == null || kinds.Length == 0) return set;
+
+        foreach (var item in kinds)
+        {
+            if (string.IsNullOrWhiteSpace(item)) continue;
+            var parts = item.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (var part in parts)
+            {
+                set.Add(part.ToLowerInvariant());
+            }
+        }
+
+        if (set.Contains("tool_use"))
+        {
+            set.Add("tool_call");
+            set.Add("tool_result");
+        }
+
+        return set;
+    }
+
+    private static bool MatchesKind(string line, HashSet<string> allowedKinds)
+    {
+        if (allowedKinds.Count == 0) return true;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(line);
+            if (doc.RootElement.TryGetProperty("kind", out var kindProp))
+            {
+                var kindStr = kindProp.GetString();
+                return kindStr != null && allowedKinds.Contains(kindStr);
+            }
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     [HttpPost]


### PR DESCRIPTION
# Summary

## Changes

Added an optional `kind` query parameter to the job events SSE endpoint so subscribers can filter the stream to only the event kinds they need, and wired the VS Code extension's `JobRunner` to pass those kinds through when subscribing. Filtering is applied to both the buffered replay of prior events and the live event stream, and the terminal `end` event is always delivered regardless of the filter.

## API Changes

- `JobController.GetJobEvents(string jobId, string[]? kind, CancellationToken)` — new `[FromQuery] string[]? kind` parameter on `GET /api/jobs/{jobId}/events`. Accepts repeated params (`?kind=tool_call&kind=tool_result`) and/or comma-separated values (`?kind=tool_call,tool_result`); values are case-insensitive. `?kind=tool_use` expands to match both `tool_call` and `tool_result`.
- `IJobRunner.subscribeJobEvents` / `JobRunner.subscribeJobEvents` (VS Code extension) — new optional `kinds?: string[]` parameter that appends `kind` query params to the events request URL.

## Files Modified

- `src/Ivy.Tendril/Controllers/JobController.cs` — `GetJobEvents` binds `kind`, adds `ParseAllowedKinds` and `MatchesKind` helpers, filters both the replay loop and live subscription.
- `src/Ivy.Tendril.Test/JobControllerTests.cs` — 5 new tests covering buffered/live filtering, comma-separated kinds, the `tool_use` alias, and the always-emitted `end` event.
- `extensions/vscode/src/jobs/jobRunner.ts` — `subscribeJobEvents` accepts `kinds` and appends `kind` query params.
- `extensions/vscode/src/test/suite/jobs.test.ts` — new test verifying `kind` query params are appended.

## Manual Testing

1. Start the Tendril server and kick off a long-running job (e.g. `ExecutePlan`).
2. Open `http://localhost:<port>/api/jobs/<jobId>/events` in a browser or `curl -N`.
3. Add `?kind=tool_call,tool_result` (or `?kind=tool_use`) to the URL and confirm only tool-related events stream through, while a plain request (no `kind`) still streams everything.
4. Confirm the stream still ends with an `event: end` message when the job finishes, with or without a filter applied.
5. In the VS Code extension, call `jobRunner.subscribeJobEvents(jobId, onEvent, token, ['tool_use'])` and confirm the request URL sent to the server includes `?kind=tool_use`.

---
Commits:
- fe57bb84 Filter job events by kind query parameter in SSE endpoint (Plan 00438)
- abffc53b Support event kind filtering in VS Code extension JobRunner (Plan 00438)

---
Created using [Ivy Tendril](https://ivy.app).
