### PR TITLE
[00481] Replace the Guessed Moonshot and DeepSeek Limits in the OpenCode Catalog

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeModelCatalogTests.cs
@@ -82,4 +82,31 @@ public class OpenCodeModelCatalogTests
         var model = Assert.Single(models);
         Assert.Equal(128_000, model.MaxOutputTokens);
     }
+
+    [Fact]
+    public void GetStaticModels_KimiK3_HasBergetLimits()
+    {
+        var model = _catalog.GetStaticModels().Single(m => m.Id == "moonshotai/Kimi-K3");
+
+        Assert.Equal(327_680, model.ContextWindow);
+        Assert.Equal(32_768, model.MaxOutputTokens);
+    }
+
+    [Fact]
+    public void TryGetLimits_KimiK3_ReturnsBergetLimits()
+    {
+        var limits = OpenCodeModelCatalog.TryGetLimits("moonshotai/Kimi-K3");
+
+        Assert.Equal((327_680, 32_768), limits);
+    }
+
+    [Fact]
+    public void GetStaticModels_NoUnservedMoonshotOrDeepSeekEntries()
+    {
+        var ids = _catalog.GetStaticModels().Select(m => m.Id);
+
+        Assert.DoesNotContain("kimi-k2", ids);
+        Assert.DoesNotContain("deepseek-v3", ids);
+        Assert.DoesNotContain("deepseek-r1", ids);
+    }
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
@@ -11,31 +11,16 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
 
     public override string AgentId => Abstractions.AgentId.OpenCode;
 
+    // moonshotai/Kimi-K3's limits are Berget's published figures (https://models.dev/api.json,
+    // provider "berget"; cross-checked against https://api.berget.ai/v1/models), since every
+    // selection path for this id targets Berget, not Moonshot direct. Checked 2026-09-12.
     public override IReadOnlyList<ModelInfo> GetStaticModels() =>
     [
         new()
         {
             Id = "moonshotai/Kimi-K3", DisplayName = "Kimi k3",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot", IsDefault = true,
-            ContextWindow = 256_000, MaxOutputTokens = 32_000,
-        },
-        new()
-        {
-            Id = "kimi-k2", DisplayName = "Kimi k2",
-            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot",
-            ContextWindow = 128_000, MaxOutputTokens = 32_000,
-        },
-        new()
-        {
-            Id = "deepseek-v3", DisplayName = "DeepSeek V3",
-            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek",
-            ContextWindow = 64_000, MaxOutputTokens = 8_000,
-        },
-        new()
-        {
-            Id = "deepseek-r1", DisplayName = "DeepSeek R1",
-            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek",
-            ContextWindow = 64_000, MaxOutputTokens = 8_000,
+            ContextWindow = 327_680, MaxOutputTokens = 32_768,
         },
         new()
         {


### PR DESCRIPTION
# Summary

## Changes

Corrected `moonshotai/Kimi-K3`'s declared limits in `OpenCodeModelCatalog.GetStaticModels()` to
Berget's published figures (327,680 context / 32,768 output, from models.dev), and removed the
`kimi-k2`, `deepseek-v3`, and `deepseek-r1` entries entirely, since no provider reachable from this
codebase serves any of the three. A two-line comment now documents the source and check date so
future edits don't have to re-guess.

## API Changes

`OpenCodeModelCatalog.GetStaticModels()` (internal to `Ivy.Tendril.Agents`, not a public API):
- `moonshotai/Kimi-K3`: `ContextWindow` 256_000 → 327_680, `MaxOutputTokens` 32_000 → 32_768.
- Removed entries: `kimi-k2`, `deepseek-v3`, `deepseek-r1`.

No public API changes.

## Files Modified

- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs` — corrected Kimi K3 limits,
  removed the three unserved entries, added a source comment.
- `src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeModelCatalogTests.cs` — added tests asserting the
  corrected Kimi K3 limits (both via `GetStaticModels()` and `TryGetLimits()`) and asserting the
  three removed IDs are absent from the catalog.

## Manual Testing

N/A — internal model-limit data change with no user-facing UI surface. The effect is that opencode's
`OPENCODE_CONFIG_CONTENT` override for `moonshotai/Kimi-K3` (written by
`OpenCodeCli.TryGetLimits`) now reflects Berget's real ceiling instead of a smaller guessed one, and
the model picker no longer offers three IDs that fail at request time. To confirm at runtime: launch
an OpenCode/Berget agent session and check that responses are not truncated at the previous
32,000-token guess.

---
## Commits
- 02824384 Correct OpenCode catalog limits for models Berget actually serves
- 55910afc Add tests for corrected OpenCode catalog limits

---
Created using [Ivy Tendril](https://ivy.app).
