### PR TITLE
[00476] Realign the JobsApp Partial Files With Their Names

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobRerunEligibilityTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobRerunEligibilityTests.cs
@@ -1,8 +1,7 @@
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Models;
-using Xunit;
 
-namespace Ivy.Tendril.Test;
+namespace Ivy.Tendril.Test.Apps.Jobs;
 
 public class JobRerunEligibilityTests
 {

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -84,46 +84,4 @@ public partial class JobsApp
 
         return new StackedProgress(statusSegments).ShowLabels();
     }
-
-    /// <summary>
-    /// Builds the candidate cell set exactly as before, then keeps only cells whose value actually
-    /// changed since the previous tick, per <paramref name="lastSent"/> (keyed by the
-    /// (jobId, columnName) pair, owned by the caller so it survives across ticks). Keys for jobs no
-    /// longer returned by the service are pruned so the cache cannot grow without bound as jobs are
-    /// evicted.
-    /// </summary>
-    internal static IEnumerable<DataTableCellUpdate> BuildDataTableUpdates(
-        IJobService jobService, Dictionary<(string RowId, string ColumnName), string> lastSent)
-    {
-        var currentJobs = jobService.GetJobs();
-        var currentJobIds = currentJobs.Select(j => j.Id).ToHashSet(StringComparer.Ordinal);
-        foreach (var staleKey in lastSent.Keys.Where(k => !currentJobIds.Contains(k.RowId)).ToList())
-            lastSent.Remove(staleKey);
-
-        var candidates = currentJobs
-            .Where(j => j.Status is JobStatus.Running or JobStatus.Blocked ||
-                        ((j.Status is JobStatus.Stopped or JobStatus.Failed or JobStatus.Timeout or JobStatus.Completed)
-                         && j.CompletedAt.HasValue
-                         && DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromMinutes(1)))
-            .SelectMany(j => new[]
-            {
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Timer), FormatTimer(j)),
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Cost), FormatJobCost(j)),
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Tokens), j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : ""),
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.AgentOutput), FormatAgentOutput(j)),
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Status), j.Status.ToString()),
-                new DataTableCellUpdate(j.Id, nameof(JobItemRow.StatusMessage), GetStatusMessage(j))
-            });
-
-        foreach (var update in candidates)
-        {
-            // A hard cast, not a ToString(): every candidate above is built from j.Id, a string, so a
-            // failure here means that invariant broke and should say so loudly.
-            var key = ((string)update.RowId, update.ColumnName);
-            var value = update.Value as string ?? update.Value?.ToString() ?? "";
-            if (lastSent.TryGetValue(key, out var previous) && previous == value) continue;
-            lastSent[key] = value;
-            yield return update;
-        }
-    }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -1,6 +1,6 @@
 using Ivy.Tendril.Apps.Plans;
-using Ivy.Tendril.Apps.Jobs.Dialogs;
 using Ivy.Tendril.Apps.Review;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -8,25 +8,6 @@ namespace Ivy.Tendril.Apps.Jobs;
 
 public partial class JobsApp
 {
-    /// <summary>
-    /// Determines if a job can be rerun. Returns true for Failed/Timeout/Stopped
-    /// jobs (existing behavior), or for Completed jobs whose args type supports
-    /// corrective feedback (ExecutePlan/RetryPlan/UpdatePlan).
-    /// </summary>
-    internal static bool CanRerun(JobItem? job)
-    {
-        if (job == null) return false;
-
-        // Existing behavior: all failed-state jobs can be rerun regardless of type
-        if (job.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Stopped)
-            return true;
-
-        // New: Completed jobs can be rerun only when their args support feedback
-        if (job.Status is JobStatus.Completed)
-            return RerunJobDialog.SupportsFeedback(job.TypedArgs);
-
-        return false;
-    }
     private static object BuildDataTable(
         INavigator nav,
         List<JobItemRow> rows,
@@ -368,5 +349,47 @@ public partial class JobsApp
         ) : null;
 
         return new Fragment(dataTable, confirmDialog, confirmStopQueuedDialog, stopAllDialog);
+    }
+
+    /// <summary>
+    /// Builds the candidate cell set exactly as before, then keeps only cells whose value actually
+    /// changed since the previous tick, per <paramref name="lastSent"/> (keyed by the
+    /// (jobId, columnName) pair, owned by the caller so it survives across ticks). Keys for jobs no
+    /// longer returned by the service are pruned so the cache cannot grow without bound as jobs are
+    /// evicted.
+    /// </summary>
+    internal static IEnumerable<DataTableCellUpdate> BuildDataTableUpdates(
+        IJobService jobService, Dictionary<(string RowId, string ColumnName), string> lastSent)
+    {
+        var currentJobs = jobService.GetJobs();
+        var currentJobIds = currentJobs.Select(j => j.Id).ToHashSet(StringComparer.Ordinal);
+        foreach (var staleKey in lastSent.Keys.Where(k => !currentJobIds.Contains(k.RowId)).ToList())
+            lastSent.Remove(staleKey);
+
+        var candidates = currentJobs
+            .Where(j => j.Status is JobStatus.Running or JobStatus.Blocked ||
+                        ((j.Status is JobStatus.Stopped or JobStatus.Failed or JobStatus.Timeout or JobStatus.Completed)
+                         && j.CompletedAt.HasValue
+                         && DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromMinutes(1)))
+            .SelectMany(j => new[]
+            {
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Timer), FormatTimer(j)),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Cost), FormatJobCost(j)),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Tokens), j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : ""),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.AgentOutput), FormatAgentOutput(j)),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Status), j.Status.ToString()),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.StatusMessage), GetStatusMessage(j))
+            });
+
+        foreach (var update in candidates)
+        {
+            // A hard cast, not a ToString(): every candidate above is built from j.Id, a string, so a
+            // failure here means that invariant broke and should say so loudly.
+            var key = ((string)update.RowId, update.ColumnName);
+            var value = update.Value as string ?? update.Value?.ToString() ?? "";
+            if (lastSent.TryGetValue(key, out var previous) && previous == value) continue;
+            lastSent[key] = value;
+            yield return update;
+        }
     }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Ivy.Tendril.Apps.Jobs.Dialogs;
 using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Apps.Jobs;
