### PR TITLE
[00460] Fail the Build on Conditional Ivy Hook Warnings

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,5 +8,17 @@
     <!-- Ivy.Tendril.Widgets manages its own frontend build and embedding -->
     <IvyEnableExternalWidgets>false</IvyEnableExternalWidgets>
     <RestorePackagesPath Condition="'$(RestorePackagesPath)' == '' and '$(HOME)' != '' and Exists('$(HOME)/.nuget/packages')">$(HOME)/.nuget/packages</RestorePackagesPath>
+    <!-- Any hook rule violation is a real bug (order can change between renders, or the hook runs
+         somewhere the framework doesn't expect): never ship one as a warning -->
+    <WarningsAsErrors>$(WarningsAsErrors);IVYHOOK002;IVYHOOK003;IVYHOOK004;IVYHOOK005;IVYHOOK007</WarningsAsErrors>
   </PropertyGroup>
+  <!-- Ivy Analyser: wired once here so every project under src/ gets hook checking in source mode -->
+  <ItemGroup Condition="'$(IvySource)' == 'true' And Exists('$(MSBuildThisFileDirectory)../../Ivy-Framework/src/Ivy.Analyser/Ivy.Analyser.csproj')">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../../Ivy-Framework/src/Ivy.Analyser/Ivy.Analyser.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Analyzer</OutputItemType>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
+++ b/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
@@ -50,15 +50,4 @@
         <Watch Remove="Docs/**/*" />
     </ItemGroup>
 
-    <!-- enable ivy analyzer -->
-    <ItemGroup Condition="'$(IvySource)' == 'true'">
-        <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Analyser/Ivy.Analyser.csproj">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-            <OutputItemType>Analyzer</OutputItemType>
-        </ProjectReference>
-    </ItemGroup>
-
-
 </Project>

--- a/src/Ivy.Tendril.Widgets/.samples/Ivy.Tendril.Widgets.Samples.csproj
+++ b/src/Ivy.Tendril.Widgets/.samples/Ivy.Tendril.Widgets.Samples.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>WidgetSamples</RootNamespace>
-    <NoWarn>$(NoWarn);IVYHOOK005;IVYHOOK007</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ivy.Tendril.Widgets.csproj" />

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -60,15 +60,6 @@
     <PackageReference Include="Ivy" Version="1.4.0" />
     <PackageReference Include="Ivy.Desktop" Version="1.4.0" />
   </ItemGroup>
-  <!-- Ivy Analyser -->
-  <ItemGroup Condition="'$(IvySource)' == 'true'">
-    <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Analyser/Ivy.Analyser.csproj">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>Analyzer</OutputItemType>
-    </ProjectReference>
-  </ItemGroup>
   <!-- Tendril ProjectReferences -->
   <ItemGroup>
     <ProjectReference Include="../Ivy.Tendril.Agents/Ivy.Tendril.Agents.csproj" />


### PR DESCRIPTION
Fixes #2634

# Summary

## Changes

Escalated every current Ivy hook analyser warning rule (`IVYHOOK002`, `003`, `004`, `005`, `007`)
to a build error via `src/Directory.Build.props`, and moved the `Ivy.Analyser` `ProjectReference`
wiring out of `Ivy.Tendril.csproj`/`Ivy.Tendril.Docs.csproj` into that same shared props file so
every project under `src/` is analysed in source mode, not just those two. Removed the widget
samples project's `IVYHOOK005;IVYHOOK007` `NoWarn`, which was masking that project from the same
gate and turned out to be unnecessary (zero diagnostics across its 22 views).

The originally-reported `#2634` `UseMemo` violation was already fixed by commit `6022a6ea` before
this plan started; this change closes the two reasons a *future* hook rule violation of any kind
would go unnoticed rather than moving any existing hook.

## API Changes

None. This is a build-configuration-only change — no C# public API surface was touched.

## Files Modified

- `src/Directory.Build.props` — added `WarningsAsErrors` entries for the five hook rules and the
  centralized `Ivy.Analyser` `ItemGroup`.
- `src/Ivy.Tendril/Ivy.Tendril.csproj` — removed the now-redundant analyser `ItemGroup`.
- `src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj` — removed the now-redundant analyser `ItemGroup`.
- `src/Ivy.Tendril.Widgets/.samples/Ivy.Tendril.Widgets.Samples.csproj` — removed the stale
  `IVYHOOK005;IVYHOOK007` `NoWarn`.

## Manual Testing

N/A — internal build-configuration change with no user-facing behavior. To confirm the gate works:
add a hook call inside an `if`/`for`/`switch` anywhere under `src/`, run
`dotnet build <affected>.csproj`, and observe `error IVYHOOK00N` failing the build (verified during
this execution against `ChatApp.Build()` and reverted; see `Verification/DotnetBuild.md`).

---
- 9eaef2e0 Fail the build on hook rule violations (Plan 00460)

---
Created using [Ivy Tendril](https://ivy.app).