### PR TITLE
[00455] Let a Partly Answered Chat Questions Block Be Submitted

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx
@@ -33,6 +33,23 @@ describe("ChatWidget Interactive Question Draft Persistence", () => {
 
   const freeTextQuestion = questionsFence("- id: comment", "  title: Anything else?");
 
+  const costAndScopeQuestion = questionsFence(
+    "- id: cost",
+    "  title: How should cost be attributed?",
+    "  options:",
+    "    - title: Per session",
+    "      value: session",
+    "    - title: Per token",
+    "      value: token",
+    "- id: scope",
+    "  title: Which scope should ship first?",
+    "  options:",
+    "    - title: Ledger first",
+    "      value: ledger",
+    "    - title: Surfacing first",
+    "      value: surfacing",
+  );
+
   const twoBlockMessage = [
     "First block:",
     questionsFence(
@@ -320,5 +337,43 @@ describe("ChatWidget Interactive Question Draft Persistence", () => {
     );
 
     expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+  });
+
+  it("submits a partly answered block, reporting only the answered question and leaving the rest to the agent", () => {
+    const session = sessionWith("sess-partial", costAndScopeQuestion);
+    const handleEvent = vi.fn();
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-partial"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    const submitBtn = screen.getByRole("button", { name: /Submit Response/i });
+    expect(submitBtn).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("radio", { name: /Ledger first/i }));
+    expect(submitBtn).not.toBeDisabled();
+
+    fireEvent.click(submitBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnAnswerQuestion",
+      "test-chat",
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: "sess-partial",
+          messageId: "sess-partial-msg",
+          answers: { scope: ["ledger"] },
+          responseText: expect.stringContaining(
+            "How should cost be attributed?**: *(no preference, your call)*",
+          ),
+        }),
+      ]),
+    );
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
@@ -551,18 +551,40 @@ describe("DraftMarkdown interactive questions", () => {
     expect(eventHandler).not.toHaveBeenCalled();
   });
 
-  it("ignores card click when user has an active text selection", () => {
+  it("ignores card click when the active text selection is anchored inside that card", () => {
     const { container, eventHandler } = renderInteractive(SINGLE);
-
-    const selectionSpy = vi.spyOn(window, "getSelection").mockReturnValue({
-      toString: () => "selected text",
-    } as Selection);
 
     const card = container.querySelector<HTMLElement>(".tq-option");
     expect(card).not.toBeNull();
+
+    const selectionSpy = vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+      anchorNode: card,
+      toString: () => "selected text",
+    } as unknown as Selection);
+
     fireEvent.click(card!);
 
     expect(eventHandler).not.toHaveBeenCalled();
+    selectionSpy.mockRestore();
+  });
+
+  it("still handles a card click when the active text selection is anchored elsewhere", () => {
+    const { container, eventHandler } = renderInteractive(SINGLE);
+
+    const cards = container.querySelectorAll<HTMLElement>(".tq-option");
+    const [firstCard, secondCard] = Array.from(cards);
+    expect(secondCard).not.toBeUndefined();
+
+    const selectionSpy = vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+      anchorNode: firstCard,
+      toString: () => "selected text",
+    } as unknown as Selection);
+
+    fireEvent.click(secondCard);
+
+    expect(eventHandler).toHaveBeenCalled();
     selectionSpy.mockRestore();
   });
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/ChatQuestionsBlock.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/ChatQuestionsBlock.tsx
@@ -9,6 +9,7 @@ import {
   documentAnswers,
   documentOtherOpen,
   hasEntries,
+  submitNote,
 } from "./answers";
 
 interface ChatQuestionsBlockProps {
@@ -72,7 +73,12 @@ export const ChatQuestionsBlock: React.FC<ChatQuestionsBlockProps> = ({ question
       onAnswer={handleAnswer}
       onOtherOpenChange={handleOtherOpenChange}
       onClear={hasAnyAnswers ? clearAll : undefined}
-      submit={{ label: "Submit response", disabled: !submitEnabled, onSubmit: handleSubmit }}
+      submit={{
+        label: "Submit response",
+        disabled: !submitEnabled,
+        note: submitNote(questions, draft.answers),
+        onSubmit: handleSubmit,
+      }}
     />
   );
 };

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/QuestionsForm.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/QuestionsForm.tsx
@@ -2,13 +2,15 @@ import React, { useId, useState } from "react";
 import { Check } from "lucide-react";
 import type { PlanQuestion, QuestionOption } from "../PlanMarkdown/questionsSchema";
 import { DescriptionMarkdown } from "./DescriptionMarkdown";
-import { entryTitle, hasEntries } from "./answers";
+import { entryTitle, hasEntries, unansweredRequired } from "./answers";
 import type { AnswerMap } from "./answers";
 import "./tendril-questions.css";
 
 export interface QuestionsSubmitAction {
   label?: string;
   disabled?: boolean;
+  /** Shown in the footer next to the button, and as its tooltip while disabled. */
+  note?: string;
   onSubmit: () => void;
 }
 
@@ -29,10 +31,17 @@ export interface QuestionsFormProps {
   submit?: QuestionsSubmitAction;
 }
 
-/** A click on a control, link or selected text inside a card must not toggle the card. */
+/** Whether the current selection is a real range anchored inside the given node. */
+const selectionInside = (node: EventTarget | null): boolean => {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || !selection.anchorNode) return false;
+  return node instanceof Node && (node as HTMLElement).contains?.(selection.anchorNode) === true;
+};
+
+/** A click on a control, link or text selected inside the clicked card must not toggle the card. */
 const ignoresCardClick = (e: React.MouseEvent): boolean =>
   Boolean((e.target as HTMLElement).closest("label, input, textarea, button, a")) ||