@@ -224,5 +225,25 @@ public partial class JobsApp
     private static Colors GetStatusColor(JobStatus status)
     {
         return Constants.JobStatusColors.GetValueOrDefault(status, Colors.Slate);
+    }
+
+    /// <summary>
+    /// Determines if a job can be rerun. Returns true for Failed/Timeout/Stopped
+    /// jobs (existing behavior), or for Completed jobs whose args type supports
+    /// corrective feedback (ExecutePlan/RetryPlan/UpdatePlan).
+    /// </summary>
+    internal static bool CanRerun(JobItem? job)
+    {
+        if (job == null) return false;
+
+        // Existing behavior: all failed-state jobs can be rerun regardless of type
+        if (job.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Stopped)
+            return true;
+
+        // New: Completed jobs can be rerun only when their args support feedback
+        if (job.Status is JobStatus.Completed)
+            return RerunJobDialog.SupportsFeedback(job.TypedArgs);
+
+        return false;
     }
 }


### PR DESCRIPTION
## Problem

`JobsApp` is split across five partials named after what each holds, but three members sit in the file whose name predicts the opposite. Reading the type means checking all five files instead of one.

**Current placement (verified on `development` at `cc5c31ee`):**

| Member | Lives in | Belongs in |
|---|---|---|
| `BuildDataTableUpdates` | JobsApp.Data.cs:95 | `JobsApp.DataTable.cs` |
| `CanRerun` | JobsApp.DataTable.cs:16 | `JobsApp.Helpers.cs` |
| `JobRerunEligibilityTests` | JobRerunEligibilityTests.cs | `src/Ivy.Tendril.Test/Apps/Jobs/` |

This is the Accepted recommendation "Realign the JobsApp partial files with their names" from Plan 00455. Pure moves, no behaviour change.

## Solution

All three moves are within the same `partial class JobsApp`, so **no call site changes**. 

### 1. Move `BuildDataTableUpdates` into `JobsApp.DataTable.cs`

Cut lines 88-128 of JobsApp.Data.cs and paste into JobsApp.DataTable.cs after `BuildDataTable`. Add `using Ivy.Tendril.Helpers;` to resolve `FormatHelper.FormatTokens`.

### 2. Move `CanRerun` into `JobsApp.Helpers.cs`

Cut lines 11-29 of JobsApp.DataTable.cs and append to JobsApp.Helpers.cs after `GetStatusColor`, next to other `JobItem` predicates. Move `using Ivy.Tendril.Apps.Jobs.Dialogs;` with it.

### 3. Move `JobRerunEligibilityTests` under `Apps/Jobs/`

Use `git mv` to preserve history, change namespace to `Ivy.Tendril.Test.Apps.Jobs`, and drop redundant `using Xunit;`.

---

**Commits:**
- 2b01074e

---

Created using [Ivy Tendril](https://ivy.app).
