### PR TITLE
[00468] Update the Stale Not Answered Copy Expectations in the Questions Spec

### DIFF
--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
@@ -221,8 +221,8 @@ test.describe("DraftMarkdown Questions", () => {
     // Unanswered questions say which kind they are — both are decisions nobody explicitly made.
     const naming = blockFor(page, "service-name");
     await expect(naming.locator(".tq-answer--none")).toHaveText([
-      "Not answered — Not required",
-      "Not answered — Agent decided",
+      "Not answered (not required)",
+      "Not answered (agent decided)",
     ]);
 
     await stepScreenshot("review-read-only");


### PR DESCRIPTION
# Summary

## Changes

Corrected two stale string expectations in the widget Playwright spec
`src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts`, which asserted an older
dash-separated form of the "Not answered" copy that `QuestionsForm.tsx` no longer renders. The spec now
asserts `"Not answered (not required)"` and `"Not answered (agent decided)"`, matching the component and
the two frontend unit suites. No production code was touched; the test was the stale side.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts` - two string literals in the
  `the review sample presents answers instead of controls` test (lines 223-226). 2 insertions,
  2 deletions, one file, one commit.

## Manual Testing

N/A - test-only change with no user-facing behavior. The behavior it asserts was already correct in the
widget.

For a reviewer who wants to see it pass:

```bash
cd src/Ivy.Tendril.Widgets/.tests
npx --prefer-offline -y pnpm@10.33.0 install
npx playwright install chromium
npx playwright test widgets/draft-markdown/questions.spec.ts -g "the review sample presents answers instead of controls"
```

Expect `1 passed`. The suite's global setup builds `.samples` and starts its own server, so nothing needs
to be running first.

---

## Commits

- 63c92ea4 [00468] Match the reworded Not answered copy in the review-sample spec

---
Created using [Ivy Tendril](https://ivy.app).
