### PR TITLE
[00456] Give Claude Full Tool Permissions in the Chat App

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
@@ -130,13 +130,8 @@ public class ClaudeCliTests
         Assert.Contains("--output-format", spec.Arguments);
         Assert.Contains("stream-json", spec.Arguments);
         Assert.Contains("--permission-mode", spec.Arguments);
-        Assert.Contains("dontAsk", spec.Arguments);
-        Assert.Contains("--settings", spec.Arguments);
-
-        var settingsIdx = spec.Arguments.ToList().IndexOf("--settings");
-        Assert.True(settingsIdx >= 0);
-        Assert.Contains("permissions", spec.Arguments[settingsIdx + 1]);
-        Assert.Contains("allow", spec.Arguments[settingsIdx + 1]);
+        Assert.Contains("bypassPermissions", spec.Arguments);
+        Assert.DoesNotContain("--settings", spec.Arguments);
 
         Assert.Contains("-", spec.Arguments);
         Assert.Equal("Hello", spec.StdinContent);
@@ -199,7 +194,6 @@ public class ClaudeCliTests
     }
 
     [Theory]
-    [InlineData(PermissionMode.FullAuto, "dontAsk")]
     [InlineData(PermissionMode.AcceptEdits, "acceptEdits")]
     [InlineData(PermissionMode.Plan, "plan")]
     [InlineData(PermissionMode.Default, "default")]
