### PR TITLE
[00462] Center Chat Sample Prompt Chips and Fix Hover Tokens

### DIFF
--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -1393,6 +1393,72 @@ public class ChatExecutionServiceJobTrackingTests
     }
 
     /// <summary>
+    /// Every LaunchAsync call returns a session that is already complete, so notifying a plan edit
+    /// never spawns a real agent CLI process. Without this, PlanEditFanOutHarness resolved "codex"
+    /// through the real TestAgentRunner registration and each SendMessageAsync launched an actual
+    /// `codex exec` subprocess against a live model, which cannot finish inside WaitForIdleAsync's
+    /// 20-second budget (plan 00462 recommendation).
+    /// </summary>
+    private sealed class InstantAgentRunner : IAgentRunner
+    {
+        private readonly IAgentRunner _inner;
+
+        public InstantAgentRunner(IAgentRunner inner) => _inner = inner;
+
+        public Task<IAgentSession> LaunchAsync(AgentResolutionContext context, CancellationToken ct = default)
+            => Task.FromResult<IAgentSession>(new InstantCompletionTestSession());
+
+        public Task<ResultEvent> RunToCompletionAsync(AgentResolutionContext context, CancellationToken ct = default)
+            => _inner.RunToCompletionAsync(context, ct);
+
+        public IReadOnlyList<IAgentSession> ActiveSessions => _inner.ActiveSessions;
+        public IObservable<IAgentSession> Sessions => _inner.Sessions;
+        public Task StopAllAsync(CancellationToken ct = default) => _inner.StopAllAsync(ct);
+        public IReadOnlyList<string> RegisteredAgents => _inner.RegisteredAgents;
+        public IAgentCli GetCli(string agentId) => _inner.GetCli(agentId);
+        public IEventParser GetParser(string agentId) => _inner.GetParser(agentId);
+        public IAgentHealthCheck GetHealthCheck(string agentId) => _inner.GetHealthCheck(agentId);
+        public IAgentDescriptor GetDescriptor(string agentId) => _inner.GetDescriptor(agentId);
+        public IFailureAnalyzer? GetFailureAnalyzer(string agentId) => _inner.GetFailureAnalyzer(agentId);
+        public ISessionCostParser? GetCostParser(string agentId) => _inner.GetCostParser(agentId);
+        public IAgentPty? GetPty(string agentId) => _inner.GetPty(agentId);
+        public IModelCatalogProvider? GetModelCatalog(string agentId) => _inner.GetModelCatalog(agentId);
+        public IEnumerable<IModelCatalogProvider> ModelCatalogs => _inner.ModelCatalogs;
+    }
+
+    private sealed class InstantCompletionTestSession : IAgentSession
+    {
+        private static readonly ResultEvent CompletedResult = new()
+        {
+            Kind = AgentEventKind.Result,
+            IsSuccess = true,
+            Response = "Task completed successfully."
+        };
+
+        public string SessionId { get; } = "sess-instant-" + Guid.NewGuid().ToString("N");
+        public string AgentId { get; } = "codex";
+        public SessionState State => SessionState.Completed;
+        public DateTimeOffset StartedAt { get; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset? CompletedAt { get; } = DateTimeOffset.UtcNow;
+        public SessionMetadata? Metadata => null;
+        public IObservable<AgentEvent> Events { get; } = System.Reactive.Linq.Observable.Empty<AgentEvent>();
+        public IObservable<string>? RawOutput => null;
+        public IObservable<string>? RawStderr => null;
+        public ResultEvent? Result => CompletedResult;
+        public bool SupportsPermissionResponse => false;
+        public bool SupportsQuestionResponse => false;
+        public bool SupportsMultiTurn => false;
+
+        public Task<ResultEvent> WaitForCompletionAsync(CancellationToken ct = default) => Task.FromResult(CompletedResult);
+        public Task StopAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync() => Task.CompletedTask;
+        public Task RespondToPermissionAsync(string requestId, PermissionDecision decision, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task RespondToQuestionAsync(string questionId, QuestionResponse response, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task SendFollowUpAsync(string message, CancellationToken ct = default) => throw new NotSupportedException();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    /// <summary>
     /// A plan edited directly from one chat has to reach the plan's other sessions, or the agent that
     /// created the plan keeps reasoning from the version it last read (plan 00400, issue #2455).
     /// </summary>
@@ -1422,7 +1488,7 @@ public class ChatExecutionServiceJobTrackingTests
                 "state: Draft");
             Database.UpsertPlan(Plan);
 
-            var agentRunner = TestAgentRunner.Create();
+            var agentRunner = new InstantAgentRunner(TestAgentRunner.Create());
             JobService = new FakeChatJobService();
             ExecService = new ChatExecutionService(
                 configService,

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -512,6 +512,7 @@ button.chat-jobs-dropdown-item:hover .chat-job-nav-icon {
 .chat-sample-prompts {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 8px;
   margin-top: 16px;
 }
@@ -529,8 +530,8 @@ button.chat-jobs-dropdown-item:hover .chat-job-nav-icon {
 }
 
 .chat-sample-prompt:hover {
-  background: var(--tch-bg-hover);
-  border-color: var(--tch-fg-faint);
+  background: var(--tch-surface-hover);
+  border-color: var(--tch-faint);
 }
 
 .chat-message-row {
@@ -1846,6 +1847,8 @@ button.chat-system-event-plan {
 
 .chat-widget-root[data-embedded="true"] .chat-sample-prompts {
   flex-wrap: nowrap;
+  /* keep chips flush left: centering an overflowing nowrap scroller would push leading chips past the scroll origin */
+  justify-content: flex-start;
   overflow-x: auto;
 }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css.test.ts
@@ -25,4 +25,55 @@ describe("chat-widget.css", () => {
       expect(embeddedThreadBlock).not.toMatch(/padding:\s*0\s/);
     });
   });
+
+  describe("sample prompts", () => {
+    it("centers the base rule's chip rows", () => {
+      const baseBlock = css.slice(
+        css.indexOf(".chat-sample-prompts {"),
+        css.indexOf("}", css.indexOf(".chat-sample-prompts {")) + 1
+      );
+
+      expect(baseBlock).toContain("justify-content: center");
+    });
+
+    it("keeps the embedded scroller flush left and non-wrapping", () => {
+      const embeddedSamplePromptsBlock = css.slice(
+        css.indexOf('.chat-widget-root[data-embedded="true"] .chat-sample-prompts {'),
+        css.indexOf(
+          "}",
+          css.indexOf('.chat-widget-root[data-embedded="true"] .chat-sample-prompts {')
+        ) + 1
+      );
+
+      expect(embeddedSamplePromptsBlock).toContain("flex-wrap: nowrap");
+      expect(embeddedSamplePromptsBlock).toContain("justify-content: flex-start");
+    });
+
+    it("hovers with the defined surface/faint tokens, not the removed ones", () => {
+      const hoverBlock = css.slice(
+        css.indexOf(".chat-sample-prompt:hover {"),
+        css.indexOf("}", css.indexOf(".chat-sample-prompt:hover {")) + 1
+      );
+
+      expect(hoverBlock).toContain("var(--tch-surface-hover)");
+      expect(hoverBlock).toContain("var(--tch-faint)");
+      expect(hoverBlock).not.toContain("--tch-bg-hover");
+      expect(hoverBlock).not.toContain("--tch-fg-faint");
+    });
+  });
+
+  describe("token integrity", () => {
+    it("defines every --tch-* custom property referenced by a var()", () => {
+      const referenced = new Set(
+        Array.from(css.matchAll(/var\(\s*(--tch-[a-z0-9-]+)/g)).map((m) => m[1])
+      );
+      const defined = new Set(
+        Array.from(css.matchAll(/^\s*(--tch-[a-z0-9-]+)\s*:/gm)).map((m) => m[1])
+      );
+
+      const undefinedTokens = [...referenced].filter((name) => !defined.has(name));
+
+      expect(undefinedTokens).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
# Summary

## Changes

Centered the wrapping chip rows in the main chat empty state by adding `justify-content: center` to
`.chat-sample-prompts`, while adding an explicit `justify-content: flex-start` to the
`[data-embedded="true"]` override so the plan side panel's horizontal scroller keeps its leading
chips flush left and reachable. Also fixed `.chat-sample-prompt:hover` to reference the tokens that
actually exist (`--tch-surface-hover`, `--tch-faint`) instead of two undefined tokens
(`--tch-bg-hover`, `--tch-fg-faint`), which previously caused hover to strip the chip background to
transparent instead of tinting it.

## API Changes

None. CSS-only; no changes to `ChatWidget.cs` or `ChatWidget.tsx`.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css` — three rule-level edits (base
  `.chat-sample-prompts`, its embedded override, and `.chat-sample-prompt:hover`)
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css.test.ts` — four new test cases
  asserting the centering, the embedded flush-left override, the corrected hover tokens, and a
  generic guard that every `--tch-*` token referenced by `var()` is defined somewhere in the file

## Manual Testing

1. Run the app (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse
   --find-available-port`) and open the main chat empty state.
2. Resize the window (or use enough sample prompts) so the chip row wraps to a second line — the
   second row should now sit centered under the first, not packed left.
3. Hover a chip — the background should tint (not clear to transparent) and the border should not
   turn solid `currentColor`.
4. Open a plan side panel (embedded chat) with sample prompts — the chip strip should remain flush
   left at the panel's inset and still scroll horizontally, with the first chip always reachable.

## Fix: Flaky ChatExecutionServiceJobTrackingTests fan-out harness timeout

Per the review recommendation, investigated why the six `PlanEditFanOutHarness`-based tests in
`ChatExecutionServiceJobTrackingTests` time out identically on unmodified `development`. The
harness built `ChatExecutionService` with the real `TestAgentRunner.Create()` registrations, so
every `SendMessageAsync` call (triggered by `NotifyPlanEditAsync`) launched an actual `codex exec`
subprocess against a live model instead of a fake session. `WaitForIdleAsync`'s 20 second budget
could never observe that real process finish, so it failed deterministically, not intermittently.
Fixed by wrapping the runner in an `InstantAgentRunner` that returns an already-completed fake
session for every launch, following the same pattern as the existing `CancellableAgentRunner` in
this file. The scoped suite now passes 3778/3779 (1 skipped) in under 2 minutes, down from 6
failures and 20-30+ minutes of wall-clock time.

### Files Modified

- `src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs` — added `InstantAgentRunner` and
  `InstantCompletionTestSession`, and pointed `PlanEditFanOutHarness` at the wrapped runner instead
  of the raw `TestAgentRunner.Create()` result

**Note:** No user-facing behavior changed; this is a test-only fix.

---
## Commits
- 821bfc92 Center chat sample prompt chips and fix hover token names
- 85965dc5 Fix flaky ChatExecutionServiceJobTrackingTests fan-out harness timeout

---
Created using [Ivy Tendril](https://ivy.app).