### PR TITLE
[00450] Raise the 4096 Token Output Cap for Ivy and OpenCode Provider Runs

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Ivy/IvyCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Ivy/IvyCliTests.cs
@@ -1,0 +1,26 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Ivy;
+
+namespace Ivy.Tendril.Agents.Test.Providers.Ivy;
+
+public class IvyCliTests
+{
+    private readonly IvyCli _cli = new();
+
+    [Fact]
+    public void BuildProcessSpec_PreservesOpenCodeConfigContent()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            Model = "claude-opus-5",
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        Assert.Equal("ivy-agent", Path.GetFileNameWithoutExtension(spec.FileName));
+        Assert.True(spec.Environment.TryGetValue("OPENCODE_CONFIG_CONTENT", out var configContent));
+        Assert.Contains("\"output\":128000", configContent);
+    }
+}

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeCliTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Providers.OpenCode;
 
@@ -315,5 +316,61 @@ public class OpenCodeCliTests
     {
         var env = _cli.GetDefaultEnvironment();
         Assert.Equal("dumb", env["TERM"]);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_WithKnownModel_SetsOutputLimitInConfigContent()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            Model = "anthropic/claude-opus-5",
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        Assert.True(spec.Environment.TryGetValue("OPENCODE_CONFIG_CONTENT", out var configContent));
+        using var doc = JsonDocument.Parse(configContent);
+        var limit = doc.RootElement
+            .GetProperty("provider").GetProperty("anthropic")
+            .GetProperty("models").GetProperty("claude-opus-5")
+            .GetProperty("limit");
+        Assert.Equal(128000, limit.GetProperty("output").GetInt32());
+        Assert.True(limit.TryGetProperty("context", out _));
+    }
+
+    [Fact]
+    public void BuildProcessSpec_WithUnknownModel_OmitsConfigContent()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            Model = "totally-unknown-model-xyz",
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        Assert.False(spec.Environment.ContainsKey("OPENCODE_CONFIG_CONTENT"));
+    }
+
+    [Fact]
+    public void BuildProcessSpec_WhenCallerSuppliesConfigContent_DoesNotOverwriteIt()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            Model = "anthropic/claude-opus-5",
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                ["OPENCODE_CONFIG_CONTENT"] = "{\"custom\":true}",
+            },
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        Assert.Equal("{\"custom\":true}", spec.Environment["OPENCODE_CONFIG_CONTENT"]);
     }
 }

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeModelCatalogTests.cs
@@ -58,4 +58,28 @@ public class OpenCodeModelCatalogTests
             "gpt-4.1",
         ], ids);
     }
+
+    [Fact]
+    public void GetStaticModels_DeclaresOutputLimits()
+    {
+        var models = _catalog.GetStaticModels();
+
+        foreach (var model in models.Where(m => m.Id != "default"))
+        {
+            Assert.True(model.MaxOutputTokens.HasValue, $"{model.Id} is missing MaxOutputTokens");
+            Assert.True(model.ContextWindow.HasValue, $"{model.Id} is missing ContextWindow");
+        }
+
+        Assert.Equal(128_000, models.Single(m => m.Id == "claude-opus-5").MaxOutputTokens);
+    }
+
+    [Fact]
+    public async Task ParseModelsListAsync_PopulatesMaxOutputTokens()
+    {
+        var models = await OpenCodeModelCatalog.ParseModelsListAsync("claude-opus-5");
+
+        Assert.NotNull(models);
+        var model = Assert.Single(models);
+        Assert.Equal(128_000, model.MaxOutputTokens);
+    }
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeCli.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using System.Text.Json.Nodes;
 using Ivy.Tendril.Agents.Abstractions;
 
 namespace Ivy.Tendril.Agents.Providers.OpenCode;
@@ -64,10 +65,12 @@ public sealed class OpenCodeCli : IAgentCli
             "--format", "json"
         };
 
+        string? formattedModel = null;
         if (!string.IsNullOrEmpty(config.Model))
         {
+            formattedModel = Helpers.OpenCodeModelHelper.FormatModel(config.Model);
             args.Add("--model");
-            args.Add(Helpers.OpenCodeModelHelper.FormatModel(config.Model));
+            args.Add(formattedModel);
         }
 
         if (config.Effort is not null)
@@ -101,6 +104,38 @@ public sealed class OpenCodeCli : IAgentCli
             args.Add(arg);
 
         var env = new Dictionary<string, string>(GetDefaultEnvironment());
