### PR TITLE
[00449] Scope The Duplicate Plan Marker To Agent Text And Require A Resolvable Folder

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -127,7 +127,10 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
   ```
 
   The marker is how the server tells a deliberate duplicate rejection apart from a CreatePlan run
-  that simply produced nothing. Omit it and the job is recorded as **Failed**.
+  that simply produced nothing. Omit it and the job is recorded as **Failed**. `<existing plan
+  folder name>` must be a real plan folder (or its plan id) that resolves on disk; a marker whose
+  target does not resolve is ignored and the job is recorded **Failed** the same as if it were
+  omitted.
 
   Include the reasoning above the marker — the original request, the existing plan's state, and why
   it is a duplicate — so the job log carries the full record.

--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -342,6 +342,8 @@ public class JobServiceCompletionGuardTests : IDisposable
     {
         var service = CreateServiceWithPlanReader(_tempDir.Path);
         var id = service.CreateTestJob(new CreatePlanArgs("Fix login bug", "Tendril"));
+        // The marker's target has to resolve to a real plan folder now.
+        Directory.CreateDirectory(Path.Combine(_tempDir.Path, "01234-ExistingPlan"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);
@@ -366,7 +368,8 @@ public class JobServiceCompletionGuardTests : IDisposable
         var job = service.GetJob(id);
         Assert.NotNull(job);
         // The agent read Program.md mid-run, so the marker's template form appears in its output.
-        // That must not pass for a real duplicate rejection.
+        // It fails because `<existing plan folder name>` resolves to no plan on disk, not because
+        // of a lookahead on the character after the colon.
         job.EnqueueOutput("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"identified as duplicate: <existing plan folder name>\"}]}}");
 
         service.CompleteJob(id, 0);
@@ -374,6 +377,64 @@ public class JobServiceCompletionGuardTests : IDisposable
         job = service.GetJob(id);
         Assert.NotNull(job);
         Assert.Equal(JobStatus.Failed, job.Status);
+    }
+
+    [Fact]
+    public void CompleteJob_CreatePlan_FailsWhenDuplicateMarkerIsOnlyInToolOutput()
+    {
+        var service = CreateServiceWithPlanReader(_tempDir.Path);
+        var id = service.CreateTestJob(new CreatePlanArgs("Fix login bug", "Tendril"));
+        // A real plan folder on disk, so folder resolution cannot be what fails this test - the
+        // fix under test is that tool output never counts, regardless of whether its target resolves.
+        Directory.CreateDirectory(Path.Combine(_tempDir.Path, "01234-ExistingPlan"));
+
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+        // The agent read AGENTS.md mid-run, which quotes the marker inside backticks - a `read`
+        // tool result, not the agent's own text.
+        job.OutputLines.Enqueue(
+            """{"kind":"tool_result","tool_use_id":"t1","output":"3. Agent output doesn't carry the `identified as duplicate:` marker either (`IsDuplicatePlan`)"}""");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id);
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Failed, job.Status);
+    }
+
+    [Fact]
+    public void CompleteJob_CreatePlan_FailsWhenDuplicateTargetDoesNotResolve()
+    {
+        var service = CreateServiceWithPlanReader(_tempDir.Path);
+        var id = service.CreateTestJob(new CreatePlanArgs("Fix login bug", "Tendril"));
+
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+        job.EnqueueOutput("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"identified as duplicate: 09999-NoSuchPlan\"}]}}");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id);
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Failed, job.Status);
+    }
+
+    [Fact]
+    public void CompleteJob_CreatePlan_AcceptsDuplicateMarkerNamingPlanIdOnly()
+    {
+        var service = CreateServiceWithPlanReader(_tempDir.Path);
+        var id = service.CreateTestJob(new CreatePlanArgs("Fix login bug", "Tendril"));
+        Directory.CreateDirectory(Path.Combine(_tempDir.Path, "01234-ExistingPlan"));
+
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+        job.EnqueueOutput("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"identified as duplicate: 01234\"}]}}");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id);
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Completed, job.Status);
     }
 
     private class StubPlanReaderService(string plansDirectory) : IPlanReaderService

--- a/src/Ivy.Tendril.Test/JobServiceCreatePlanVerificationTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCreatePlanVerificationTests.cs
@@ -59,4 +59,35 @@ public class JobServiceCreatePlanVerificationTests : IDisposable
         Assert.Equal(JobStatus.Failed, job.Status);
         Assert.False(Directory.Exists(planFolder));
     }
+
+    [Fact]
+    public void VerifyCreatePlanResult_FailsWhenDuplicateMarkerIsOnlyInToolOutput()
+    {
+        // The marker's target resolves, but only inside a tool result - it must not count.
+        Directory.CreateDirectory(Path.Combine(_plansDir, "01234-ExistingPlan"));
+
+        var planReader = new FakePlanReaderService { PlansDirectory = _plansDir };
+        var handler = new JobCompletionHandler(
+            configService: null,
+            logger: NullLogger.Instance,
+            modelPricingService: null,
+            planReaderService: planReader,
+            telemetryService: null,
+            planWatcherService: null,
+            promptsRoot: _promptsRoot
+        );
+
+        var job = new JobItem
+        {
+            Id = "00002",
+            Type = "CreatePlan",
+            Status = JobStatus.Completed
+        };
+        job.OutputLines.Enqueue(
+            """{"kind":"tool_result","tool_use_id":"t1","output":"identified as duplicate: 01234-ExistingPlan"}""");
+
+        handler.VerifyCreatePlanResult(job);
+
+        Assert.Equal(JobStatus.Failed, job.Status);
+    }
 }

--- a/src/Ivy.Tendril/AGENTS.md
+++ b/src/Ivy.Tendril/AGENTS.md
@@ -198,7 +198,7 @@ Jobs flow through: `Pending → Queued → Running → Completed/Failed/Timeout/
 
 1. Agent output doesn't contain a `"PlanId: <id>"` line resolving to a folder on disk (`FindPlanFolderById`)
 2. No plan folder matching `AllocatedPlanId` exists on disk either (`FindPlanFolderById`)
