### PR TITLE
[00477] Fix Plan Yaml Field Update Regex and Unvalidated Repair Write

### DIFF
--- a/src/Ivy.Tendril.Test/Helpers/PlanYamlHelperParseTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PlanYamlHelperParseTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Test.Helpers;
@@ -147,6 +148,89 @@ public class PlanYamlHelperParseTests
             Assert.Contains("state: Executing", updatedContent);
             Assert.Contains("chatSessionId: sess-999", updatedContent);
             Assert.DoesNotContain("state: Draft", updatedContent);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void UpdatePlanYamlFields_WithBlankFieldFollowedByKey_DoesNotEatNextLine()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "PlanYamlBlankFieldTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var initialYaml = "title: Feature Plan\nstate: Draft\nsourceUrl: \nchatSessionId: \nrecommendations:\n- title: R\n  description: d\n  state: Pending\n";
+            File.WriteAllText(Path.Combine(tempDir, "plan.yaml"), initialYaml);
+
+            var result = PlanYamlHelper.UpdatePlanYamlFields(tempDir, ("chatSessionId", "sess-1"));
+
+            Assert.True(result);
+            var updatedContent = File.ReadAllText(Path.Combine(tempDir, "plan.yaml"));
+            Assert.Contains("chatSessionId: sess-1", updatedContent);
+            Assert.Contains("recommendations:", updatedContent);
+            Assert.Contains("state: Pending", updatedContent);
+
+            var plan = PlanYamlHelper.ReadPlanYaml(tempDir);
+            Assert.NotNull(plan);
+            Assert.NotNull(plan.Recommendations);
+            Assert.Single(plan.Recommendations);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void UpdatePlanYamlFields_WhenResultWouldNotParse_LeavesFileUnchanged()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "PlanYamlUnparseableTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var initialYaml = "title: Feature Plan\nstate: Draft\n";
+            var planYamlPath = Path.Combine(tempDir, "plan.yaml");
+            File.WriteAllText(planYamlPath, initialYaml);
+
+            var result = PlanYamlHelper.UpdatePlanYamlFields(tempDir, ("title", "\"unbalanced"));
+
+            Assert.False(result);
+            var contentAfter = File.ReadAllText(planYamlPath);
+            Assert.Equal(initialYaml, contentAfter);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void UpdatePlanYamlFields_LeavesNoTempFiles()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "PlanYamlNoTempFilesTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var initialYaml = "title: Feature Plan\nstate: Draft\n";
+            File.WriteAllText(Path.Combine(tempDir, "plan.yaml"), initialYaml);
+
+            var result = PlanYamlHelper.UpdatePlanYamlFields(tempDir, ("state", "Executing"));
+
+            Assert.True(result);
+            var remaining = Directory.GetFiles(tempDir).Select(Path.GetFileName).ToList();
+            Assert.All(remaining, name => Assert.True(name == "plan.yaml" || name == "plan.yaml.lock"));
         }
         finally
         {

--- a/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
@@ -187,6 +187,42 @@ public class PlanReaderServiceTests
         }
     }
 