+
+        if (formattedModel is not null)
+        {
+            var slash = formattedModel.IndexOf('/');
+            if (slash > 0 && OpenCodeModelCatalog.TryGetLimits(formattedModel) is { } limits)
+            {
+                var provider = formattedModel[..slash];
+                var modelKey = formattedModel[(slash + 1)..];
+                var configContent = new JsonObject
+                {
+                    ["provider"] = new JsonObject
+                    {
+                        [provider] = new JsonObject
+                        {
+                            ["models"] = new JsonObject
+                            {
+                                [modelKey] = new JsonObject
+                                {
+                                    ["limit"] = new JsonObject
+                                    {
+                                        ["context"] = limits.Context,
+                                        ["output"] = limits.Output,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                };
+                env["OPENCODE_CONFIG_CONTENT"] = configContent.ToJsonString();
+            }
+        }
+
         if (config.EnvironmentVariables is not null)
         {
             foreach (var (key, value) in config.EnvironmentVariables)

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
@@ -17,66 +17,79 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
         {
             Id = "moonshotai/Kimi-K3", DisplayName = "Kimi k3",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot", IsDefault = true,
+            ContextWindow = 256_000, MaxOutputTokens = 32_000,
         },
         new()
         {
             Id = "kimi-k2", DisplayName = "Kimi k2",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot",
+            ContextWindow = 128_000, MaxOutputTokens = 32_000,
         },
         new()
         {
             Id = "deepseek-v3", DisplayName = "DeepSeek V3",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek",
+            ContextWindow = 64_000, MaxOutputTokens = 8_000,
         },
         new()
         {
             Id = "deepseek-r1", DisplayName = "DeepSeek R1",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek",
+            ContextWindow = 64_000, MaxOutputTokens = 8_000,
         },
         new()
         {
             Id = "claude-fable-5", DisplayName = "Claude Fable 5",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
         },
         new()
         {
             Id = "claude-opus-5-1", DisplayName = "Claude Opus 5.1",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
         },
         new()
         {
             Id = "claude-opus-5", DisplayName = "Claude Opus 5",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
         },
         new()
         {
             Id = "claude-opus-4-7", DisplayName = "Claude Opus 4.7",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
         },
         new()
         {
             Id = "claude-sonnet-5-1", DisplayName = "Claude Sonnet 5.1",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
         },
         new()
         {
             Id = "claude-5.1", DisplayName = "Claude 5.1",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
         },
         new()
         {
             Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
         },
         new()
         {
             Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
         },
         new()
         {
             Id = "gpt-5.5", DisplayName = "GPT-5.5",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "openai",
+            ContextWindow = 400_000, MaxOutputTokens = 32_000,
         },
         new()
         {
@@ -122,6 +135,7 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
                 Provider = provider,
                 IsDefault = first,
                 ContextWindow = pricing?.ContextWindow,
+                MaxOutputTokens = pricing?.MaxOutput,
                 InputPerMillion = pricing?.Input ?? 0m,
                 OutputPerMillion = pricing?.Output ?? 0m,
                 CacheReadPerMillion = pricing?.CacheRead ?? 0m,
@@ -140,7 +154,35 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
         return slash > 0 ? modelId[..slash] : "opencode";
     }
 
-    private record KnownPricing(decimal Input, decimal Output, decimal CacheRead = 0m, decimal CacheWrite = 0m, int? ContextWindow = null);
+    private record KnownPricing(decimal Input, decimal Output, decimal CacheRead = 0m, decimal CacheWrite = 0m, int? ContextWindow = null, int? MaxOutput = null);
+
+    /// <summary>
+    /// Resolves the context and output token limits for a formatted model string (e.g.
+    /// <c>anthropic/claude-opus-5</c>), checking the static catalog first and falling back to
+    /// <see cref="LookupPricing"/>. Returns null when neither source has both values.
+    /// </summary>
+    internal static (int Context, int Output)? TryGetLimits(string formattedModel)
+    {
+        if (string.IsNullOrWhiteSpace(formattedModel))
+            return null;
+
+        var slash = formattedModel.IndexOf('/');
+        var bareModel = slash > 0 ? formattedModel[(slash + 1)..] : formattedModel;
+
+        var staticMatch = new OpenCodeModelCatalog().GetStaticModels().FirstOrDefault(m =>
+            m.ContextWindow is not null && m.MaxOutputTokens is not null &&
+            (string.Equals(m.Id, formattedModel, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(m.Id, bareModel, StringComparison.OrdinalIgnoreCase)));
+
+        if (staticMatch is not null)
+            return (staticMatch.ContextWindow!.Value, staticMatch.MaxOutputTokens!.Value);
+
+        var pricing = LookupPricing(formattedModel);
+        if (pricing is { ContextWindow: not null, MaxOutput: not null })
+            return (pricing.ContextWindow.Value, pricing.MaxOutput.Value);
+
+        return null;
+    }
 
     private static KnownPricing? LookupPricing(string modelId)
     {
@@ -171,51 +213,51 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
     private static readonly (string Pattern, KnownPricing Pricing)[] KnownPricingTable =
     [
         // Anthropic
-        ("claude-fable-5",    new(10.00m, 50.00m, 1.00m, 12.50m, 1_000_000)),
-        ("claude-opus-5-1",   new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000)),
-        ("claude-opus-5.1",   new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000)),
-        ("claude-opus-5",     new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000)),
-        ("claude-sonnet-5-1", new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000)),
-        ("claude-sonnet-5.1", new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000)),
-        ("claude-5.1",        new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000)),
-        ("claude-sonnet-5",   new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000)),
-        ("claude-haiku-5-1",  new(1.00m, 5.00m, 0.10m, 1.25m, 200_000)),
-        ("claude-opus-4-7",   new(10.00m, 50.00m, 1.00m, 12.50m, 200_000)),
-        ("claude-opus-4-6",   new(5.00m, 25.00m, 0.50m, 6.25m, 200_000)),
-        ("claude-opus-4-5",   new(5.00m, 25.00m, 0.50m, 6.25m, 200_000)),
-        ("claude-opus-4-1",   new(15.00m, 75.00m, 1.50m, 18.75m, 200_000)),
-        ("claude-opus-4",     new(15.00m, 75.00m, 1.50m, 18.75m, 200_000)),
-        ("claude-sonnet-4-6", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000)),
-        ("claude-sonnet-4-5", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000)),
-        ("claude-sonnet-4",   new(3.00m, 15.00m, 0.30m, 3.75m, 200_000)),
-        ("claude-3.7-sonnet", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000)),
-        ("claude-3.5-sonnet", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000)),
-        ("claude-3.5-haiku",  new(0.80m, 4.00m, 0.08m, 1.00m, 200_000)),
-        ("claude-3-haiku",    new(0.25m, 1.25m, 0.03m, 0.30m, 200_000)),
-        ("claude-3-opus",     new(15.00m, 75.00m, 1.50m, 18.75m, 200_000)),
+        ("claude-fable-5",    new(10.00m, 50.00m, 1.00m, 12.50m, 1_000_000, 128_000)),
+        ("claude-opus-5-1",   new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000, 128_000)),
+        ("claude-opus-5.1",   new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000, 128_000)),
+        ("claude-opus-5",     new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000, 128_000)),
+        ("claude-sonnet-5-1", new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000, 128_000)),
+        ("claude-sonnet-5.1", new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000, 128_000)),
+        ("claude-5.1",        new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000, 128_000)),
+        ("claude-sonnet-5",   new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000, 128_000)),
+        ("claude-haiku-5-1",  new(1.00m, 5.00m, 0.10m, 1.25m, 200_000, 64_000)),
+        ("claude-opus-4-7",   new(10.00m, 50.00m, 1.00m, 12.50m, 200_000, 128_000)),
+        ("claude-opus-4-6",   new(5.00m, 25.00m, 0.50m, 6.25m, 200_000, 128_000)),
+        ("claude-opus-4-5",   new(5.00m, 25.00m, 0.50m, 6.25m, 200_000, 128_000)),
+        ("claude-opus-4-1",   new(15.00m, 75.00m, 1.50m, 18.75m, 200_000, 128_000)),
+        ("claude-opus-4",     new(15.00m, 75.00m, 1.50m, 18.75m, 200_000, 128_000)),
+        ("claude-sonnet-4-6", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 128_000)),
+        ("claude-sonnet-4-5", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 128_000)),
+        ("claude-sonnet-4",   new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 128_000)),
+        ("claude-3.7-sonnet", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 64_000)),
+        ("claude-3.5-sonnet", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 64_000)),
+        ("claude-3.5-haiku",  new(0.80m, 4.00m, 0.08m, 1.00m, 200_000, 64_000)),
+        ("claude-3-haiku",    new(0.25m, 1.25m, 0.03m, 0.30m, 200_000, 64_000)),
+        ("claude-3-opus",     new(15.00m, 75.00m, 1.50m, 18.75m, 200_000, 64_000)),
         // OpenAI
