### PR TITLE
[00447] Fix Chat Job DTO Test for Missing Plan Folder

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs
@@ -229,18 +229,20 @@ public class ChatAppSidebarListTests
     [Fact]
     public void ToJobDto_ClearsPlanId_WhenPlanFolderMissingOnDisk()
     {
-        var nonExistentFolder = Path.Combine(Path.GetTempPath(), "non-existent-" + Guid.NewGuid().ToString("N"));
+        // The id prefix is load-bearing: FindPlan must resolve the plan by id before the
+        // on-disk check is what clears PlanId, not an unresolved-plan fallback.
+        var missingFolder = Path.Combine(Path.GetTempPath(), "01583-MissingFolderPlan-" + Guid.NewGuid().ToString("N"));
         var metadata = new PlanMetadata(
             1583, "test-project", "Feature", "Missing Folder Plan", PlanStatus.Draft,
             [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
-        var planFile = new PlanFile(metadata, "", nonExistentFolder, "");
+        var planFile = new PlanFile(metadata, "", missingFolder, "");
         var planService = new FakePlanReaderService { Plans = [planFile] };
         var job = new JobItem
         {
             Id = "00155",
             Type = Constants.JobTypes.ExecutePlan,
             Status = JobStatus.Running,
-            PlanFile = Path.GetFileName(nonExistentFolder)
+            PlanFile = Path.GetFileName(missingFolder)
         };
 
         var dto = ChatApp.ToJobDto(job, planService);


### PR DESCRIPTION
# Summary

## Changes

Fixed `ToJobDto_ClearsPlanId_WhenPlanFolderMissingOnDisk` in `ChatAppSidebarListTests.cs`, which was
failing on `development` because its fake plan folder name lacked a numeric plan-id prefix.
`ContentView.FindPlan`'s current numeric-lookup logic (added in PR #2619) could never resolve the
plan from that folder name, so the test passed for the wrong reason before this fix and failed after
CI started enforcing it. The folder is now prefixed with the plan's metadata id, matching sibling
tests, so the test again exercises the "resolved plan whose folder is missing on disk" path its name
describes.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Test/Apps/Chat/ChatAppSidebarListTests.cs` — renamed the test's fake folder
  variable and gave it an id-prefixed name (`01583-MissingFolderPlan-<guid>`) instead of
  (`non-existent-<guid>`).

## Manual Testing

N/A — internal test-fidelity fix with no user-facing behavior. Verified via
`dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --configuration Release`, which now passes
3761/3762 (1 pre-existing unrelated skip) including the previously-failing test.

---
37379343 Fix ToJobDto_ClearsPlanId_WhenPlanFolderMissingOnDisk test setup

---
Created using [Ivy Tendril](https://ivy.app).