### PR TITLE
[00452] Report OpenCode Output Truncation as a Failure

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Ivy/IvyFailureAnalyzerTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Ivy/IvyFailureAnalyzerTests.cs
@@ -1,0 +1,36 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Ivy;
+using Ivy.Tendril.Agents.Providers.OpenCode;
+
+namespace Ivy.Tendril.Agents.Test.Providers.Ivy;
+
+public class IvyFailureAnalyzerTests
+{
+    private readonly IvyFailureAnalyzer _analyzer = new();
+
+    [Fact]
+    public void Analyze_TruncationErrorEvent_KindAndMessageSurviveRewrite()
+    {
+        var errorEvent = new ErrorEvent
+        {
+            Kind = AgentEventKind.Error,
+            Message = "Model output truncated at the max output token limit (4096 output tokens in the final step); any pending tool call was aborted.",
+            Code = OpenCodeEventParser.OutputTruncatedCode,
+            IsRetryable = true,
+        };
+
+        var ctx = new FailureContext
+        {
+            Events = [errorEvent],
+            AgentId = AgentId.Ivy,
+            ExitCode = 0,
+        };
+
+        var result = _analyzer.Analyze(ctx);
+
+        Assert.Equal(FailureKind.OutputTruncated, result.Kind);
+        Assert.True(result.IsRetryable);
+        Assert.DoesNotContain("OpenCode", result.Reason);
+        Assert.Contains("output token limit", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs
@@ -178,6 +178,66 @@ public class OpenCodeEventParserTests
     }
 
     [Fact]
+    public void ParseLine_StepFinish_WithReasonLength_ReturnsErrorAndFailedResult()
+    {
+        var json = """{"type":"step_finish","part":{"reason":"length","cost":0,"tokens":{"input":2,"output":4096}}}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Equal(2, events.Count);
+
+        var errorEvt = Assert.IsType<ErrorEvent>(events[0]);
+        Assert.Equal(OpenCodeEventParser.OutputTruncatedCode, errorEvt.Code);
+        Assert.True(errorEvt.IsRetryable);
+        Assert.Contains("4096", errorEvt.Message);
+
+        var result = Assert.IsType<ResultEvent>(events[1]);
+        Assert.False(result.IsSuccess);
+        Assert.False(string.IsNullOrEmpty(result.Error));
+        Assert.NotNull(result.Usage);
+        Assert.Equal(4096, result.Usage.OutputTokens);
+    }
+
+    [Fact]
+    public void ParseLine_StepFinish_Length_ReportsStepTokensNotAccumulated()
+    {
+        _parser.ParseLine("""{"type":"step_finish","part":{"reason":"tool-calls","cost":0,"tokens":{"input":10,"output":134}}}""");
+        var events = _parser.ParseLine("""{"type":"step_finish","part":{"reason":"length","cost":0,"tokens":{"input":2,"output":4096}}}""");
+
+        var errorEvt = Assert.IsType<ErrorEvent>(events[0]);
+        Assert.Contains("4096", errorEvt.Message);
+        Assert.DoesNotContain("4230", errorEvt.Message);
+
+        var result = Assert.IsType<ResultEvent>(events[1]);
+        Assert.NotNull(result.Usage);
+        Assert.Equal(4230, result.Usage.OutputTokens);
+    }
+
+    [Fact]
+    public void BuildResult_AfterLengthStop_StaysUnsuccessful()
+    {
+        var events = _parser.ParseLine("""{"type":"step_finish","part":{"reason":"length","cost":0,"tokens":{"input":2,"output":4096}}}""");
+
+        var result = _parser.BuildResult(events, 0);
+        Assert.False(result!.IsSuccess);
+    }
+
+    [Fact]
+    public void ParseLine_StepFinish_WithUnrecognisedReason_ReturnsErrorAndFailedResult()
+    {
+        var json = """{"type":"step_finish","part":{"reason":"content-filter"}}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Equal(2, events.Count);
+
+        var errorEvt = Assert.IsType<ErrorEvent>(events[0]);
+        Assert.Equal(OpenCodeEventParser.UnhandledStopReasonCode, errorEvt.Code);
+        Assert.Contains("content-filter", errorEvt.Message);
+
+        var result = Assert.IsType<ResultEvent>(events[1]);
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
     public void ParseLine_StepFinish_NoCostOrTokens_UsageIsNull()
     {
         var json = """{"type":"step_finish","part":{"reason":"stop"}}""";

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeFailureAnalyzerTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeFailureAnalyzerTests.cs
@@ -141,6 +141,55 @@ public class OpenCodeFailureAnalyzerTests
     }
 
     [Fact]
+    public void Analyze_TruncationErrorEvent_ReturnsOutputTruncated()
+    {
+        var errorEvent = new ErrorEvent
+        {
+            Kind = AgentEventKind.Error,
+            Message = "Model output truncated at the max output token limit (4096 output tokens in the final step); any pending tool call was aborted.",
+            Code = OpenCodeEventParser.OutputTruncatedCode,
+            IsRetryable = true,
+        };
+
+        var ctx = new FailureContext
+        {
+            Events = [errorEvent],
+            AgentId = AgentId.OpenCode,
+            ExitCode = 0,
+        };
+
+        var result = _analyzer.Analyze(ctx);
+
+        Assert.Equal(FailureKind.OutputTruncated, result.Kind);
+        Assert.True(result.IsRetryable);
+        Assert.Contains("output token limit", result.Suggestion!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Analyze_UnhandledStopReasonErrorEvent_ReturnsUnhandledStopReason()
+    {
+        var errorEvent = new ErrorEvent
+        {
+            Kind = AgentEventKind.Error,
+            Message = "Agent stopped with an unhandled reason 'content-filter'; treating as a failure.",
+            Code = OpenCodeEventParser.UnhandledStopReasonCode,
+            IsRetryable = true,
+        };
+
+        var ctx = new FailureContext
+        {
+            Events = [errorEvent],
+            AgentId = AgentId.OpenCode,
+            ExitCode = 0,
+        };
+
+        var result = _analyzer.Analyze(ctx);
+
+        Assert.Equal(FailureKind.UnhandledStopReason, result.Kind);
+        Assert.True(result.IsRetryable);
+    }
+
+    [Fact]
     public void Analyze_ErrorEvent_NotRetryable_NotAuth_ReturnsUnknown()
     {
         var errorEvent = new ErrorEvent

--- a/src/Ivy.Tendril.Agents/Abstractions/IEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/IEventParser.cs
@@ -44,5 +44,7 @@ public enum FailureKind
     ValidationError,
     PermissionBlocked,
     NetworkError,
+    OutputTruncated,
+    UnhandledStopReason,
     Unknown
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
@@ -8,6 +8,9 @@ namespace Ivy.Tendril.Agents.Providers.OpenCode;
 
 public sealed class OpenCodeEventParser : IEventParser
 {
+    public const string OutputTruncatedCode = "output_truncated";
+    public const string UnhandledStopReasonCode = "unhandled_stop_reason";
+
     public string AgentId => Abstractions.AgentId.OpenCode;
 
     private static readonly IReadOnlyList<AgentEvent> Empty = Array.Empty<AgentEvent>();
@@ -203,17 +206,20 @@ public sealed class OpenCodeEventParser : IEventParser
         if (part.TryGetProperty("cost", out var cProp))
             _accumulatedCost += cProp.GetDecimal();
 
+        var stepOutputTokens = 0;
         if (part.TryGetProperty("tokens", out var tokens))
         {
             _accumulatedInputTokens += tokens.TryGetProperty("input", out var it) ? it.GetInt32() : 0;
-            _accumulatedOutputTokens += tokens.TryGetProperty("output", out var ot) ? ot.GetInt32() : 0;
+            stepOutputTokens = tokens.TryGetProperty("output", out var ot) ? ot.GetInt32() : 0;
+            _accumulatedOutputTokens += stepOutputTokens;
         }
 
         var reason = part.TryGetProperty("reason", out var rProp) ? rProp.GetString() : null;
 
-        // Intermediate steps (reason == "tool-calls") are not terminal — suppress them
-        // to avoid the UI rendering each step as an error.
-        if (reason is not ("stop" or "error"))
+        // Only "tool-calls" is an intermediate step - suppress it to avoid the UI
+        // rendering each step as an error. Every other reason really did end
+        // generation, including ones we don't have an explicit case for.
+        if (reason == "tool-calls")
             return Empty;
 
         AgentUsage? usage = (_accumulatedInputTokens > 0 || _accumulatedOutputTokens > 0 || _accumulatedCost > 0)
@@ -225,13 +231,43 @@ public sealed class OpenCodeEventParser : IEventParser
             }
             : null;
 
-        return [new ResultEvent
+        if (reason is "stop" or "error")
         {
-            Kind = AgentEventKind.Result,
-            IsSuccess = reason == "stop",
-            Usage = usage,
-            RawLine = rawLine,
-        }];
+            return [new ResultEvent
+            {
+                Kind = AgentEventKind.Result,
+                IsSuccess = reason == "stop",
+                Usage = usage,
+                RawLine = rawLine,
+            }];
+        }
+
+        _hasError = true;
+
+        var (code, message) = reason == "length"
+            ? (OutputTruncatedCode,
+               $"Model output truncated at the max output token limit ({stepOutputTokens} output tokens in the final step); any pending tool call was aborted.")
+            : (UnhandledStopReasonCode,
+               $"Agent stopped with an unhandled reason '{reason}'; treating as a failure.");
+
+        return [
+            new ErrorEvent
+            {
+                Kind = AgentEventKind.Error,
+                Message = message,
+                Code = code,
+                IsRetryable = true,
+                RawLine = rawLine,
+            },
+            new ResultEvent
+            {
+                Kind = AgentEventKind.Result,
+                IsSuccess = false,
+                Error = message,
+                Usage = usage,
+                RawLine = rawLine,
+            },
+        ];
     }
 
     private IReadOnlyList<AgentEvent> ParseError(JsonElement root, string rawLine)

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeFailureAnalyzer.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeFailureAnalyzer.cs
@@ -23,6 +23,30 @@ public sealed class OpenCodeFailureAnalyzer : IFailureAnalyzer
         var errorEvent = context.Events.OfType<ErrorEvent>().LastOrDefault();
         if (errorEvent is not null)
         {
+            if (errorEvent.Code == OpenCodeEventParser.OutputTruncatedCode)
+            {
+                return new FailureAnalysis
+                {
+                    Kind = FailureKind.OutputTruncated,
+                    Reason = errorEvent.Message,
+                    ContextLines = [errorEvent.Message],
+                    IsRetryable = true,
+                    Suggestion = "Retry with a smaller step, or raise the model's max output token limit",
+                };
+            }
+
+            if (errorEvent.Code == OpenCodeEventParser.UnhandledStopReasonCode)
+            {
+                return new FailureAnalysis
+                {
+                    Kind = FailureKind.UnhandledStopReason,
+                    Reason = errorEvent.Message,
+                    ContextLines = [errorEvent.Message],
+                    IsRetryable = true,
+                    Suggestion = "Retry the step; if this reason recurs often, the parser may need an explicit case for it",
+                };
+            }
+
             if (errorEvent.IsAuthError)
             {
                 return new FailureAnalysis

--- a/src/Ivy.Tendril.Test/Services/JobFailureAnalyzerTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobFailureAnalyzerTests.cs
@@ -1,3 +1,5 @@
+using Ivy.Tendril.Agents.Providers.OpenCode;
+using Ivy.Tendril.Agents.Runtime;
 using Ivy.Tendril.Services.Jobs;
 
 namespace Ivy.Tendril.Test.Services;
@@ -145,5 +147,22 @@ public class JobFailureAnalyzerTests
         Assert.Contains("b28ur1i7n", result);
         Assert.Contains("b1hduuleo", result);
         Assert.StartsWith("Background task(s) still running when the turn ended", result);
+    }
+
+    // Regression for #2638: a step_finish with reason=length must surface as an actual failure
+    // reason, not be silently discarded like an intermediate tool-calls step.
+    [Fact]
+    public void TruncatedRun_IsReportedAsAFailureReason()
+    {
+        var parser = new OpenCodeEventParser();
+        var events = parser.ParseLine("""{"type":"step_finish","part":{"reason":"length","cost":0,"tokens":{"input":2,"output":4096}}}""");
+
+        var serializer = new JsonEventSerializer();
+        var lines = events.Select(serializer.Serialize).ToList();
+
+        var reason = JobFailureAnalyzer.ExtractFailureReason(lines, "CreatePlan");
+
+        Assert.Contains("truncated", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("4096", reason);
     }
 }


### PR DESCRIPTION
Fixes #2638

# Summary

## Changes

`OpenCodeEventParser.ParseStepFinish` previously discarded any `step_finish` whose `reason` was
anything other than `stop`/`error` — including `length` (an output-token-limit truncation), so a
truncated run silently completed with exit code 0 and no error. It now treats only `tool-calls` as
an intermediate step; every other reason (`length`, and any unrecognised value) emits an `ErrorEvent`
plus a failed `ResultEvent`, which flows through the `ivy`/`openaiproxy` providers (they delegate to
the same parser/analyzer) and lets `JobFailureAnalyzer` report a real failure reason instead of
"Completed" with no explanation.

## API Changes

- `FailureKind` (`Ivy.Tendril.Agents.Abstractions.IEventParser`) — two new enum members added after
  `NetworkError`: `OutputTruncated`, `UnhandledStopReason`.
- `OpenCodeEventParser` — two new public constants: `OutputTruncatedCode = "output_truncated"`,
  `UnhandledStopReasonCode = "unhandled_stop_reason"`, used as the `Code` on the emitted `ErrorEvent`.
- `OpenCodeFailureAnalyzer.Analyze` — now returns `FailureKind.OutputTruncated` /
  `FailureKind.UnhandledStopReason` (both `IsRetryable = true`) for errors carrying those two codes.

## Files Modified

- `src/Ivy.Tendril.Agents/Abstractions/IEventParser.cs` — new `FailureKind` members.
- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs` — `ParseStepFinish` rewritten to
  treat every non-`tool-calls` reason as terminal.
- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeFailureAnalyzer.cs` — two new cases in `Analyze`.
- `src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs` — 4 new facts covering `length`
  and unrecognised-reason parsing, token reporting, and `BuildResult`.
- `src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeFailureAnalyzerTests.cs` — 2 new facts covering the
  new `FailureKind` mappings.
- `src/Ivy.Tendril.Agents.Test/Ivy/IvyFailureAnalyzerTests.cs` — new file; confirms the `ivy` provider
  gets the same classification with its "OpenCode" → "Ivy Agent" message rewrite intact.
- `src/Ivy.Tendril.Test/Services/JobFailureAnalyzerTests.cs` — new end-to-end regression
  (`TruncatedRun_IsReportedAsAFailureReason`) feeding a raw `length` line through the real parser and
  serializer into `JobFailureAnalyzer.ExtractFailureReason`.

## Manual Testing

N/A — internal change with no user-facing UI. Operator-visible effect: a job (`CreatePlan`,
`ExecutePlan`, etc.) run through the `opencode` or `ivy` provider that hits the model's max output
token limit mid-response will now be reported `Failed` with a message like "Model output truncated
at the max output token limit (4096 output tokens in the final step); any pending tool call was
aborted." instead of silently completing with no explanation.

---
9609fee6 Report OpenCode output truncation as a failure (Plan 00452)
7458f376 Add tests for OpenCode truncation and unhandled stop-reason handling (Plan 00452)

---
Created using [Ivy Tendril](https://ivy.app).