### PR TITLE
[00451] Confine Local File Endpoint to Configured Roots

### DIFF
--- a/src/Ivy.Tendril.Test/LocalFileGuardMiddlewareTests.cs
+++ b/src/Ivy.Tendril.Test/LocalFileGuardMiddlewareTests.cs
@@ -34,12 +34,15 @@ public class LocalFileGuardMiddlewareTests
         public bool Called { get; set; }
     }
 
-    private static (LocalFileGuardMiddleware middleware, DefaultHttpContext context, NextCalledTracker tracker) CreateMiddleware(
+    private const string TendrilHome = "/tmp";
+
+    private static (LocalFileGuardMiddleware middleware, DefaultHttpContext context, NextCalledTracker tracker, ConfigService config) CreateMiddleware(
         TendrilSettings? settings = null,
         string? tunnelUrl = null,
-        bool tunnelConnected = false)
+        bool tunnelConnected = false,
+        string? tendrilHome = null)
     {
-        var config = new ConfigService(settings ?? new TendrilSettings(), "/tmp");
+        var config = new ConfigService(settings ?? new TendrilSettings(), tendrilHome ?? TendrilHome);
         var tunnelService = new StubShareTunnelService
         {
             TunnelUrl = tunnelUrl,
@@ -62,13 +65,13 @@ public class LocalFileGuardMiddlewareTests
         var context = new DefaultHttpContext();
         context.Response.Body = new MemoryStream();
 
-        return (middleware, context, tracker);
+        return (middleware, context, tracker, config);
     }
 
     [Fact]
     public async Task UnrelatedPath_PassesThrough()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/api/plans/00001";
         context.Request.Host = new HostString("localhost", 5000);
 
@@ -80,10 +83,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task LocalhostWithImageExtension_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -93,10 +96,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task Loopback127_0_0_1_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("127.0.0.1", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -106,10 +109,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task LoopbackIpv6_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("[::1]", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -119,10 +122,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task DisallowedHost_Returns403()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("evil.example.com", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -133,12 +136,12 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task TunnelHost_WhenConnected_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware(
+        var (middleware, context, tracker, _) = CreateMiddleware(
             tunnelUrl: "https://tunnel.example.com",
             tunnelConnected: true);
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("tunnel.example.com", 443);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -148,12 +151,12 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task TunnelHost_WhenNotConnected_Returns403()
     {
-        var (middleware, context, tracker) = CreateMiddleware(
+        var (middleware, context, tracker, _) = CreateMiddleware(
             tunnelUrl: "https://tunnel.example.com",
             tunnelConnected: false);
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("tunnel.example.com", 443);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -171,10 +174,10 @@ public class LocalFileGuardMiddlewareTests
                 AllowedHosts = new List<string> { "custom.local" }
             }
         };
-        var (middleware, context, tracker) = CreateMiddleware(settings);
+        var (middleware, context, tracker, _) = CreateMiddleware(settings);
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("custom.local", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -184,11 +187,11 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task CrossOrigin_Returns403()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.Headers["Origin"] = "https://evil.example.com";
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -199,11 +202,11 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task MatchingOrigin_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.Headers["Origin"] = "http://localhost:5000";
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -213,11 +216,11 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task CrossSiteFetch_Returns403()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.Headers["Sec-Fetch-Site"] = "cross-site";
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -228,11 +231,11 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task SameOriginFetch_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.Headers["Sec-Fetch-Site"] = "same-origin";
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -242,11 +245,11 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task SameSiteFetch_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.Headers["Sec-Fetch-Site"] = "same-site";
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -256,11 +259,11 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task NoneFetch_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.Headers["Sec-Fetch-Site"] = "none";
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -270,10 +273,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task AbsentFetchSite_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -283,7 +286,7 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task SshKey_Returns404()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.QueryString = new QueryString("?path=C:/Users/x/.ssh/id_rsa");
@@ -297,7 +300,7 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task YamlFile_Returns404()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.QueryString = new QueryString("?path=C:/config/config.yaml");
@@ -311,7 +314,7 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task JsonFile_Returns404()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.QueryString = new QueryString("?path=C:/secrets/.credentials.json");
@@ -325,7 +328,7 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task MarkdownFile_Returns404()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.QueryString = new QueryString("?path=C:/docs/README.md");
@@ -339,7 +342,7 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task CSharpFile_Returns404()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.QueryString = new QueryString("?path=C:/src/Program.cs");
@@ -353,7 +356,7 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task ExtensionlessFile_Returns404()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.QueryString = new QueryString("?path=C:/etc/hosts");
@@ -367,10 +370,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task PngFile_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/images/test.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/images/test.png");
 
         await middleware.InvokeAsync(context);
 
@@ -380,10 +383,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task JpgFile_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/images/test.jpg");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/images/test.jpg");
 
         await middleware.InvokeAsync(context);
 
@@ -393,10 +396,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task SvgFile_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/images/test.svg");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/images/test.svg");
 
         await middleware.InvokeAsync(context);
 
@@ -406,10 +409,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task WebpFile_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/images/test.webp");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/images/test.webp");
 
         await middleware.InvokeAsync(context);
 
@@ -419,10 +422,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task AvifFile_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/images/test.avif");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/images/test.avif");
 
         await middleware.InvokeAsync(context);
 
@@ -432,10 +435,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task PdfFile_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/docs/manual.pdf");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/docs/manual.pdf");
 
         await middleware.InvokeAsync(context);
 
@@ -445,7 +448,7 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task TraversalPath_Returns404()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
         context.Request.QueryString = new QueryString("?path=D:/.tendril/Plans/../../Users/x/.ssh/id_rsa");
@@ -459,10 +462,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task AllowedRequest_SetsSecurityHeaders()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("localhost", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -474,10 +477,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task PrivateIpv4_10Network_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("10.0.0.5", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -487,10 +490,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task PrivateIpv4_172Network_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("172.16.0.1", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -500,10 +503,10 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task PrivateIpv4_192Network_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("192.168.1.100", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
@@ -513,13 +516,99 @@ public class LocalFileGuardMiddlewareTests
     [Fact]
     public async Task LocalMdnsHost_CallsNext()
     {
-        var (middleware, context, tracker) = CreateMiddleware();
+        var (middleware, context, tracker, _) = CreateMiddleware();
         context.Request.Path = "/ivy/local-file";
         context.Request.Host = new HostString("mycomputer.local", 5000);
-        context.Request.QueryString = new QueryString("?path=C:/test/image.png");
+        context.Request.QueryString = new QueryString($"?path={TendrilHome}/test/image.png");
 
         await middleware.InvokeAsync(context);
 
         Assert.True(tracker.Called);
+    }
+
+    [Fact]
+    public async Task PngUnderTendrilHome_CallsNext()
+    {
+        var home = CreateTempDir();
+        var (middleware, context, tracker, _) = CreateMiddleware(tendrilHome: home);
+        context.Request.Path = "/ivy/local-file";
+        context.Request.Host = new HostString("localhost", 5000);
+        context.Request.QueryString = new QueryString($"?path={Path.Combine(home, "image.png")}");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(tracker.Called);
+    }
+
+    [Fact]
+    public async Task PngOutsideEveryRoot_Returns404NotFound()
+    {
+        var home = CreateTempDir();
+        var outside = CreateTempDir();
+        var (middleware, context, tracker, _) = CreateMiddleware(tendrilHome: home);
+        context.Request.Path = "/ivy/local-file";
+        context.Request.Host = new HostString("localhost", 5000);
+        context.Request.QueryString = new QueryString($"?path={Path.Combine(outside, "image.png")}");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(tracker.Called);
+        Assert.Equal(404, context.Response.StatusCode);
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var body = new StreamReader(context.Response.Body).ReadToEnd();
+        Assert.Contains("File not found", body);
+    }
+
+    [Fact]
+    public async Task PathUnderSecurityLocalFileRoot_CallsNext()
+    {
+        var home = CreateTempDir();
+        var extraRoot = CreateTempDir();
+        var settings = new TendrilSettings
+        {
+            Security = new SecuritySettings { LocalFileRoots = new List<string> { extraRoot } }
+        };
+        var (middleware, context, tracker, _) = CreateMiddleware(settings, tendrilHome: home);
+        context.Request.Path = "/ivy/local-file";
+        context.Request.Host = new HostString("localhost", 5000);
+        context.Request.QueryString = new QueryString($"?path={Path.Combine(extraRoot, "image.png")}");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(tracker.Called);
+    }
+
+    [Fact]
+    public async Task EditingSecurityLocalFileRoots_InvalidatesCache()
+    {
+        var home = CreateTempDir();
+        var extraRoot = CreateTempDir();
+        var (middleware, context, tracker, config) = CreateMiddleware(tendrilHome: home);
+        var candidatePath = Path.Combine(extraRoot, "image.png");
+
+        context.Request.Path = "/ivy/local-file";
+        context.Request.Host = new HostString("localhost", 5000);
+        context.Request.QueryString = new QueryString($"?path={candidatePath}");
+        await middleware.InvokeAsync(context);
+        Assert.False(tracker.Called);
+        Assert.Equal(404, context.Response.StatusCode);
+
+        config.Settings.Security = new SecuritySettings { LocalFileRoots = new List<string> { extraRoot } };
+        config.SaveSettings();
+
+        var context2 = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+        context2.Request.Path = "/ivy/local-file";
+        context2.Request.Host = new HostString("localhost", 5000);
+        context2.Request.QueryString = new QueryString($"?path={candidatePath}");
+        await middleware.InvokeAsync(context2);
+
+        Assert.True(tracker.Called);
+    }
+
+    private static string CreateTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "tendril-lfgm-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
     }
 }

--- a/src/Ivy.Tendril.Test/LocalFileRootPolicyTests.cs
+++ b/src/Ivy.Tendril.Test/LocalFileRootPolicyTests.cs
@@ -1,0 +1,151 @@
+using Ivy.Tendril.Controllers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class LocalFileRootPolicyTests
+{
+    private static string CreateTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "tendril-lfrp-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void ComputeRoots_IncludesHomePlanFolderReposAndSecurityRoots_DropsBlankAndDuplicate()
+    {
+        var home = CreateTempDir();
+        var repoPath = CreateTempDir();
+        var extraRoot = CreateTempDir();
+
+        var settings = new TendrilSettings
+        {
+            Projects = new List<ProjectConfig>
+            {
+                new()
+                {
+                    Name = "demo",
+                    Repos = new List<RepoRef> { new() { Path = repoPath } }
+                }
+            },
+            Security = new SecuritySettings
+            {
+                LocalFileRoots = new List<string> { extraRoot, "", "  ", extraRoot }
+            }
+        };
+
+        var config = new ConfigService(settings, home);
+        var roots = LocalFileRootPolicy.ComputeRoots(config);
+
+        Assert.Contains(Path.GetFullPath(home), roots, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains(Path.GetFullPath(Path.Combine(home, "Plans")), roots, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains(Path.GetFullPath(repoPath), roots, StringComparer.OrdinalIgnoreCase);
+        Assert.Single(roots, r => string.Equals(r, Path.GetFullPath(extraRoot), StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ComputeRoots_ExpandsTildeAndEnvironmentVariables()
+    {
+        var home = CreateTempDir();
+        const string varName = "TENDRIL_LFRP_TEST_ROOT";
+        var varTarget = CreateTempDir();
+        Environment.SetEnvironmentVariable(varName, varTarget);
+        try
+        {
+            var settings = new TendrilSettings
+            {
+                Security = new SecuritySettings
+                {
+                    LocalFileRoots = new List<string> { $"${varName}" }
+                }
+            };
+
+            var config = new ConfigService(settings, home);
+            var roots = LocalFileRootPolicy.ComputeRoots(config);
+
+            Assert.Contains(Path.GetFullPath(varTarget), roots, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(varName, null);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_FileDirectlyInRoot_Allowed()
+    {
+        var root = CreateTempDir();
+        var file = Path.Combine(root, "image.png");
+
+        var allowed = LocalFileRootPolicy.TryResolve(file, new List<string> { root }, out var resolved);
+
+        Assert.True(allowed);
+        Assert.Equal(Path.GetFullPath(file), resolved);
+    }
+
+    [Fact]
+    public void TryResolve_FileNestedUnderRoot_Allowed()
+    {
+        var root = CreateTempDir();
+        var file = Path.Combine(root, "nested", "deep", "image.png");
+
+        var allowed = LocalFileRootPolicy.TryResolve(file, new List<string> { root }, out _);
+
+        Assert.True(allowed);
+    }
+
+    [Fact]
+    public void TryResolve_SiblingDirectorySharingRootPrefix_Rejected()
+    {
+        var parent = CreateTempDir();
+        var root = Path.Combine(parent, "pub");
+        var sibling = Path.Combine(parent, "pub-secrets", "x.png");
+        Directory.CreateDirectory(root);
+
+        var allowed = LocalFileRootPolicy.TryResolve(sibling, new List<string> { root }, out _);
+
+        Assert.False(allowed);
+    }
+
+    [Fact]
+    public void TryResolve_TraversalOutsideRoot_Rejected()
+    {
+        var parent = CreateTempDir();
+        var root = Path.Combine(parent, "root");
+        Directory.CreateDirectory(root);
+        var traversal = Path.Combine(root, "..", "outside", "x.png");
+
+        var allowed = LocalFileRootPolicy.TryResolve(traversal, new List<string> { root }, out _);
+
+        Assert.False(allowed);
+    }
+
+    [Fact]
+    public void TryResolve_SymlinkInsideRootPointingOutside_Rejected()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var root = CreateTempDir();
+        var outside = CreateTempDir();
+        var outsideFile = Path.Combine(outside, "secret.png");
+        File.WriteAllText(outsideFile, "");
+        var linkPath = Path.Combine(root, "link.png");
+        File.CreateSymbolicLink(linkPath, outsideFile);
+
+        var allowed = LocalFileRootPolicy.TryResolve(linkPath, new List<string> { root }, out _);
+
+        Assert.False(allowed);
+    }
+
+    [Fact]
+    public void TryResolve_EmptyRootList_RejectsEverything()
+    {
+        var allowed = LocalFileRootPolicy.TryResolve("/anything/at/all.png", new List<string>(), out _);
+
+        Assert.False(allowed);
+    }
+}

--- a/src/Ivy.Tendril/Controllers/LocalFileGuardMiddleware.cs
+++ b/src/Ivy.Tendril/Controllers/LocalFileGuardMiddleware.cs
@@ -6,17 +6,32 @@ using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Controllers;
 
-public class LocalFileGuardMiddleware(
-    RequestDelegate next,
-    IConfigService configService,
-    IShareTunnelService tunnelService,
-    ILogger<LocalFileGuardMiddleware> logger)
+public class LocalFileGuardMiddleware
 {
+    private readonly RequestDelegate _next;
+    private readonly IConfigService _configService;
+    private readonly IShareTunnelService _tunnelService;
+    private readonly ILogger<LocalFileGuardMiddleware> _logger;
+    private volatile List<string>? _cachedRoots;
+
+    public LocalFileGuardMiddleware(
+        RequestDelegate next,
+        IConfigService configService,
+        IShareTunnelService tunnelService,
+        ILogger<LocalFileGuardMiddleware> logger)
+    {
+        _next = next;
+        _configService = configService;
+        _tunnelService = tunnelService;
+        _logger = logger;
+        _configService.SettingsReloaded += (_, _) => _cachedRoots = null;
+    }
+
     public async Task InvokeAsync(HttpContext context)
     {
         if (!context.Request.Path.StartsWithSegments("/ivy/local-file"))
         {
-            await next(context);
+            await _next(context);
             return;
         }
 
@@ -24,7 +39,7 @@ public class LocalFileGuardMiddleware(
         var host = context.Request.Host.Host;
         if (!IsAllowedHost(host))
         {
-            logger.LogWarning("LocalFileGuard: Rejected request from disallowed host: {Host}, Path: {Path}",
+            _logger.LogWarning("LocalFileGuard: Rejected request from disallowed host: {Host}, Path: {Path}",
                 host, context.Request.Query["path"]);
             context.Response.StatusCode = 403;
             await context.Response.WriteAsJsonAsync(new { error = "Access denied: invalid host" });
@@ -39,7 +54,7 @@ public class LocalFileGuardMiddleware(
             {
                 if (!string.Equals(originUri.Host, host, StringComparison.OrdinalIgnoreCase))
                 {
-                    logger.LogWarning(
+                    _logger.LogWarning(
                         "LocalFileGuard: Rejected cross-origin request from {Origin} to {Host}, Path: {Path}",
                         originString, host, context.Request.Query["path"]);
                     context.Response.StatusCode = 403;
@@ -55,7 +70,7 @@ public class LocalFileGuardMiddleware(
             var fetchSiteValue = fetchSite.ToString();
             if (string.Equals(fetchSiteValue, "cross-site", StringComparison.OrdinalIgnoreCase))
             {
-                logger.LogWarning(
+                _logger.LogWarning(
                     "LocalFileGuard: Rejected cross-site fetch from {Host}, Path: {Path}",
                     host, context.Request.Query["path"]);
                 context.Response.StatusCode = 403;
@@ -73,9 +88,21 @@ public class LocalFileGuardMiddleware(
 
             if (!IsAllowedFileType(extension))
             {
-                logger.LogWarning(
+                _logger.LogWarning(
                     "LocalFileGuard: Rejected request for disallowed file type {Extension}, Path: {Path}",
                     extension, fullPath);
+                context.Response.StatusCode = 404;
+                await context.Response.WriteAsJsonAsync(new { error = "File not found" });
+                return;
+            }
+
+            // 4.5 Root confinement: the resolved path must fall inside a configured root.
+            var roots = GetRoots();
+            if (!LocalFileRootPolicy.TryResolve(path, roots, out _))
+            {
+                _logger.LogWarning(
+                    "LocalFileGuard: Rejected request for path outside configured roots, Path: {Path}, RootCount: {RootCount}",
+                    fullPath, roots.Count);
                 context.Response.StatusCode = 404;
                 await context.Response.WriteAsJsonAsync(new { error = "File not found" });
                 return;
@@ -86,7 +113,12 @@ public class LocalFileGuardMiddleware(
         context.Response.Headers["X-Content-Type-Options"] = "nosniff";
         context.Response.Headers["Content-Security-Policy"] = "default-src 'none'; sandbox";
 
-        await next(context);
+        await _next(context);
+    }
+
+    private List<string> GetRoots()
+    {
+        return _cachedRoots ??= LocalFileRootPolicy.ComputeRoots(_configService);
     }
 
     private bool IsAllowedHost(string host)
@@ -102,9 +134,9 @@ public class LocalFileGuardMiddleware(
         }
 
         // Active tunnel host
-        if (tunnelService.IsConnected && tunnelService.TunnelUrl != null)
+        if (_tunnelService.IsConnected && _tunnelService.TunnelUrl != null)
         {
-            if (Uri.TryCreate(tunnelService.TunnelUrl, UriKind.Absolute, out var tunnelUri))
+            if (Uri.TryCreate(_tunnelService.TunnelUrl, UriKind.Absolute, out var tunnelUri))
             {
                 if (string.Equals(host, tunnelUri.Host, StringComparison.OrdinalIgnoreCase))
                 {
@@ -126,7 +158,7 @@ public class LocalFileGuardMiddleware(
         }
 
         // Configured allowed hosts
-        var allowedHosts = configService.Settings.Security?.AllowedHosts;
+        var allowedHosts = _configService.Settings.Security?.AllowedHosts;
         if (allowedHosts != null && allowedHosts.Contains(host, StringComparer.OrdinalIgnoreCase))
         {
             return true;

--- a/src/Ivy.Tendril/Controllers/LocalFileGuardMiddleware.cs
+++ b/src/Ivy.Tendril/Controllers/LocalFileGuardMiddleware.cs
@@ -13,6 +13,7 @@ public class LocalFileGuardMiddleware
     private readonly IShareTunnelService _tunnelService;
     private readonly ILogger<LocalFileGuardMiddleware> _logger;
     private volatile List<string>? _cachedRoots;
+    private volatile bool _loggedEmptyRoots;
 
     public LocalFileGuardMiddleware(
         RequestDelegate next,
@@ -24,7 +25,11 @@ public class LocalFileGuardMiddleware
         _configService = configService;
         _tunnelService = tunnelService;
         _logger = logger;
-        _configService.SettingsReloaded += (_, _) => _cachedRoots = null;
+        _configService.SettingsReloaded += (_, _) =>
+        {
+            _cachedRoots = null;
+            _loggedEmptyRoots = false;
+        };
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -98,6 +103,13 @@ public class LocalFileGuardMiddleware
 
             // 4.5 Root confinement: the resolved path must fall inside a configured root.
             var roots = GetRoots();
+            if (roots.Count == 0 && !_loggedEmptyRoots)
+            {
+                _loggedEmptyRoots = true;
+                _logger.LogError(
+                    "LocalFileGuard: No local-file roots are configured; every /ivy/local-file request will be rejected. Check TendrilHome, the plans folder and project repo paths.");
+            }
+
             if (!LocalFileRootPolicy.TryResolve(path, roots, out _))
             {
                 _logger.LogWarning(

--- a/src/Ivy.Tendril/Controllers/LocalFileRootPolicy.cs
+++ b/src/Ivy.Tendril/Controllers/LocalFileRootPolicy.cs
@@ -1,0 +1,110 @@
+using System.Security;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Controllers;
+
+/// <summary>
+/// Confines GET /ivy/local-file to a set of configured roots. Unlike a general-purpose "no
+/// restriction when unset" policy, an empty root list here means deny everything: fail closed.
+/// </summary>
+internal static class LocalFileRootPolicy
+{
+    public static List<string> ComputeRoots(IConfigService config)
+    {
+        var candidates = new List<string?> { config.TendrilHome, config.PlanFolder };
+
+        foreach (var project in config.Projects)
+        {
+            candidates.AddRange(project.RepoPaths);
+        }
+
+        if (config.Settings.Security?.LocalFileRoots is { } extraRoots)
+        {
+            candidates.AddRange(extraRoots);
+        }
+
+        var roots = new List<string>();
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                continue;
+            }
+
+            string normalized;
+            try
+            {
+                normalized = PathHelper.ResolvePath(candidate)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException or IOException)
+            {
+                continue;
+            }
+
+            if (normalized.Length > 0 && !roots.Contains(normalized, StringComparer.OrdinalIgnoreCase))
+            {
+                roots.Add(normalized);
+            }
+        }
+
+        return roots;
+    }
+
+    public static bool TryResolve(string? path, IReadOnlyList<string> roots, out string fullPath)
+    {
+        fullPath = "";
+
+        if (string.IsNullOrEmpty(path) || roots.Count == 0)
+        {
+            return false;
+        }
+
+        string resolved;
+        try
+        {
+            resolved = Path.GetFullPath(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+
+        var target = resolved;
+        try
+        {
+            var linkTarget = new FileInfo(resolved).ResolveLinkTarget(returnFinalTarget: true);
+            if (linkTarget != null)
+            {
+                target = linkTarget.FullName;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or SecurityException)
+        {
+            // Leave target as the unresolved path; containment is still checked below.
+        }
+
+        foreach (var root in roots)
+        {
+            if (IsWithinRoot(target, root))
+            {
+                fullPath = resolved;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsWithinRoot(string path, string root)
+    {
+        if (string.Equals(path, root, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return path.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith(root + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -251,6 +251,10 @@ public class InboxConfig
 public class SecuritySettings
 {
     public List<string>? AllowedHosts { get; set; }
+
+    /// <summary>Extra directories GET /ivy/local-file may serve from, on top of the Tendril home,
+    /// the plans folder and configured project repos.</summary>
+    public List<string>? LocalFileRoots { get; set; }
 }
 
 public static class ChatModes

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -22,7 +22,10 @@ public static class TendrilServer
     {
         PathHelper.AugmentPath(forceShellPath: true);
         var server = new Server();
-        // LocalFileGuardMiddleware enforces Host, Origin, Sec-Fetch-Site, and file type restrictions
+        // LocalFileGuardMiddleware enforces Host, Origin, Sec-Fetch-Site, file type and path root
+        // restrictions (see LocalFileRootPolicy). The framework's DangerouslyAllowLocalFiles(roots)
+        // overload would let the framework enforce roots too, but the referenced Ivy package
+        // (1.4.0) does not have it yet; revisit once Ivy is bumped to a version that does.
         server.DangerouslyAllowLocalFiles();
         server.UseCulture("en-US");
 #if DEBUG


### PR DESCRIPTION
Fixes #2635

# Summary

## Changes

Confined `GET /ivy/local-file` to a set of configured roots (Tendril home, plans folder, every
configured project repo, plus an opt-in `security.localFileRoots` config list), fixing the security
warning from [issue #2635](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/2635). Any path
outside every root, including `../` traversal and symlinks that escape a root, now 404s instead of
being served; an empty root list fails closed and logs a one-time error.

## API Changes

- New `Ivy.Tendril.Controllers.LocalFileRootPolicy` (internal): `ComputeRoots(IConfigService)` and
  `TryResolve(string?, IReadOnlyList<string>, out string)`.
- `Ivy.Tendril.Services.SecuritySettings` gains `List<string>? LocalFileRoots` (new `config.yaml`
  key `security.localFileRoots`).
- `LocalFileGuardMiddleware`'s constructor changed from a primary constructor to a standard one
  (same parameter list, now `public LocalFileGuardMiddleware(RequestDelegate, IConfigService,
  IShareTunnelService, ILogger<LocalFileGuardMiddleware>)`) so it can subscribe to
  `IConfigService.SettingsReloaded` for root-cache invalidation. No behavior change for existing
  callers (DI still resolves it the same way).

## Files Modified

- `src/Ivy.Tendril/Controllers/LocalFileRootPolicy.cs` (new) — root computation and path containment.
- `src/Ivy.Tendril/Controllers/LocalFileGuardMiddleware.cs` — enforces the new root check between
  file-type validation and hardening headers; caches roots, invalidated on config reload.
- `src/Ivy.Tendril/Services/ConfigService.cs` — `SecuritySettings.LocalFileRoots`.
- `src/Ivy.Tendril/TendrilServer.cs` — updated comment explaining the middleware's scope and why the
  framework's `DangerouslyAllowLocalFiles(roots)` overload isn't used yet.
- `src/Ivy.Tendril.Test/LocalFileRootPolicyTests.cs` (new) — 8 tests for `LocalFileRootPolicy`.
- `src/Ivy.Tendril.Test/LocalFileGuardMiddlewareTests.cs` — 4 new root-confinement/cache-invalidation
  tests; 33 pre-existing tests' fake query paths updated to resolve under a real root.

## Manual Testing

1. Run Tendril (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse
   --find-available-port`) and open a plan or chat view that embeds a local image via
   `file:///` (e.g. a plan screenshot under `TendrilHome`).
2. Confirm the image still loads normally — it is served from a path under `TendrilHome`/the plans
   folder, one of the default roots.
3. In a browser devtools console (or via `curl`), request `GET /ivy/local-file?path=<path to a
   readable file outside TendrilHome, the plans folder and every configured project repo>` (e.g.
   `/etc/hosts` on macOS/Linux, adjusted for an allowed extension like `.png` to isolate the root
   check from the file-type check). Confirm the response is `404 {"error":"File not found"}` instead
   of the file contents.
4. Add a directory to `security.localFileRoots` in Settings (or `config.yaml`) and repeat step 3
   with a path under that directory — it should now load successfully without restarting Tendril
   (the middleware picks up the change via `SettingsReloaded`).

---
## Commits

- 02bf1490 Log a one-time error when no local-file roots are configured
- 3f9df234 Add tests for local-file root confinement
- e9213d73 Confine local-file endpoint to configured roots

---
Created using [Ivy Tendril](https://ivy.app).