-  Boolean(window.getSelection()?.toString());
+  selectionInside(e.currentTarget);
 
 interface OptionCardProps {
   option: QuestionOption;
@@ -97,6 +106,8 @@ interface QuestionCardProps {
   entries: string[];
   otherOpen: boolean;
   groupName: string;
+  /** Marks a required question with no answer, once some other question in the block is answered. */
+  unanswered?: boolean;
   onChange: (entries: string[]) => void;
   onOtherOpenChange: (open: boolean) => void;
 }
@@ -106,6 +117,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
   entries,
   otherOpen,
   groupName,
+  unanswered = false,
   onChange,
   onOtherOpenChange,
 }) => {
@@ -171,7 +183,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
   );
 
   return (
-    <div className="tq-question" data-question-id={question.id}>
+    <div className="tq-question" data-question-id={question.id} data-unanswered={unanswered || undefined}>
       <QuestionHeading question={question} />
       {question.multiple && hasOptions && <div className="tq-question-hint">Select all that apply</div>}
       <div className="tq-options">
@@ -258,6 +270,9 @@ export const QuestionsForm: React.FC<QuestionsFormProps> = ({
   const reactId = useId();
   const hasAnyAnswers = Object.values(answers).some(hasEntries);
   const showFooter = !readOnly && ((onClear && hasAnyAnswers) || submit);
+  const unansweredIds = hasAnyAnswers
+    ? new Set(unansweredRequired(questions, answers).map((question) => question.id))
+    : new Set<string>();
 
   return (
     <div className="tq-root" role="group">
@@ -271,6 +286,7 @@ export const QuestionsForm: React.FC<QuestionsFormProps> = ({
             entries={answers[question.id] ?? []}
             otherOpen={otherOpen[question.id] ?? false}
             groupName={`tq-${reactId}-${question.id}`}
+            unanswered={unansweredIds.has(question.id)}
             onChange={(entries) => onAnswer?.(question.id, entries)}
             onOtherOpenChange={(open) => onOtherOpenChange?.(question.id, open)}
           />
@@ -278,6 +294,7 @@ export const QuestionsForm: React.FC<QuestionsFormProps> = ({
       )}
       {showFooter && (
         <div className="tq-footer">
+          {submit?.note && <span className="tq-footer-note">{submit.note}</span>}
           {onClear && hasAnyAnswers && (
             <button
               type="button"
@@ -289,7 +306,13 @@ export const QuestionsForm: React.FC<QuestionsFormProps> = ({
             </button>
           )}
           {submit && (
-            <button type="button" className="tq-submit" disabled={submit.disabled} onClick={submit.onSubmit}>
+            <button
+              type="button"
+              className="tq-submit"
+              disabled={submit.disabled}
+              title={submit.note}
+              onClick={submit.onSubmit}
+            >
               {submit.label ?? "Submit response"}
             </button>
           )}

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/TendrilQuestions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/TendrilQuestions.test.tsx
@@ -4,7 +4,7 @@ import "@testing-library/jest-dom";
 import { TendrilQuestions } from "./TendrilQuestions";
 import { QuestionsForm } from "./QuestionsForm";
 import { parseQuestions } from "../PlanMarkdown/questionsSchema";
-import { buildAnswersSummary } from "./answers";
+import { buildAnswersSummary, unansweredRequired } from "./answers";
 
 const yaml = (...lines: string[]) => lines.join("\n");
 
@@ -48,6 +48,23 @@ const withOther = yaml(
 );
 
 const freeText = yaml("- id: notes", "  title: Anything else?", "  optional: true");
+
+const twoRequired = yaml(
+  "- id: cost",
+  "  title: How should cost be attributed?",
+  "  options:",
+  "    - title: Per session",
+  "      value: session",
+  "    - title: Per token",
+  "      value: token",
+  "- id: scope",
+  "  title: Which scope should ship first?",
+  "  options:",
+  "    - title: Ledger first",
+  "      value: ledger",
+  "    - title: Surfacing first",
+  "      value: surfacing",
+);
 
 const answered = yaml(
   "- id: proceed",
@@ -174,6 +191,27 @@ describe("TendrilQuestions widget", () => {
     render(<TendrilQuestions id="q" eventHandler={vi.fn()} content={"Just a note for the reader"} />);
     expect(screen.getByText("Just a note for the reader")).toHaveClass("tq-static");
   });
+
+  it("stays disabled with a note until something is answered, then enables and names what is left", () => {
+    render(<TendrilQuestions id="q" eventHandler={vi.fn()} content={twoRequired} showSubmit />);
+
+    const submit = screen.getByRole("button", { name: "Submit response" });
+    expect(submit).toBeDisabled();
+    expect(screen.getByText("Answer a question to submit.")).toBeInTheDocument();
+    expect(submit).toHaveAttribute("title", "Answer a question to submit.");
+
+    fireEvent.click(screen.getByRole("radio", { name: /Ledger first/i }));
+
+    expect(submit).not.toBeDisabled();
+    const note = 'Unanswered: "How should cost be attributed?". Submitting leaves it to me.';
+    expect(screen.getByText(note)).toBeInTheDocument();
+    expect(submit).toHaveAttribute("title", note);
+
+    const costQuestion = screen.getByText("How should cost be attributed?").closest(".tq-question");
+    expect(costQuestion).toHaveAttribute("data-unanswered", "true");
+    const scopeQuestion = screen.getByText("Which scope should ship first?").closest(".tq-question");
+    expect(scopeQuestion).not.toHaveAttribute("data-unanswered");
+  });
 });
 
 describe("QuestionsForm", () => {
@@ -196,5 +234,41 @@ describe("QuestionsForm", () => {
     expect(buildAnswersSummary(questions, { env: ["canary"] })).toBe(
       "Answers:\n- **Which environment?**: canary\n- **Anything else?**: *(skipped)*",
     );
+  });
+
+  it("summarises a required question left to the agent, distinct from an optional skip", () => {
+    const questions = [...questionsOf(withOther), ...questionsOf(freeText)];
+    expect(buildAnswersSummary(questions, {})).toBe(
+      "Answers:\n- **Which environment?**: *(no preference, your call)*\n- **Anything else?**: *(skipped)*",
+    );
+  });
+
+  it("unansweredRequired ignores optional questions and ones the document already answers", () => {
+    const questions = [...questionsOf(answered), ...questionsOf(withOther)];
+    expect(unansweredRequired(questions, {}).map((question) => question.id)).toEqual(["env"]);
+  });
+
+  it("does not toggle a card when the selection is anchored inside it, but does toggle when the selection is elsewhere", () => {
+    const onAnswer = vi.fn();
+    const questions = questionsOf(singleSelect);
+    render(<QuestionsForm questions={questions} answers={{}} onAnswer={onAnswer} />);
+
+    const openPrCard = screen.getByText("Open a PR").closest(".tq-option") as HTMLElement;
+    const reviewCard = screen.getByText("Review the diff first").closest(".tq-option") as HTMLElement;
+
+    const getSelectionSpy = vi.spyOn(window, "getSelection");
+    getSelectionSpy.mockReturnValue({
+      isCollapsed: false,
+      anchorNode: openPrCard,
+      toString: () => "some selected text",
+    } as unknown as Selection);
+
+    fireEvent.click(openPrCard);
+    expect(onAnswer).not.toHaveBeenCalled();
+
+    fireEvent.click(reviewCard);
+    expect(onAnswer).toHaveBeenCalledWith("proceed", ["review"]);
+
+    getSelectionSpy.mockRestore();
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/TendrilQuestions.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/TendrilQuestions.tsx
@@ -8,6 +8,7 @@ import {
   documentAnswers,
   documentOtherOpen,
   hasEntries,
+  submitNote,
 } from "./answers";
 import type { AnswerMap } from "./answers";
 import "./tendril-questions.css";
@@ -100,6 +101,7 @@ export const TendrilQuestions: React.FC<TendrilQuestionsProps> = ({
           ? {
               label: submitLabel || "Submit response",
               disabled: !submitEnabled,
+              note: submitNote(questions, answers),
               onSubmit: () => emit("OnSubmit", { answers, summary: buildAnswersSummary(questions, answers) }),
             }
           : undefined

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/answers.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/answers.ts
@@ -30,11 +30,40 @@ export function entryTitle(question: PlanQuestion, entry: string): string {
   return question.options?.find((option) => option.value === entry)?.title ?? entry;
 }
 
-/** Every required question has an answer, either drafted here or already in the document. */
+/** A block is submittable once it carries at least one answer, drafted here or in the document. */
 export function canSubmitAnswers(questions: PlanQuestion[], answers: AnswerMap): boolean {
-  return questions.every(
-    (question) => question.optional || hasEntries(answers[question.id]) || question.answerPresent,
+  return questions.some((question) => hasEntries(answers[question.id]) || question.answerPresent);
+}
+
+/** Required questions with no drafted entry and no answer already in the document. */
+export function unansweredRequired(questions: PlanQuestion[], answers: AnswerMap): PlanQuestion[] {
+  return questions.filter(
+    (question) => !question.optional && !hasEntries(answers[question.id]) && !question.answerPresent,
   );
+}
+
+const TITLE_TRUNCATE_LENGTH = 60;
+
+const truncateTitle = (title: string): string =>
+  title.length > TITLE_TRUNCATE_LENGTH ? `${title.slice(0, TITLE_TRUNCATE_LENGTH - 1)}…` : title;
+
+/**
+ * The footer note explaining why Submit is disabled or what a partial submit leaves to the agent.
+ * Shared by `ChatQuestionsBlock` and `TendrilQuestions` so both surfaces read identically.
+ */
+export function submitNote(questions: PlanQuestion[], answers: AnswerMap): string | undefined {
+  const hasAnyAnswers = questions.some(
+    (question) => hasEntries(answers[question.id]) || question.answerPresent,
+  );
+  if (!hasAnyAnswers) return "Answer a question to submit.";
+
+  const missing = unansweredRequired(questions, answers);
+  if (missing.length === 0) return undefined;
+  if (missing.length === 1) {
+    const title = missing[0].title || missing[0].id;
+    return `Unanswered: "${truncateTitle(title)}". Submitting leaves it to me.`;
+  }
+  return `${missing.length} questions unanswered. Submitting leaves them to me.`;
 }
 
 /**
@@ -50,6 +79,8 @@ export function buildAnswersSummary(questions: PlanQuestion[], answers: AnswerMa
       lines.push(`- **${label}**: ${entries.map((entry) => entryTitle(question, entry)).join(", ")}`);
     } else if (question.optional) {
       lines.push(`- **${label}**: *(skipped)*`);
+    } else {
+      lines.push(`- **${label}**: *(no preference, your call)*`);
     }
   }
   return lines.join("\n");

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/index.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/index.ts
@@ -11,5 +11,7 @@ export {
   documentOtherOpen,
   entryTitle,
   hasEntries,
+  submitNote,
+  unansweredRequired,
 } from "./answers";
 export type { AnswerMap } from "./answers";

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/tendril-questions.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/tendril-questions.css
@@ -69,6 +69,14 @@
   color: var(--tq-muted);
 }
 
+.tq-question[data-unanswered="true"] .tq-question-title::after {
+  content: "Unanswered";
+  margin-left: 8px;
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--tq-faint);
+}
+
 .tq-question-hint {
   margin-top: -4px;
   font-size: 12px;
@@ -260,6 +268,12 @@
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
+}
+
+.tq-footer-note {
+  margin-right: auto;
+  font-size: 12px;
+  color: var(--tq-muted);
 }
 
 .tq-clear {


### PR DESCRIPTION
# Summary

A chat questions block with more than one question refused to submit until every non-optional
question was answered, with no explanation why. This contradicted the questions schema's own
semantics: an unanswered question means "the agent decides," so a partly answered block is a
legitimate response, not an incomplete form. A related bug made this worse: any leftover text
selection anywhere on the page (e.g. from double-clicking to read) silently blocked clicks on
option cards until the selection was cleared.

## Changes

- `answers.ts`: `canSubmitAnswers` now enables Submit once any question has an answer, instead of
  requiring every required question answered. Added `unansweredRequired()` and `submitNote()` to
  identify and describe what is still unanswered. `buildAnswersSummary()` now renders a required
  unanswered question as `*(no preference, your call)*`, distinct from `*(skipped)*` for optional
  ones.
- `QuestionsForm.tsx`: the footer now shows a note naming what is unanswered (also as the submit
  button's `title` tooltip), and a required question with no answer gets a `data-unanswered="true"`
  marker (styled with an "Unanswered" cue) once the user has answered something else in the block.
  `ignoresCardClick`'s selection check is now scoped to the clicked card, so a selection elsewhere
  on the page no longer blocks selecting an option.
- `ChatQuestionsBlock.tsx` and `TendrilQuestions.tsx`: wired the new footer note into both the
  chat-embedded and standalone widget paths.
- `tendril-questions.css`: styling for the footer note and the unanswered marker.

The one unanswered plan question ("How strict should the submit gate be?") was resolved by taking
its recommended option, `any-answer`.

## Verification

All six seeded verifications pass: `DotnetFormat`, `DotnetBuild`, `DotnetTest` (32/32, scoped to
`ChatHistoryServiceTests`, run via `Ivy.Tendril.Test.csproj` directly since the `.slnx` cannot
restore in a worktree), `CheckResult`, `NpmLint`, and `NpmTest` (69/69 across
`TendrilQuestions`, `ChatWidget.questions.test.tsx`, and `PlanMarkdown.questions.test.tsx`).

No C# was changed; the submit payload and `ChatHistoryService.ApplyQuestionAnswers` already handled
a partial answer set.

---
Commits:
- e6cdf8b7 test(00455): cover partial-answer submit and scoped selection guard
- 84da1857 fix(00455): let a partly answered chat questions block be submitted

---
Created using [Ivy Tendril](https://ivy.app).