-3. Agent output doesn't carry the `identified as duplicate:` marker either (`IsDuplicatePlan`)
+3. The agent's own message text doesn't carry the `identified as duplicate:` marker naming an existing plan folder either (`IsDuplicatePlan`). Tool output does not count, and the named folder must resolve on disk.
 
 When debugging a failed CreatePlan, check in order:
 1. Does the plan folder exist in `$TENDRIL_PLANS/{PlanId}-*`?

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -164,7 +164,10 @@ Report status: `tendril job status TendrilJobId --message="Researching codebase.
   ```
 
   The marker is how the server tells a deliberate duplicate rejection apart from a CreatePlan run
-  that simply produced nothing. Omit it and the job is recorded as **Failed**.
+  that simply produced nothing. Omit it and the job is recorded as **Failed**. `<existing plan
+  folder name>` must be a real plan folder (or its plan id) that resolves on disk; a marker whose
+  target does not resolve is ignored and the job is recorded **Failed** the same as if it were
+  omitted.
 
   Include the reasoning above the marker — the original request, the existing plan's state, and why
   it is a duplicate — so the job log carries the full record.

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -654,6 +654,10 @@ internal class JobCompletionHandler
         @"^https?://github\.com/(?<owner>[^/\s]+)/(?<repo>[^/\s]+)/pull/(?<number>\d+)(?=/?(?:#\S*)?$)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    internal static readonly Regex DuplicateMarkerPattern = new(
+        @"identified as duplicate:\s*(?<target>[^\s]+)",
+        RegexOptions.Compiled);
+
     /// <summary>
     ///     Safety net for CreatePr. The agent is supposed to record each PR URL via
     ///     `tendril plan add-pr` and set the plan to Completed (Program.md step 6), but a rushed or
@@ -838,7 +842,7 @@ internal class JobCompletionHandler
                 }
             }
 
-            if (IsDuplicatePlan(job)) return;
+            if (IsDuplicatePlan(job, plansDir)) return;
 
             if (!string.IsNullOrEmpty(job.AllocatedPlanId))
             {
@@ -989,7 +993,7 @@ internal class JobCompletionHandler
             }
         }
 
-        return IsDuplicatePlan(job);
+        return IsDuplicatePlan(job, plansDir);
     }
 
     internal static int GetPlanRevisionCount(string planFolder)
@@ -1096,15 +1100,50 @@ internal class JobCompletionHandler
         return true;
     }
 