+    [Fact]
+    public void ParseSinglePlanFolder_WhenRepairOutputDoesNotParse_LeavesFileOnDisk()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        var testConfig = new TempDirConfigService(tempDir);
+        var testLogger = new TestLogger();
+
+        var service = new PlanReaderService(testConfig, testLogger);
+
+        var folderName = "01234-TestPlan";
+        var planFolder = Path.Combine(tempDir, folderName);
+        Directory.CreateDirectory(planFolder);
+
+        var unrepairable = "{{{{not valid yaml at all: [[[\n";
+        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
+        File.WriteAllText(planYamlPath, unrepairable);
+
+        try
+        {
+            // Act
+            var result = service.ParseSinglePlanFolder(planFolder);
+
+            // Assert
+            Assert.Null(result);
+            var contentAfter = File.ReadAllText(planYamlPath);
+            Assert.Equal(unrepairable, contentAfter);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
     private class TempDirConfigService(string planFolder) : StubConfigService, IConfigService
     {
         string IConfigService.PlanFolder => planFolder;

--- a/src/Ivy.Tendril.Test/Services/PlanYamlRepairKeyCoverageTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanYamlRepairKeyCoverageTests.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class PlanYamlRepairKeyCoverageTests
+{
+    [Fact]
+    public void TopLevelKeys_CoversEveryPlanYamlProperty()
+    {
+        var field = typeof(PlanYamlRepairService).GetField("TopLevelKeys", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(field);
+        var topLevelKeys = (HashSet<string>)field!.GetValue(null)!;
+
+        foreach (var property in typeof(PlanYaml).GetProperties())
+        {
+            var camelCaseName = char.ToLowerInvariant(property.Name[0]) + property.Name[1..];
+            Assert.True(topLevelKeys.Contains(camelCaseName),
+                $"TopLevelKeys is missing '{camelCaseName}' (property {property.Name})");
+        }
+    }
+
+    [Fact]
+    public void RepairPlanYaml_PreservesChatSessionIdAndPartialDelivery()
+    {
+        var yaml = "title: Plan\nstate: Draft\nchatSessionId: sess-123\npartialDelivery: true\n";
+
+        var repaired = PlanYamlRepairService.RepairPlanYaml(yaml);
+
+        Assert.Contains("chatSessionId: sess-123", repaired);
+        Assert.Contains("partialDelivery: true", repaired);
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -29,14 +29,21 @@ internal static class PlanYamlHelper
         return File.Exists(planYamlPath) ? FileHelper.ReadAllText(planYamlPath) : null;
     }
 
-    internal static void UpdatePlanYamlFields(string planFolder, params (string field, string value)[] updates)
+    /// <summary>
+    ///     Applies best-effort textual field updates to plan.yaml. Unlike
+    ///     <see cref="PlanCommandHelpers.WritePlan" />, this does not run
+    ///     <see cref="PlanValidationService.Validate" /> — it is also used against legacy/fragmentary
+    ///     files that lack required fields like <c>project</c>/<c>title</c>. Returns <c>false</c>
+    ///     (without writing) when the plan.yaml is missing or the updated content fails to deserialize.
+    /// </summary>
+    internal static bool UpdatePlanYamlFields(string planFolder, params (string field, string value)[] updates)
     {
         var content = ReadPlanYamlRaw(planFolder);
-        if (content == null) return;
+        if (content == null) return false;
 
         foreach (var (field, value) in updates)
         {
-            var pattern = $@"(?m)^{Regex.Escape(field)}:\s*.*$";
+            var pattern = $@"(?m)^{Regex.Escape(field)}:[^\r\n]*$";
             if (Regex.IsMatch(content, pattern))
             {
                 var replacement = $"{field}: {value}";
@@ -53,8 +60,27 @@ internal static class PlanYamlHelper
             }
         }
 
+        if (ParsePlanYaml(content) == null) return false;
+
         var planYamlPath = Path.Combine(planFolder, "plan.yaml");
-        FileHelper.WriteAllText(planYamlPath, content);
+        var tempPath = Path.Combine(planFolder, $"plan.yaml.tmp.{Guid.NewGuid():N}");
+
+        using var lockFile = PlanFileLock.Acquire(planFolder);
+        try
+        {
+            FileHelper.WriteAllText(tempPath, content);
+
+            var roundTrip = FileHelper.ReadAllText(tempPath);
+            if (ParsePlanYaml(roundTrip) == null) return false;
+
+            File.Move(tempPath, planYamlPath, overwrite: true);
+            return true;
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
     }
 
     internal static void SetPlanStateByFolder(string planFolder, string state)

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -812,7 +812,8 @@ internal class JobCompletionHandler
                 {
                     if (!string.IsNullOrEmpty(job.ChatSessionId) && !string.IsNullOrEmpty(job.PlanFile))
                     {
-                        PlanYamlHelper.UpdatePlanYamlFields(planFolder, ("chatSessionId", job.ChatSessionId));
+                        if (!PlanYamlHelper.UpdatePlanYamlFields(planFolder, ("chatSessionId", job.ChatSessionId)))
+                            _logger.LogWarning("Failed to update chatSessionId in plan.yaml for job {JobId} at {PlanFolder}", job.Id, planFolder);
                         _planWatcherService?.NotifyChanged(planFolder);
                         if (_planReaderService is PlanReaderService prs)
                         {

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -1657,7 +1657,7 @@ public class JobService : IJobService
     internal static PlanYaml? ReadPlanYaml(string planFolder)
         => PlanYamlHelper.ReadPlanYaml(planFolder);
 
-    internal static void UpdatePlanYamlFields(string planFolder, params (string field, string value)[] updates)
+    internal static bool UpdatePlanYamlFields(string planFolder, params (string field, string value)[] updates)
         => PlanYamlHelper.UpdatePlanYamlFields(planFolder, updates);
 
     internal static void SetPlanStateByFolder(string planFolder, string state)

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -1179,10 +1179,22 @@ public class PlanReaderService(
             // Fall back to the repair pass for malformed agent-generated YAML.
             logger.LogWarning(ex, "Failed to parse plan YAML {PlanYamlPath}, attempting repair", planYamlPath);
             var repaired = PlanSchemaVersion.Stamp(PlanYamlRepairService.RepairPlanYaml(yamlContent), PlanYaml.CurrentSchemaVersion);
-            if (repaired != yamlContent)
-                FileHelper.WriteAllText(planYamlPath, repaired);
 
-            planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(repaired);
+            try
+            {
+                planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(repaired);
+            }
+            catch (Exception repairEx)
+            {
+                logger.LogWarning(repairEx, "Repair pass produced unparseable YAML for {PlanYamlPath}, leaving file untouched", planYamlPath);
+                throw ex;
+            }
+
+            if (repaired != yamlContent)
+            {
+                using var _ = PlanFileLock.Acquire(Path.GetDirectoryName(planYamlPath)!);
+                FileHelper.WriteAllText(planYamlPath, repaired);
+            }
         }
 
         return planYaml;

--- a/src/Ivy.Tendril/Services/Plans/PlanYamlRepairService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanYamlRepairService.cs
@@ -10,7 +10,8 @@ public static class PlanYamlRepairService
         "state", "project", "level", "title", "sessionId",
         "repos", "created", "updated", "initialPrompt", "sourceUrl",
         "prs", "commits", "verifications", "relatedPlans", "dependsOn",
-        "priority", "executionProfile", "recommendations", "allocatedPorts"
+        "priority", "executionProfile", "recommendations", "allocatedPorts",
+        "chatSessionId", "partialDelivery"
     };
 
     private static readonly HashSet<string> ListKeys = new(StringComparer.Ordinal)


### PR DESCRIPTION
Fixes #2657

# Summary

## Changes

Fixed two composing bugs that could corrupt `plan.yaml`: the field-update regex in
`PlanYamlHelper.UpdatePlanYamlFields` used `\s*` (which matches newlines) and could swallow a
following key like `recommendations:` when updating a blank field; and `PlanYamlRepairService` and
`PlanReaderService` could drop the `chatSessionId`/`partialDelivery` keys and write unvalidated
repair output to disk before confirming it deserializes. All three writers now validate before
persisting, and the field updater's write is now locked and atomic.

## API Changes

- `PlanYamlHelper.UpdatePlanYamlFields(string planFolder, params (string field, string value)[] updates)` now returns `bool` (previously `void`) — `true` on a successful write, `false` when the file is missing or the resulting content would not deserialize (in which case no write happens).
- `JobService.UpdatePlanYamlFields` forwards the same `bool` return value.
- `PlanYamlRepairService`'s internal `TopLevelKeys` set now includes `chatSessionId` and `partialDelivery`.

## Files Modified

- `src/Ivy.Tendril/Helpers/PlanYamlHelper.cs` — regex fix, locked/atomic/validated write, `bool` return
- `src/Ivy.Tendril/Services/Jobs/JobService.cs` — forwards the new `bool` return
- `src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs` — logs a warning when the `chatSessionId` update fails
- `src/Ivy.Tendril/Services/Plans/PlanYamlRepairService.cs` — added `chatSessionId`/`partialDelivery` to `TopLevelKeys`
- `src/Ivy.Tendril/Services/Plans/PlanReaderService.cs` — validates repair output before writing it to disk
- `src/Ivy.Tendril.Test/Helpers/PlanYamlHelperParseTests.cs`, `src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs`, `src/Ivy.Tendril.Test/Services/PlanYamlRepairKeyCoverageTests.cs` (new) — regression tests

## Manual Testing

N/A — internal change with no user-facing behavior. The fix is exercised by the new/existing unit
tests (`dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~PlanYaml"`),
which is the practical way to confirm the corruption scenario from issue #2657 no longer reproduces.

---
## Commits
- 05098116 Fix greedy regex and unsafe write in PlanYamlHelper.UpdatePlanYamlFields
- e6e8d296 Fix dropped keys and unvalidated write in plan.yaml repair pass
- 556a0c3d Add regression tests for plan.yaml field-update and repair fixes

---
Created using [Ivy Tendril](https://ivy.app).
