### PR TITLE
[00473] Assert Annotation Highlights Per Annotation in the Questions Spec

### DIFF
--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
@@ -179,18 +179,35 @@ test.describe("DraftMarkdown Questions", () => {
   });
 
   test("a seeded annotation never highlights inside a question block", async ({ page }) => {
-    // The sample seeds three: one on prose, one spanning a block, one after it. The spanning one
-    // becomes several marks, since a mark is created per text node it covers.
-    const highlights = page.locator(".pmv-annotation-highlight");
-    await expect(highlights).toHaveCount(5);
+    // Asserted per annotation, never as a total: a mark is created per text node an annotation
+    // covers, and how many nodes that is is a property of sample prose this test does not own.
+    const marksFor = (id: string) =>
+      page.locator(`.pmv-annotation-highlight[data-annotation-id="${id}"]`);
 
-    // Whatever they cover, no block takes a highlight.
+    // Each is anchored to the prose it was placed on. The second sits after a block, and proves a
+    // block cannot move what follows it however it renders - otherwise it would have drifted off
+    // "separate consumer".
+    await expect(marksFor("prose")).toHaveText(["Where the budget lives"]);
+    await expect(marksFor("after")).toHaveText(["separate consumer"]);
+
+    // Whatever they cover, no block takes a highlight: the picker is a form, and a mark spliced
+    // into it would fight React for the DOM.
     await expect(page.locator(".pmv-questions .pmv-annotation-highlight")).toHaveCount(0);
 
-    // The last one is after a block, and proves a block's rendering cannot move what follows it —
-    // otherwise this would have drifted off "separate consumer".
-    await expect(highlights.first()).toHaveText("Where the budget lives");
-    await expect(highlights.last()).toHaveText("separate consumer");
+    // All three arrive, and nothing else does. Read without polling: one effect applies every
+    // annotation in a single pass, so the assertions above have already waited for all of them.
+    const ids = await page
+      .locator(".pmv-annotation-highlight")
+      .evaluateAll((marks) => [...new Set(marks.map((m) => (m as HTMLElement).dataset.annotationId))]);
+    expect(ids).toEqual(["prose", "across", "after"]);
+
+    // The spanning one is split around the block it crosses: prose before, prose after, nothing in
+    // between. Whitespace-only marks are dropped - the newline nodes between block elements are
+    // covered too, and how many of them there are is not the subject.
+    const across = (await marksFor("across").allTextContents()).map((t) => t.trim()).filter(Boolean);
+    expect(across.length).toBeGreaterThan(1);
+    expect(across[0]).toBe("snippets inside can use three.");
+    expect(across[across.length - 1]).toBe("Delivery is fanned out");
   });
 
   test("the review sample presents answers instead of controls", async ({ page, stepScreenshot }) => {


### PR DESCRIPTION
## Problem

The test `a seeded annotation never highlights inside a question block` in `questions.spec.ts:181` asserts a raw total of highlight marks (expected 5, received 8). The assertion fails because the count encodes text node count, not annotation behavior. The test's actual subject (line 188: no highlights inside question blocks) never runs because the count check fails first.

The sample seeds three annotations, one spanning a question block. That annotation renders as one mark per covered text node, including whitespace nodes between block elements. The expected count of 5 drifted when sample markdown grew, coupling the test to unrelated content changes.

## Solution

Rewrite the test to assert per annotation instead of using a raw total:
- Use `toHaveText([...])` to pin specific annotations to exact text and count
- Assert the ID set to catch missing annotations without node counts
- For the spanning annotation, assert it's split (>1 mark) with first/last text
- Keep the core invariant: `.pmv-questions .pmv-annotation-highlight` must be 0

No source changes, no sample changes. The test now tolerates whitespace node variance.

---

**Commits:**
- 3cc67a14 Assert annotation highlights per annotation in questions spec

---
Created using [Ivy Tendril](https://ivy.app).