-        ("gpt-5.5",       new(10.00m, 40.00m, 2.50m, 12.50m, 400_000)),
-        ("gpt-5.4",       new(10.00m, 40.00m, 2.50m, 12.50m, 400_000)),
-        ("gpt-5.4-mini",  new(1.10m, 4.40m, 0.275m, 1.375m, 400_000)),
-        ("gpt-4.5",       new(75.00m, 150.00m, 37.50m, 93.75m, 128_000)),
-        ("gpt-4.1-mini",  new(0.40m, 1.60m, 0.10m, 0.50m, 1_047_576)),
-        ("gpt-4.1-nano",  new(0.10m, 0.40m, 0.025m, 0.125m, 1_047_576)),
-        ("gpt-4.1",       new(2.00m, 8.00m, 0.50m, 2.50m, 1_047_576)),
-        ("gpt-4o-mini",   new(0.15m, 0.60m, 0.075m, 0.1875m, 128_000)),
-        ("gpt-4o",        new(2.50m, 10.00m, 1.25m, 3.125m, 128_000)),
-        ("o4-mini",       new(1.10m, 4.40m, 0.275m, 1.375m, 200_000)),
-        ("o3-mini",       new(1.10m, 4.40m, 0.275m, 1.375m, 200_000)),
-        ("o3",            new(10.00m, 40.00m, 2.50m, 12.50m, 200_000)),
-        ("o1-mini",       new(1.10m, 4.40m, 0.275m, 1.375m, 128_000)),
-        ("o1-pro",        new(150.00m, 600.00m, 0m, 0m, 128_000)),
-        ("o1",            new(15.00m, 60.00m, 7.50m, 18.75m, 200_000)),
+        ("gpt-5.5",       new(10.00m, 40.00m, 2.50m, 12.50m, 400_000, 32_000)),
+        ("gpt-5.4",       new(10.00m, 40.00m, 2.50m, 12.50m, 400_000, 32_000)),
+        ("gpt-5.4-mini",  new(1.10m, 4.40m, 0.275m, 1.375m, 400_000, 16_000)),
+        ("gpt-4.5",       new(75.00m, 150.00m, 37.50m, 93.75m, 128_000, 16_000)),
+        ("gpt-4.1-mini",  new(0.40m, 1.60m, 0.10m, 0.50m, 1_047_576, 16_000)),
+        ("gpt-4.1-nano",  new(0.10m, 0.40m, 0.025m, 0.125m, 1_047_576, 16_000)),
+        ("gpt-4.1",       new(2.00m, 8.00m, 0.50m, 2.50m, 1_047_576, 32_000)),
+        ("gpt-4o-mini",   new(0.15m, 0.60m, 0.075m, 0.1875m, 128_000, 16_000)),
+        ("gpt-4o",        new(2.50m, 10.00m, 1.25m, 3.125m, 128_000, 16_000)),
+        ("o4-mini",       new(1.10m, 4.40m, 0.275m, 1.375m, 200_000, 100_000)),
+        ("o3-mini",       new(1.10m, 4.40m, 0.275m, 1.375m, 200_000, 100_000)),
+        ("o3",            new(10.00m, 40.00m, 2.50m, 12.50m, 200_000, 100_000)),
+        ("o1-mini",       new(1.10m, 4.40m, 0.275m, 1.375m, 128_000, 100_000)),
+        ("o1-pro",        new(150.00m, 600.00m, 0m, 0m, 128_000, 100_000)),
+        ("o1",            new(15.00m, 60.00m, 7.50m, 18.75m, 200_000, 100_000)),
         // Google