@@ -215,6 +209,67 @@ public class ClaudeCliTests
         var spec = _cli.BuildProcessSpec(config);
         var idx = spec.Arguments.ToList().IndexOf("--permission-mode");
         Assert.Equal(expected, spec.Arguments[idx + 1]);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_FullAutoWithoutAllowedTools_UsesBypassPermissions()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            PermissionMode = PermissionMode.FullAuto,
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        var idx = spec.Arguments.ToList().IndexOf("--permission-mode");
+        Assert.True(idx >= 0);
+        Assert.Equal("bypassPermissions", spec.Arguments[idx + 1]);
+        Assert.DoesNotContain("--settings", spec.Arguments);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_FullAutoWithAllowedTools_KeepsDontAsk()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            PermissionMode = PermissionMode.FullAuto,
+            AllowedTools = ["Read", "Bash"],
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        var idx = spec.Arguments.ToList().IndexOf("--permission-mode");
+        Assert.True(idx >= 0);
+        Assert.Equal("dontAsk", spec.Arguments[idx + 1]);
+
+        var settingsIdx = spec.Arguments.ToList().IndexOf("--settings");
+        Assert.True(settingsIdx >= 0);
+        Assert.Contains("Bash(*)", spec.Arguments[settingsIdx + 1]);
+
+        var toolsIdx = spec.Arguments.ToList().IndexOf("--tools");
+        Assert.True(toolsIdx >= 0);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_PlanModeWithoutAllowedTools_KeepsPlan()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            PermissionMode = PermissionMode.Plan,
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        var idx = spec.Arguments.ToList().IndexOf("--permission-mode");
+        Assert.True(idx >= 0);
+        Assert.Equal("plan", spec.Arguments[idx + 1]);
+        Assert.DoesNotContain("--settings", spec.Arguments);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeCli.cs
@@ -60,13 +60,19 @@ public sealed class ClaudeCli : IAgentCli
 
     public AgentProcessSpec BuildProcessSpec(AgentLaunchConfig config)
     {
+        // A caller that supplies no allowlist (the chat app) wants an unrestricted trusted
+        // session, the same thing ClaudePty gives the interactive agent. dontAsk plus a prefix
+        // allow list denies anything the list does not name, including every Bash command that
+        // reaches outside the working directory, and --print has no prompt surface to ask through.
+        var unrestricted = config.PermissionMode == PermissionMode.FullAuto && config.AllowedTools.Count == 0;
+
         var args = new List<string>
         {
             "--print",
             "--verbose",
             "--output-format", "stream-json",
             "--permission-mode",
-            config.PermissionMode switch
+            unrestricted ? "bypassPermissions" : config.PermissionMode switch
             {
                 PermissionMode.FullAuto => "dontAsk",
                 PermissionMode.AcceptEdits => "acceptEdits",
@@ -107,53 +113,6 @@ public sealed class ClaudeCli : IAgentCli
                 args.Add("--tools");
                 args.Add(string.Join(",", activeTools));
             }
-        }
-        else if (config.PermissionMode == PermissionMode.FullAuto)
-        {
-            // Tailor default safe/essential permissions needed to work with Tendril
-            allowedRules.AddRange([
-                "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch",
-                "Bash(tendril *)",
-                "Bash(git *)",
-                "Bash(gh *)",
-                "Bash(dotnet *)",
-                "Bash(pnpm *)",
-                "Bash(npm *)",
-                "Bash(yarn *)",
-                "Bash(bun *)",
-                "Bash(node *)",
-                "Bash(ls *)",
-                "Bash(find *)",
-                "Bash(cat *)",
-                "Bash(head *)",
-                "Bash(tail *)",
-                "Bash(grep *)",
-                "Bash(mkdir *)",
-                "Bash(rmdir *)",
-                "Bash(rm *)",
-                "Bash(cp *)",
-                "Bash(mv *)",
-                "Bash(touch *)",
-                "Bash(chmod *)",
-                "Bash(pwd)",
-                "Bash(echo *)",
-                "Bash(which *)",
-                "Bash(npx *)",
-                "Bash(vite *)",
-                "Bash(tsc *)",
-                "Bash(eslint *)",
-                "Bash(prettier *)",
-                "Bash(python *)",
-                "Bash(python3 *)",
-                "Bash(pip *)",
-                "Bash(pip3 *)",
-                "Bash(uv *)",
-                "Bash(refitter *)",
-                "Bash(svcutil *)",
-                "Bash(ivy-inspector-*)",
-                "Bash(dotnet-*)",
-                "Bash(strawberryshake *)"
-            ]);
         }
 
         if (allowedRules.Count > 0)


### PR DESCRIPTION
Fixes #2641

# Summary

## Changes

`ClaudeCli.BuildProcessSpec` now emits `--permission-mode bypassPermissions` (instead of `dontAsk`
plus a hardcoded ~40-entry `Bash(...)` prefix allow list) whenever `PermissionMode.FullAuto` is
requested with no `AllowedTools` — which is exactly the chat app's launch path, since it is the
only caller that supplies no allowlist. This gives chat the same unrestricted, trusted-session
behavior the interactive Agent app already gets from `ClaudePty` via
`--dangerously-skip-permissions`, fixing chat's inability to run Bash commands (or any tool)
touching paths outside `TendrilHome`. Every other launch path (jobs, promptwares) supplies a
non-empty allowlist and is unaffected.

## API Changes

None — internal behavior change in `ClaudeCli.BuildProcessSpec`, no public signature changes.

## Files Modified

- `src/Ivy.Tendril.Agents/Providers/Claude/ClaudeCli.cs` — reordered permission-mode computation
  ahead of the allowlist check; removed the `dontAsk` + hardcoded-prefix fallback branch entirely.
- `src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs` — added 3 new tests covering the
  unrestricted/allowlisted/plan-mode cases; updated 2 existing tests that asserted the old
  fallback behavior on a default (FullAuto, empty AllowedTools) config.

## Manual Testing

1. Start a new chat session in the Chat app.
2. Ask Claude to run a command touching a path outside `~/.tendril`, e.g. `ls /Users/<you>/git/ivy-tendril` or `grep -rln "foo" /Users/<you>/git/ivy-tendril`.
3. The command should succeed (no "Permission to use Bash has been denied because Claude Code is running in don't ask mode" denial), and Claude should be able to read/inspect files anywhere on disk, not just under `TendrilHome`.
4. As a regression check, start a Job or run a promptware (e.g. `tendril promptware run`) and confirm its Claude launch still uses the restricted `--tools`/`--settings` allowlist as before — those paths supply a non-empty `AllowedTools` and are unaffected by this change.

---
## Commits

- 17c1ab0f fix(agents): give chat's Claude launches full tool permissions
- 94c609cb test(agents): cover bypassPermissions for allowlist-free FullAuto launches

---
Created using [Ivy Tendril](https://ivy.app).
