### PR TITLE
[00474] Move the Timestamp Column to the End of the Jobs Table

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs
@@ -14,10 +14,10 @@ public class JobsTableColumnLabelTests
         { nameof(JobItemRow.Type), "Type" },
         { nameof(JobItemRow.Project), "Project" },
         { nameof(JobItemRow.Timer), "Timer" },
-        { nameof(JobItemRow.Timestamp), "Timestamp" },
         { nameof(JobItemRow.AgentOutput), "Agent Output" },
         { nameof(JobItemRow.Cost), "Cost" },
         { nameof(JobItemRow.Tokens), "Tokens" },
+        { nameof(JobItemRow.Timestamp), "Timestamp" },
         { nameof(JobItemRow.StatusMessage), "Status Message" },
         { nameof(JobItemRow.ErrorContext), "Error Context" }
     };
@@ -66,5 +66,30 @@ public class JobsTableColumnLabelTests
     {
         Assert.NotNull(typeof(JobItemRow).GetProperty("Prompt"));
         Assert.Null(typeof(JobItemRow).GetProperty("Plan"));
+    }
+
+    [Fact]
+    public void TimestampIsTheLastVisibleColumn()
+    {
+        // Ivy derives column order from JobItemRow's property declaration order, so this order IS
+        // the rendered order (issue #2636).
+        var declared = typeof(JobItemRow).GetProperties().Select(p => p.Name).ToArray();
+
+        Assert.Equal(new[]
+        {
+            nameof(JobItemRow.Id),            // hidden
+            nameof(JobItemRow.Status),
+            nameof(JobItemRow.PlanId),
+            nameof(JobItemRow.Prompt),
+            nameof(JobItemRow.Type),
+            nameof(JobItemRow.Project),
+            nameof(JobItemRow.Timer),
+            nameof(JobItemRow.AgentOutput),
+            nameof(JobItemRow.Cost),
+            nameof(JobItemRow.Tokens),
+            nameof(JobItemRow.Timestamp),
+            nameof(JobItemRow.StatusMessage),
+            nameof(JobItemRow.ErrorContext)    // hidden
+        }, declared);
     }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -68,14 +68,14 @@ public partial class JobsApp
             })
             .Width(t => t.Status, Size.Px(100))
             .Width(t => t.PlanId, Size.Px(80))
-            .Width(t => t.Type, Size.Px(100))
             .Width(t => t.Prompt, Size.Px(250))
+            .Width(t => t.Type, Size.Px(100))
             .Width(t => t.Project, Size.Px(150))
             .Width(t => t.Timer, Size.Px(80))
-            .Width(t => t.Timestamp, Size.Px(110))
             .Width(t => t.AgentOutput, Size.Px(100))
             .Width(t => t.Cost, Size.Px(80))
             .Width(t => t.Tokens, Size.Px(80))
+            .Width(t => t.Timestamp, Size.Px(110))
             .Width(t => t.StatusMessage, Size.Auto())
             .Renderer(t => t.Status, new LabelsDisplayRenderer
             {

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -359,14 +359,14 @@ public record JobItemRow
     public string Type { get; init; } = "";
     public string Project { get; init; } = "";
     public string Timer { get; init; } = "";
-    /// <summary>
-    /// When the job finished, in the viewer's local time. Empty of meaning for a job that has not
-    /// reached a terminal status, which renders "-"; the Timer column beside it carries the duration.
-    /// </summary>
-    public string Timestamp { get; init; } = "";
     public string AgentOutput { get; init; } = "";
     public string Cost { get; init; } = "";
     public string Tokens { get; init; } = "";
+    /// <summary>
+    /// When the job finished, in the viewer's local time. Empty of meaning for a job that has not
+    /// reached a terminal status, which renders "-"; the Timer column carries the duration.
+    /// </summary>
+    public string Timestamp { get; init; } = "";
     public string StatusMessage { get; init; } = "";
     public string? ErrorContext { get; init; }  // Multi-line error context for tooltip/expansion
 }


### PR DESCRIPTION
Fixes #2636

# Summary

## Changes

Reordered the Timestamp column in the Jobs table from between Timer and Agent Output to the end of the visible columns. The column now appears after Tokens, grouping all live job metrics (Timer/Agent Output/Cost/Tokens) together and making Timestamp the last fixed-width column before Status Message.

## API Changes

None - this is a UI-only change affecting column order in the Jobs table.

## Files Modified

**Models:**
- `src/Ivy.Tendril/Models/JobModels.cs` - Reordered JobItemRow properties to move Timestamp property

**UI:**
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs` - Reordered Width chain and fixed Type/Prompt inversion

**Tests:**
- `src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs` - Added TimestampIsTheLastVisibleColumn test, reordered ExpectedLabels dictionary

## Manual Testing

1. Run the Tendril application: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj`
2. Navigate to the Jobs view
3. Verify the column order is now: Status, Plan Id, Prompt, Type, Project, Timer, Agent Output, Cost, Tokens, **Timestamp**, Status Message
4. Verify that Timestamp is the last fixed-width column (Status Message auto-sizes)
5. Start a job and observe that all live metrics (Timer, Agent Output, Cost, Tokens) are now grouped together without Timestamp splitting them

---

**Commits:**
- fd5edacd Move Timestamp column to end of Jobs table

---
Created using [Ivy Tendril](https://ivy.app).