-    // CreatePlan signals a deliberate duplicate rejection by ending its final message with
-    // "identified as duplicate: <folder>". The negative lookahead skips the documented template
-    // form, whose placeholder is angle-bracketed, so an agent that reads or quotes Program.md
-    // mid-run cannot echo the marker and suppress a genuine "no plan produced" failure.
-    // OutputLines holds re-serialized JSON, so the '<' arrives escaped as < — match both.
-    private static bool IsDuplicatePlan(JobItem job)
+    // A duplicate rejection is a claim the agent makes about its own run, so only the agent's own
+    // text counts: OutputLines also carries every tool result, and a CreatePlan run that reads a
+    // file quoting the marker (AGENTS.md documents it) must not be able to suppress a real failure.
+    // The named folder has to resolve to a plan on disk as well, so prose that happens to contain the
+    // marker cannot pass either.
+    private static bool IsDuplicatePlan(JobItem job, string? plansDir)
     {
-        var outputText = string.Join("\n", job.OutputLines);
-        return Regex.IsMatch(outputText, @"identified as duplicate:\s*(?!<|\\u003[Cc])\S");
+        if (string.IsNullOrEmpty(plansDir) || !Directory.Exists(plansDir)) return false;
+
+        var serializer = new JsonEventSerializer();
+        foreach (var entry in job.OutputLines)
+        {
+            var text = serializer.Deserialize(entry) switch
+            {
+                TextEvent t => t.Text,
+                ResultEvent { Response: { } response } => response,
+                _ => null
+            };
+            if (string.IsNullOrEmpty(text)) continue;
+
+            foreach (var m in DuplicateMarkerPattern.Matches(text).Cast<Match>())
+                if (ResolvesToPlanFolder(m.Groups["target"].Value, plansDir)) return true;
+        }
+        return false;
+    }
+
+    // FindPlanFolderById globs "{planId}-*", so passing it a full folder name never matches - that's
+    // why the first resolution step below checks the full form directly rather than delegating to it.
+    private static bool ResolvesToPlanFolder(string token, string plansDir)
+    {
+        token = token.Trim('`', '"', '\'', '.', ',', ';', ')', ']');
+        if (string.IsNullOrEmpty(token)) return false;
+
+        if (Directory.Exists(Path.Combine(plansDir, token))) return true;
+
+        var idMatch = Regex.Match(token, @"^(\d{5})");
+        if (idMatch.Success && PlanYamlHelper.FindPlanFolderById(plansDir, idMatch.Groups[1].Value) != null)
+            return true;
+
+        if (Regex.IsMatch(token, @"^\d+$") &&
+            PlanYamlHelper.FindPlanFolderById(plansDir, token.PadLeft(5, '0')) != null)
+            return true;
+
+        return false;
     }
 
     private static bool TryVerifyByFilesystem(JobItem job, string plansDir)


### PR DESCRIPTION
Fixes #2639

# Summary

## Changes

`IsDuplicatePlan` in `JobCompletionHandler.cs` no longer scans the whole accumulated job output for
the `identified as duplicate:` marker; it now only matches the agent's own assistant text/final
response, and requires the token after the marker to resolve to a real plan folder on disk (by full
folder name, plan id prefix, or bare plan id). This closes the false-positive path where a CreatePlan
run reading a file that quotes the marker (e.g. `AGENTS.md`) could suppress a genuine "no plan
produced" failure. Documentation in `AGENTS.md` and both `CreatePlan/Program.md` copies now states
this explicitly.

## API Changes

- `JobCompletionHandler.IsDuplicatePlan(JobItem job)` -> `IsDuplicatePlan(JobItem job, string? plansDir)` (private, internal signature change; both call sites updated).
- Added private `JobCompletionHandler.ResolvesToPlanFolder(string token, string plansDir)`.
- Added `internal static readonly Regex DuplicateMarkerPattern` alongside `GitHubPrUrlPattern`/`BarePrUrlPattern`.

## Files Modified

- `src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs` — core fix.
- `src/Ivy.Tendril/AGENTS.md` — documents the scoped/resolved marker behaviour.
- `src/Ivy.Tendril/Promptwares/CreatePlan/Program.md`, `src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md` — same doc update, kept identical.
- `src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs` — 3 new regression tests, 2 existing tests updated.
- `src/Ivy.Tendril.Test/JobServiceCreatePlanVerificationTests.cs` — 1 new focused test driving `JobCompletionHandler` directly.

## Manual Testing

N/A — internal change with no user-facing behavior. To exercise the fix directly:
1. Run the plan's test filter: `dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~JobServiceCompletionGuardTests|FullyQualifiedName~JobServiceCreatePlanVerificationTests|FullyQualifiedName~JobServiceRecoveredExecutionTests"`.
2. All 33 tests should pass, including `CompleteJob_CreatePlan_FailsWhenDuplicateMarkerIsOnlyInToolOutput`, which reproduces the original bug scenario (marker text arriving via a tool result) and asserts the job now fails instead of completing.

---
Commits:
- 336d1273 Scope duplicate-plan marker to agent text and require a resolvable folder
- db606605 Add regression tests for the duplicate-plan marker scoping fix
- f9db9944 Document that the duplicate-plan marker must name a resolvable folder

---
Created using [Ivy Tendril](https://ivy.app).
