### PR TITLE
[00491] Fix Nine Stale DraftMarkdown Playwright Specs

### DIFF
--- a/src/Ivy.Tendril.Widgets/.tests/utils/ivy.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/utils/ivy.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import { getBaseUrl } from "./server.js";
 
 export async function navigateToApp(page: Page, appId: string): Promise<void> {
@@ -23,4 +23,36 @@ export async function waitForPageReady(page: Page): Promise<void> {
     () => document.querySelector("[data-ivy-ready]") !== null || document.body.innerText.length > 20,
     { timeout: 20_000 },
   );
+}
+
+/**
+ * Drags across the first `chars` characters of `target`'s first text node and
+ * returns the resulting selection. Anchored to the first client rect of a Range
+ * rather than the element's bounding box: the box midpoint of a wrapped
+ * paragraph falls between two lines, where a drag selects nothing and the
+ * widget correctly ignores the collapsed selection.
+ */
+export async function selectTextByDrag(page: Page, target: Locator, chars = 25): Promise<string> {
+  await target.scrollIntoViewIfNeeded();
+  const rect = await target.evaluate((el, n) => {
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      if ((node.textContent ?? "").trim().length > 3) break;
+    }
+    if (!node?.textContent) return null;
+    const range = document.createRange();
+    range.setStart(node, 0);
+    range.setEnd(node, Math.min(n, node.textContent.length));
+    const first = range.getClientRects()[0];
+    return first ? { x: first.x, y: first.y, width: first.width, height: first.height } : null;
+  }, chars);
+  if (!rect) throw new Error("selectTextByDrag: target has no measurable text rect");
+
+  const y = rect.y + rect.height / 2;
+  await page.mouse.move(rect.x + 1, y);
+  await page.mouse.down();
+  await page.mouse.move(rect.x + rect.width - 1, y);
+  await page.mouse.up();
+  return page.evaluate(() => String(window.getSelection()));
 }

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../../fixtures/widget-test.js";
-import { navigateToApp, waitForDraftMarkdown } from "../../utils/ivy.js";
+import { navigateToApp, waitForDraftMarkdown, selectTextByDrag } from "../../utils/ivy.js";
 
 test.describe("DraftMarkdown Annotations", () => {
   test.beforeEach(async ({ page }) => {
@@ -25,14 +25,7 @@ test.describe("DraftMarkdown Annotations", () => {
 
     // Find a text node to select — target the "Overview" heading text
     const heading = page.locator(".pmv-markdown h2").first();
-    const box = await heading.boundingBox();
-    expect(box).not.toBeNull();
-
-    // Click-drag to select text
-    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box!.x + box!.width - 5, box!.y + box!.height / 2);
-    await page.mouse.up();
+    await selectTextByDrag(page, heading);
 
     // Toolbar should appear
     const toolbar = page.locator(".pmv-selection-toolbar");
@@ -42,14 +35,7 @@ test.describe("DraftMarkdown Annotations", () => {
 
   test("add annotation flow", async ({ page, stepScreenshot }) => {
     // Select text in the first paragraph
-    const paragraph = page.locator(".pmv-markdown p").first();
-    const box = await paragraph.boundingBox();
-    expect(box).not.toBeNull();
-
-    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box!.x + 200, box!.y + box!.height / 2);
-    await page.mouse.up();
+    await selectTextByDrag(page, page.locator(".pmv-markdown p").first(), 30);
 
     // Wait for toolbar
     const toolbar = page.locator(".pmv-selection-toolbar");
@@ -83,14 +69,7 @@ test.describe("DraftMarkdown Annotations", () => {
 
   test("annotation state updates after adding", async ({ page, stepScreenshot }) => {
     // Add an annotation
-    const paragraph = page.locator(".pmv-markdown p").first();
-    const box = await paragraph.boundingBox();
-    expect(box).not.toBeNull();
-
-    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box!.x + 150, box!.y + box!.height / 2);
-    await page.mouse.up();
+    await selectTextByDrag(page, page.locator(".pmv-markdown p").first(), 30);
 
     const toolbar = page.locator(".pmv-selection-toolbar");
     await expect(toolbar).toBeVisible({ timeout: 5000 });
@@ -111,14 +90,7 @@ test.describe("DraftMarkdown Annotations", () => {
 
   test("click highlight opens edit popover", async ({ page, stepScreenshot }) => {
     // First add an annotation
-    const paragraph = page.locator(".pmv-markdown p").first();
-    const box = await paragraph.boundingBox();
-    expect(box).not.toBeNull();
-
-    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box!.x + 150, box!.y + box!.height / 2);
-    await page.mouse.up();
+    await selectTextByDrag(page, page.locator(".pmv-markdown p").first(), 30);
 
     const toolbar = page.locator(".pmv-selection-toolbar");
     await expect(toolbar).toBeVisible({ timeout: 5000 });
@@ -149,14 +121,7 @@ test.describe("DraftMarkdown Annotations", () => {
 
   test("edit annotation", async ({ page, stepScreenshot }) => {
     // Add an annotation
-    const paragraph = page.locator(".pmv-markdown p").first();
-    const box = await paragraph.boundingBox();
-    expect(box).not.toBeNull();
-
-    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box!.x + 150, box!.y + box!.height / 2);
-    await page.mouse.up();
+    await selectTextByDrag(page, page.locator(".pmv-markdown p").first(), 30);
 
     const toolbar = page.locator(".pmv-selection-toolbar");
     await expect(toolbar).toBeVisible({ timeout: 5000 });
@@ -190,14 +155,7 @@ test.describe("DraftMarkdown Annotations", () => {
 
   test("remove annotation", async ({ page, stepScreenshot }) => {
     // Add an annotation
-    const paragraph = page.locator(".pmv-markdown p").first();
-    const box = await paragraph.boundingBox();
-    expect(box).not.toBeNull();
-
-    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box!.x + 150, box!.y + box!.height / 2);
-    await page.mouse.up();
+    await selectTextByDrag(page, page.locator(".pmv-markdown p").first(), 30);
 
     const toolbar = page.locator(".pmv-selection-toolbar");
     await expect(toolbar).toBeVisible({ timeout: 5000 });
@@ -218,7 +176,7 @@ test.describe("DraftMarkdown Annotations", () => {
     // Click highlight, then remove
     await highlight.first().click();
     const editPopover = page.locator(".pmv-popover");
-    await editPopover.locator("button", { hasText: "Remove" }).click();
+    await editPopover.locator("button", { hasText: "Delete" }).click();
 
     // Verify highlight gone and state back to empty
     await expect(highlight).toHaveCount(0, { timeout: 15000 });
@@ -228,14 +186,7 @@ test.describe("DraftMarkdown Annotations", () => {
 
   test("multiple annotations coexist", async ({ page, stepScreenshot }) => {
     // Add first annotation on h2
-    const h2 = page.locator(".pmv-markdown h2").first();
-    const h2Box = await h2.boundingBox();
-    expect(h2Box).not.toBeNull();
-
-    await page.mouse.move(h2Box!.x + 5, h2Box!.y + h2Box!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(h2Box!.x + 80, h2Box!.y + h2Box!.height / 2);
-    await page.mouse.up();
+    await selectTextByDrag(page, page.locator(".pmv-markdown h2").first(), 30);
 
     let toolbar = page.locator(".pmv-selection-toolbar");
     await expect(toolbar).toBeVisible({ timeout: 5000 });
@@ -249,14 +200,7 @@ test.describe("DraftMarkdown Annotations", () => {
     await stepScreenshot("first-annotation-added");
 
     // Add second annotation on a paragraph
-    const para = page.locator(".pmv-markdown p").nth(1);
-    const paraBox = await para.boundingBox();
-    expect(paraBox).not.toBeNull();
-
-    await page.mouse.move(paraBox!.x + 5, paraBox!.y + paraBox!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(paraBox!.x + 200, paraBox!.y + paraBox!.height / 2);
-    await page.mouse.up();
+    await selectTextByDrag(page, page.locator(".pmv-markdown p").nth(1), 30);
 
     toolbar = page.locator(".pmv-selection-toolbar");
     await expect(toolbar).toBeVisible({ timeout: 5000 });
@@ -268,8 +212,10 @@ test.describe("DraftMarkdown Annotations", () => {
 
     // Both annotations exist
     await expect(page.getByText("Annotations (2)")).toBeVisible({ timeout: 15000 });
-    const highlights = page.locator("mark[data-annotation-id]");
-    await expect(highlights).toHaveCount(2);
+    const ids = await page.locator("mark[data-annotation-id]").evaluateAll((marks) =>
+      new Set(marks.map((m) => (m as HTMLElement).dataset.annotationId)).size,
+    );
+    expect(ids).toBe(2);
     await stepScreenshot("both-annotations-visible");
   });
 
@@ -281,17 +227,9 @@ test.describe("DraftMarkdown Annotations", () => {
   });
 
   test("selecting text inside a questions callout does not show the selection toolbar", async ({ page, stepScreenshot }) => {
-    const calloutContent = page.locator(".pmv-questions-content");
-    const box = await calloutContent.boundingBox();
-    expect(box).not.toBeNull();
-
-    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box!.x + box!.width - 5, box!.y + box!.height / 2);
-    await page.mouse.up();
-
-    const toolbar = page.locator(".pmv-selection-toolbar");
-    await expect(toolbar).not.toBeVisible();
+    const selected = await selectTextByDrag(page, page.locator(".pmv-questions-content"), 20);
+    expect(selected.trim().length).toBeGreaterThan(0);
+    await expect(page.locator(".pmv-selection-toolbar")).not.toBeVisible();
     await stepScreenshot("no-toolbar-for-questions-selection");
   });
 
@@ -304,18 +242,8 @@ test.describe("DraftMarkdown Annotations", () => {
     const isScrollable = await shell.evaluate((el) => el.scrollHeight > el.clientHeight + 50);
     expect(isScrollable).toBe(true);
 
-    // Select within the (single-line) "Overview" heading rather than a
-    // wrapped paragraph: a drag whose midpoint Y lands between two wrapped
-    // lines can produce a collapsed selection, as the "text selection shows
-    // toolbar" test above avoids by using the same heading.
     const heading = page.locator(".pmv-markdown h2").first();
-    const box = await heading.boundingBox();
-    expect(box).not.toBeNull();
-
-    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box!.x + box!.width - 5, box!.y + box!.height / 2);
-    await page.mouse.up();
+    await selectTextByDrag(page, heading);
 
     const toolbar = page.locator(".pmv-selection-toolbar");
     await expect(toolbar).toBeVisible({ timeout: 5000 });

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/collapsible.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/collapsible.spec.ts
@@ -16,7 +16,12 @@ test.describe("DraftMarkdown Collapsible Sections", () => {
     await expect(widgetPane.locator("summary").first()).toContainText(
       "What database does the plan target?",
     );
-    await expect(widgetPane).not.toContainText("<summary>");
+    const rawTagInProse = await widgetPane.evaluate((el) => {
+      const clone = el.cloneNode(true) as HTMLElement;
+      clone.querySelectorAll("code").forEach((c) => c.remove());
+      return (clone.textContent ?? "").includes("<summary>");
+    });
+    expect(rawTagInProse).toBe(false);
     await stepScreenshot("details-rendered");
   });
 
@@ -37,7 +42,8 @@ test.describe("DraftMarkdown Collapsible Sections", () => {
   test("a section marked open starts expanded", async ({ page }) => {
     const openSection = page.locator(".pmv-markdown details[open]").first();
     await expect(openSection.locator("summary")).toContainText("Still relevant?");
-    await expect(openSection.getByText("The `open` attribute", { exact: false })).toBeVisible();
+    await expect(openSection.locator("code", { hasText: "open" }).first()).toBeVisible();
+    await expect(openSection).toContainText("survives sanitisation");
   });
 
   test("rich content renders inside a section body", async ({ page, stepScreenshot }) => {

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/rendering.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/rendering.spec.ts
@@ -9,7 +9,7 @@ test.describe("DraftMarkdown Rendering Comparison", () => {
 
   test("both panes render with labels", async ({ page, stepScreenshot }) => {
     await expect(page.getByText("Markdown (Framework)")).toBeVisible();
-    await expect(page.getByText("DraftMarkdown (Widget)")).toBeVisible();
+    await expect(page.getByText("PlanMarkdown (Widget)")).toBeVisible();
     await stepScreenshot("both-panes-labeled");
   });
 


### PR DESCRIPTION
# Summary

## Changes

Fixed nine stale Playwright tests in the DraftMarkdown widget by adding a helper function that correctly selects text across wrapped lines, and updating all assertions to match current widget behavior. The helper anchors to a single-line client rect instead of a bounding-box midpoint that can fall between wrapped lines.

## API Changes

**New:** `selectTextByDrag(page: Page, target: Locator, chars = 25): Promise<string>` in [`src/Ivy.Tendril.Widgets/.tests/utils/ivy.ts`](file:///D:/.tendril/Plans/00491-FixNineStaleDraftMarkdow/Worktrees/ivy-interactive/ivy-tendril/src/Ivy.Tendril.Widgets/.tests/utils/ivy.ts)

## Files Modified

**Test utilities:**
- `src/Ivy.Tendril.Widgets/.tests/utils/ivy.ts` — added selectTextByDrag helper

**Test specs:**
- `src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts` — replaced broken drags, fixed button name, hardened assertions
- `src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/collapsible.spec.ts` — fixed assertions to check rendered text instead of markdown source
- `src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/rendering.spec.ts` — updated label to match widget rename

## Manual Testing

Run the affected Playwright tests:

```bash
cd src/Ivy.Tendril.Widgets/.tests
npx playwright test widgets/draft-markdown/annotations.spec.ts widgets/draft-markdown/collapsible.spec.ts widgets/draft-markdown/rendering.spec.ts
```

**Expected:** 30 passed, 0 failed (baseline was 40 passed / 9 failed)

**Observe:**
- All six annotation workflow tests complete successfully (toolbar appears, annotations are added/edited/removed)
- Collapsible section tests verify rendered DOM structure instead of raw markdown
- Rendering comparison test finds the current "PlanMarkdown (Widget)" label

---
### Commits

- [`764824c6`](https://github.com/Ivy-Interactive/Ivy-Tendril/commit/764824c6) Fix nine stale DraftMarkdown Playwright specs - Mikael Rinne

---
Created using [Ivy Tendril](https://ivy.app).