-        ("gemini-3.8-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
-        ("gemini-3.7-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
-        ("gemini-3.6-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
-        ("gemini-3.1-pro",   new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576)),
-        ("gemini-2.5-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
-        ("gemini-2.5",       new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576)),
-        ("gemini-2.0-flash", new(0.10m, 0.40m, 0.025m, 0.125m, 1_048_576)),
+        ("gemini-3.8-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576, 65_536)),
+        ("gemini-3.7-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576, 65_536)),
+        ("gemini-3.6-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576, 65_536)),
+        ("gemini-3.1-pro",   new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576, 65_536)),
+        ("gemini-2.5-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576, 65_536)),
+        ("gemini-2.5",       new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576, 65_536)),
+        ("gemini-2.0-flash", new(0.10m, 0.40m, 0.025m, 0.125m, 1_048_576, 65_536)),
     ];
 }

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -274,7 +274,28 @@ Adjust them as the task warrants (the user can also toggle them later in the UI;
 
 #### 4.2. Write the revision
 
-Write the revision content via CLI:
+Write the revision to a temp file in one or more appends, each its own tool call, then submit it in
+a separate final call:
+
+```bash
+cat >> /tmp/revision-<PlanId>.md <<'EOF'
+<first chunk of revision content>
+EOF
+```
+
+```bash
+cat >> /tmp/revision-<PlanId>.md <<'EOF'
+<next chunk of revision content>
+EOF
+```
+
+```bash
+tendril plan write-revision <PlanId> --file=/tmp/revision-<PlanId>.md
+```
+
+A long revision has to be split across appends so no single response has to carry the whole plan in
+one heredoc — each `cat >>` call only needs to fit that chunk, not the entire markdown. `--stdin`
+stays the right choice for short revisions that comfortably fit in one response:
 
 ```bash
 tendril plan write-revision <PlanId> --stdin <<'EOF'
@@ -284,7 +305,7 @@ EOF
 
 **The revision's first line is the `# {title}` H1 heading — it MUST be the exact same string you passed as `<Title>` to `tendril plan create` above** (human-readable Title Case, not the PascalCase folder form). The `plan.yaml` title and the spec H1 must always match.
 
-This reads from STDIN and auto-creates `Revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
+The submitting call (`--file` or `--stdin`) auto-creates `Revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`. The duplicate-candidate block described below is read from stderr of that submitting call, not from any of the append calls.
 
 **Duplicate candidates at finalization.** `write-revision` prints this to **stderr** when it finds overlapping plans, while still writing the revision and exiting 0:
 


### PR DESCRIPTION
Fixes #2637

# Summary

## Changes

`OpenCodeCli.BuildProcessSpec` now resolves the launched model's context/output token limits and
passes them to `opencode` via `OPENCODE_CONFIG_CONTENT`, so `ivy`-provider `CreatePlan` runs stop
being truncated at opencode's 4096-token default (GitHub issue #2637). `OpenCodeModelCatalog` gained
the `ContextWindow`/`MaxOutputTokens` data the resolver needs, and the `CreatePlan` promptware's
revision-write step was changed from a single stdin heredoc to an append-then-submit pattern so a
long revision no longer has to fit inside one assistant response.

## API Changes

- New: `internal static (int Context, int Output)? OpenCodeModelCatalog.TryGetLimits(string formattedModel)`
- `OpenCodeModelCatalog.GetStaticModels()`: all 13 non-`default` entries now set `ContextWindow` and `MaxOutputTokens`.
- `OpenCodeModelCatalog.ParseModelsListAsync`: discovered models now populate `MaxOutputTokens`.
- Private `KnownPricing` record gained a `MaxOutput` field (used only within `OpenCodeModelCatalog`).
- `OpenCodeCli.BuildProcessSpec`: when the launch model resolves to known limits, sets
  `OPENCODE_CONFIG_CONTENT` in the returned `AgentProcessSpec.Environment` (unless the caller already
  supplied that key).

## Files Modified

- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs` — catalog data + `TryGetLimits` resolver
- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeCli.cs` — emits `OPENCODE_CONFIG_CONTENT`
- `src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeModelCatalogTests.cs`, `OpenCodeCliTests.cs` — new coverage
- `src/Ivy.Tendril.Agents.Test/Ivy/IvyCliTests.cs` — new file, confirms `IvyCli` preserves the env var
- `src/Ivy.Tendril/Promptwares/CreatePlan/Program.md` — §4.2 append-then-submit revision write

## Manual Testing

This fix cannot be reproduced from a unit test — the 4096-token stop happens inside the `ivy-agent`
process, not in .NET code. On a machine configured for the `ivy` provider:

1. Launch a `CreatePlan` job on the `ivy` provider with `claude-opus-5`.
2. In `$TENDRIL_HOME/Jobs/{id}-CreatePlan.raw.jsonl`, confirm no `step_finish` event carries
   `reason":"length"` with `tokens.output` at 4096.

This machine's own `Jobs/*.raw.jsonl` logs are all Claude-provider format (no `ivy` provider runs to
compare against), so this step needs to be done on a box actually configured for `ivy`.

---
## Commits

- b33ac1e0 Populate OpenCode model catalog with context/output token limits (Plan 00450)
- 76adfa0b Emit OPENCODE_CONFIG_CONTENT with model output limit (Plan 00450)
- 5385cada Split CreatePlan revision writes into append-then-submit chunks (Plan 00450)

---
Created using [Ivy Tendril](https://ivy.app).
