### PR TITLE
[00479] Show Question Answers Optimistically in Plans and Review

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx
@@ -203,7 +203,36 @@ describe("ChatWidget Interactive Question Draft Persistence", () => {
     expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
   });
 
-  it("clears the draft on submit, so a later remount starts empty rather than re-offering the old selection", () => {
+  it("shows the submitted answer immediately on Submit instead of resetting to an empty form", () => {
+    const sessionA = sessionWith("sess-a", deployQuestion);
+    const sessionB = sessionWith("sess-b", "Just a plain message, no questions here.");
+    const handleEvent = vi.fn();
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-a"
+        sessions={[sessionA, sessionB]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Submit Response/i }));
+    expect(handleEvent).toHaveBeenCalled();
+
+    // Submitted to the host, but the message content itself is untouched — the host hasn't
+    // written the answer back yet.
+    expect(sessionA.messages[0].content).toBe(deployQuestion);
+
+    // The block shows the decision it was just given rather than an empty, re-enabled form.
+    expect(screen.queryByRole("radio", { name: /Staging Environment/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Submit Response/i })).toBeNull();
+    expect(screen.getByText("Staging Environment")).toBeInTheDocument();
+  });
+
+  it("keeps the submitted read-only view after a remount, and switches to the document once it carries the answer", () => {
     const sessionA = sessionWith("sess-a", deployQuestion);
     const sessionB = sessionWith("sess-b", "Just a plain message, no questions here.");
     const handleEvent = vi.fn();
@@ -220,7 +249,6 @@ describe("ChatWidget Interactive Question Draft Persistence", () => {
 
     fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
     fireEvent.click(screen.getByRole("button", { name: /Submit Response/i }));
-    expect(handleEvent).toHaveBeenCalled();
 
     // Switch away and back to force a remount of the message row.
     rerender(
@@ -242,8 +270,83 @@ describe("ChatWidget Interactive Question Draft Persistence", () => {
       />,
     );
 
+    // The submitted decision is still on screen, not a reset form.
+    expect(screen.queryByRole("radio", { name: /Staging Environment/i })).toBeNull();
+    expect(screen.getByText("Staging Environment")).toBeInTheDocument();
+
+    // Once the host has echoed the answer into the message document, that document view takes
+    // over — the block never flips back to an editable form on the way.
+    const answeredSessionA = sessionWith(
+      "sess-a",
+      questionsFence(
+        "- id: deploy_target",
+        "  title: Which environment should we deploy to?",
+        "  options:",
+        "    - title: Staging Environment",
+        "      value: staging",
+        "    - title: Production Environment",
+        "      value: prod",
+        "  answer: staging",
+      ),
+    );
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-a"
+        sessions={[answeredSessionA, sessionB]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    expect(screen.queryByRole("radio", { name: /Staging Environment/i })).toBeNull();
+    expect(screen.getByText("Staging Environment")).toBeInTheDocument();
+  });
+
+  it("keeps a second message's block unaffected by the first one's submitted state", () => {
+    const firstMessageQuestion = questionsFence(
+      "- id: deploy_target",
+      "  title: Which environment should we deploy to?",
+      "  options:",
+      "    - title: Staging Environment",
+      "      value: staging",
+      "    - title: Production Environment",
+      "      value: prod",
+    );
+    const secondMessageQuestion = questionsFence(
+      "- id: deploy_target",
+      "  title: Which environment should we deploy to next?",
+      "  options:",
+      "    - title: Staging Environment",
+      "      value: staging",
+      "    - title: Production Environment",
+      "      value: prod",
+    );
+    const session: ChatSessionDto = {
+      id: "sess-multi",
+      title: "sess-multi",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [
+        { id: "msg-1", role: "assistant", content: firstMessageQuestion, timestamp: "12:00 PM" },
+        { id: "msg-2", role: "assistant", content: secondMessageQuestion, timestamp: "12:01 PM" },
+      ],
+    };
+
+    render(
+      <ChatWidget id="test-chat" activeSessionId="sess-multi" sessions={[session]} events={["OnAnswerQuestion"]} />,
+    );
+
+    const [firstRadio, secondRadio] = screen.getAllByRole("radio", { name: /Staging Environment/i });
+    fireEvent.click(firstRadio);
+    fireEvent.click(screen.getAllByRole("button", { name: /Submit Response/i })[0]);
+
+    // The first message's block is now the read-only submitted view; the second is untouched.
     expect(screen.getByRole("radio", { name: /Staging Environment/i })).not.toBeChecked();
     expect(screen.getByRole("button", { name: /Submit Response/i })).toBeDisabled();
+    expect(secondRadio).not.toBeChecked();
   });
 
   it("keeps two question blocks in one message independent when only one is answered", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
@@ -737,6 +737,125 @@ describe("DraftMarkdown interactive questions", () => {
   });
 });
 
+describe("DraftMarkdown interactive questions — optimistic answers", () => {
+  it("marks an option selected immediately, with the content prop unchanged", () => {
+    const eventHandler = vi.fn();
+    const { container } = render(
+      <DraftMarkdown id="w1" content={SINGLE} events={["OnAnswersChange"]} eventHandler={eventHandler} />,
+    );
+
+    fireEvent.click(checks(container)[0]);
+
+    // No document round trip happened — the content the picker was handed is the same content it
+    // was given, yet the selection shows immediately.
+    expect(checks(container)[0].checked).toBe(true);
+    expect(answerCalls(eventHandler)).toEqual([{ questionId: "budget", answer: ["per-request"] }]);
+  });
+
+  it("accumulates two multi-select clicks with no echo in between", () => {
+    const { container, eventHandler } = renderInteractive(MULTI_ANSWERED);
+
+    fireEvent.click(checks(container)[1]); // Email, on top of the document's In-app.
+    fireEvent.click(checks(container)[2]); // Push, on top of the still-pending In-app + Email.
+
+    // Only the three named options — the trailing checkbox is the always-present Other toggle.
+    expect(checks(container).slice(0, 3).map((c) => c.checked)).toEqual([true, true, true]);
+    expect(answerCalls(eventHandler)).toEqual([
+      { questionId: "channels", answer: ["in-app", "email"] },
+      { questionId: "channels", answer: ["in-app", "email", "push"] },
+    ]);
+  });
+
+  it("keeps typed Other text and the open field, with no echo", () => {
+    const { container } = renderInteractive(SINGLE);
+
+    const otherRow = container.querySelector(".tq-option--other")!;
+    fireEvent.click(otherRow.querySelector<HTMLInputElement>(".tq-option-input")!);
+    const input = container.querySelector<HTMLInputElement>(".tq-text-input")!;
+    fireEvent.change(input, { target: { value: "per-tenant" } });
+
+    expect(container.querySelector<HTMLInputElement>(".tq-text-input")?.value).toBe("per-tenant");
+    expect(container.querySelector(".tq-option--other")?.getAttribute("data-selected")).toBe("true");
+  });
+
+  it("deselects immediately on Clear, with no echo", () => {
+    const { container, eventHandler } = renderInteractive(SINGLE_ANSWERED);
+
+    fireEvent.click(container.querySelector<HTMLButtonElement>(".tq-clear")!);
+
+    expect(checks(container).some((c) => c.checked)).toBe(false);
+    expect(answerCalls(eventHandler)).toEqual([{ questionId: "budget", answer: null }]);
+  });
+
+  it("keeps the answer selected once the document catches up, and yields to a differing document answer", () => {
+    const eventHandler = vi.fn();
+    const { container, rerender } = render(
+      <DraftMarkdown id="w1" content={SINGLE} events={["OnAnswersChange"]} eventHandler={eventHandler} />,
+    );
+
+    fireEvent.click(checks(container)[0]); // Selects per-request.
+    expect(checks(container)[0].checked).toBe(true);
+
+    // The host echoes back a document that agrees with the pending selection.
+    rerender(
+      <DraftMarkdown
+        id="w1"
+        content={SINGLE_ANSWERED}
+        events={["OnAnswersChange"]}
+        eventHandler={eventHandler}
+      />,
+    );
+    expect(checks(container)[0].checked).toBe(true);
+
+    // The pending entry has now reconciled, so a later document change — even one that disagrees —
+    // flows straight through rather than being masked by a stale pending value.
+    const differentAnswer = fence(
+      "questions:",
+      "  - id: budget",
+      "    title: Retry budget scope?",
+      "    options:",
+      "      - title: Per request",
+      "        value: per-request",
+      "      - title: Per session",
+      "        value: per-session",
+      "    answer: per-session",
+    );
+    rerender(
+      <DraftMarkdown
+        id="w1"
+        content={differentAnswer}
+        events={["OnAnswersChange"]}
+        eventHandler={eventHandler}
+      />,
+    );
+    expect(checks(container)[0].checked).toBe(false);
+    expect(checks(container)[1].checked).toBe(true);
+  });
+
+  it("reverts to the document after the timeout when the host never echoes", () => {
+    vi.useFakeTimers();
+    try {
+      const eventHandler = vi.fn();
+      const { container } = render(
+        <DraftMarkdown id="w1" content={SINGLE} events={["OnAnswersChange"]} eventHandler={eventHandler} />,
+      );
+
+      fireEvent.click(checks(container)[0]);
+      expect(checks(container)[0].checked).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(4000);
+      });
+
+      // A rejected write (or a dropped connection) cannot leave the picker stuck on a selection
+      // the document never actually saved.
+      expect(checks(container).some((c) => c.checked)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("QuestionsCallout without a draft context", () => {
   // Chat wraps every interactive block in `QuestionsDraftContext.Provider`, but nothing forces
   // that: `QuestionsCallout` reads the context optionally, and this proves it degrades to the

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx
@@ -1,9 +1,17 @@
-import React, { useMemo, useState } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { parseQuestions } from "./questionsSchema";
 import type { AnswerCallback, QuestionSubmitCallback } from "./questionsContext";
+import { QuestionsDraftContext } from "./questionsContext";
 import { ChatQuestionsBlock } from "../TendrilQuestions/ChatQuestionsBlock";
 import { QuestionsForm } from "../TendrilQuestions/QuestionsForm";
 import { documentAnswers, documentOtherOpen } from "../TendrilQuestions/answers";
+
+/**
+ * How long an optimistically-shown answer is trusted before the document has to have caught up.
+ * Guards against a host that never echoes back (a `TryApply` miss on a document that moved on, a
+ * dropped connection) leaving the picker permanently out of sync with what was actually saved.
+ */
+const PENDING_ANSWER_TIMEOUT_MS = 4000;
 
 /**
  * The frame every questions block sits in. It carries no heading of its own — the question text is
@@ -47,6 +55,103 @@ export const QuestionsCallout: React.FC<QuestionsCalloutProps> = ({ content, onA
   // That much is local: it is what keeps the field on screen between opening it and typing in it.
   const [opened, setOpened] = useState<Record<string, boolean>>({});
 
+  // An answer just reported to the host, shown immediately instead of waiting for the document to
+  // round-trip. `undefined` records a pending clear. Reconciled below once the document agrees.
+  const [pending, setPending] = useState<Record<string, string[] | undefined>>({});
+  const pendingTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const clearPendingTimer = (questionId: string) => {
+    const timer = pendingTimers.current[questionId];
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      delete pendingTimers.current[questionId];
+    }
+  };
+
+  useEffect(() => {
+    const timers = pendingTimers.current;
+    return () => {
+      for (const timer of Object.values(timers)) clearTimeout(timer);
+    };
+  }, []);
+
+  // Once the document carries a value matching what was pending, the document is the single
+  // source of truth again — drop the overlay entry (and its safety-valve timer) for that question.
+  useEffect(() => {
+    const settled = Object.keys(pending).filter((questionId) => {
+      const expected = pending[questionId];
+      const actual = answers[questionId];
+      if (expected === undefined) return actual === undefined;
+      return (
+        actual !== undefined &&
+        actual.length === expected.length &&
+        actual.every((entry, index) => entry === expected[index])
+      );
+    });
+    if (settled.length === 0) return;
+    for (const questionId of settled) clearPendingTimer(questionId);
+    setPending((prev) => {
+      const next = { ...prev };
+      for (const questionId of settled) delete next[questionId];
+      return next;
+    });
+  }, [answers, pending]);
+
+  // Records an optimistic answer and arms the safety-valve timeout that drops it if the document
+  // never agrees.
+  const setPendingAnswer = (questionId: string, value: string[] | undefined) => {
+    clearPendingTimer(questionId);
+    setPending((prev) => ({ ...prev, [questionId]: value }));
+    pendingTimers.current[questionId] = setTimeout(() => {
+      delete pendingTimers.current[questionId];
+      setPending((prev) => {
+        if (!(questionId in prev)) return prev;
+        const next = { ...prev };
+        delete next[questionId];
+        return next;
+      });
+    }, PENDING_ANSWER_TIMEOUT_MS);
+  };
+
+  // The overlay the draft flow actually renders: the document, with any still-pending answers
+  // layered on top.
+  const displayAnswers = useMemo(() => {
+    const overlay = { ...answers };
+    for (const questionId of Object.keys(pending)) {
+      const entries = pending[questionId];
+      if (entries === undefined) delete overlay[questionId];
+      else overlay[questionId] = entries;
+    }
+    return overlay;
+  }, [answers, pending]);
+
+  const displayOpen = useMemo(() => {
+    const overlay = { ...documentOpen };
+    for (const question of questions) {
+      if (!(question.id in pending)) continue;
+      const entries = pending[question.id];
+      if (entries === undefined) {
+        delete overlay[question.id];
+        continue;
+      }
+      const optionValues = new Set((question.options ?? []).map((option) => option.value));
+      const hasTyped = entries.some((entry) => !optionValues.has(entry));
+      if (hasTyped) overlay[question.id] = true;
+      else delete overlay[question.id];
+    }
+    return overlay;
+  }, [documentOpen, pending, questions]);
+
+  // Once a chat block's document carries every answer, the submitted-draft view below takes over —
+  // the store entry that kept it on screen during the round trip has served its purpose.
+  const draftStore = useContext(QuestionsDraftContext);
+  const allAnswered = questions.length > 0 && questions.every((q) => q.answerPresent);
+  useEffect(() => {
+    if (!onAnswer && onSubmit && allAnswered) {
+      draftStore?.clear(questions.map((q) => q.id).join("|"));
+    }
+  }, [onAnswer, onSubmit, allAnswered, draftStore, questions]);
+
   // A block that does not parse is the pre-schema plain-text form, and there is nothing to render
   // but the text itself.
   if (questions.length === 0) {
@@ -56,7 +161,7 @@ export const QuestionsCallout: React.FC<QuestionsCalloutProps> = ({ content, onA
   // Inside a chat message answers are drafted locally and submitted in one go; a settled block
   // presents the decisions.
   if (!onAnswer && onSubmit) {
-    if (questions.every((q) => q.answerPresent)) {
+    if (allAnswered) {
       return <QuestionsForm questions={questions} answers={answers} readOnly />;
     }
 
@@ -78,7 +183,10 @@ export const QuestionsCallout: React.FC<QuestionsCalloutProps> = ({ content, onA
   // questions are included — being optional does not make an answer unretractable.
   const clearAll = () => {
     for (const question of questions) {
-      if (question.answerPresent) onAnswer(question.id, undefined);
+      if (question.answerPresent) {
+        setPendingAnswer(question.id, undefined);
+        onAnswer(question.id, undefined);
+      }
     }
     setOpened({});
   };
@@ -89,11 +197,13 @@ export const QuestionsCallout: React.FC<QuestionsCalloutProps> = ({ content, onA
     <Shell>
       <QuestionsForm
         questions={questions}
-        answers={answers}
-        otherOpen={{ ...documentOpen, ...opened }}
-        onAnswer={(questionId, entries) =>
-          onAnswer(questionId, entries.length === 0 ? undefined : entries)
-        }
+        answers={displayAnswers}
+        otherOpen={{ ...displayOpen, ...opened }}
+        onAnswer={(questionId, entries) => {
+          const value = entries.length === 0 ? undefined : entries;
+          setPendingAnswer(questionId, value);
+          onAnswer(questionId, value);
+        }}
         onOtherOpenChange={(questionId, open) =>
           setOpened((prev) => ({ ...prev, [questionId]: open }))
         }

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsContext.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsContext.ts
@@ -35,6 +35,8 @@ export interface QuestionsDraftState {
   answers: Record<string, string[]>;
   /** Whether the Other field is open, by question id. Not derivable when nothing is typed yet. */
   otherOpen: Record<string, boolean>;
+  /** Submitted to the host, not yet written into the message document. */
+  submitted?: boolean;
 }
 
 export interface QuestionsDraftStore {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/ChatQuestionsBlock.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/ChatQuestionsBlock.tsx
@@ -60,9 +60,15 @@ export const ChatQuestionsBlock: React.FC<ChatQuestionsBlockProps> = ({ question
   const handleSubmit = () => {
     if (!submitEnabled) return;
     onSubmit(draft.answers, buildAnswersSummary(questions, draft.answers));
-    // The answers now live in the message document, so nothing is left to draft for this block.
-    store?.clear(blockKey);
+    // Submitted to the host, but not yet written into the message document — keep showing the
+    // submitted answers instead of clearing the draft, so Submit doesn't visibly reset the form
+    // while the document round-trips.
+    update((prev) => ({ ...prev, submitted: true }));
   };
+
+  if (draft.submitted) {
+    return <QuestionsForm questions={questions} answers={draft.answers} readOnly />;
+  }
 
   return (
     <QuestionsForm


### PR DESCRIPTION
Fixes #2653

# Summary

## Changes

**Draft flow (`QuestionsCallout.tsx`)** — Answers previously came only from the document
(`documentAnswers(questions)`), so a click didn't visually select until the host round-tripped a
new revision. Added a `pending` overlay state, keyed by question id, that is set on every
`onAnswer` call (including Clear) and overlaid onto the document's answers/other-open state for
rendering. Each pending entry is reconciled (removed) once the document matches it, or after a
4-second safety-valve timeout if the host never echoes back.

**Chat flow (`ChatQuestionsBlock.tsx` / `questionsContext.ts`)** — `handleSubmit` previously called
`onSubmit(...)` then immediately `store?.clear(blockKey)`, discarding the draft before the document
had the answer, which reset the form to empty/unanswered until the host wrote back. Added an
optional `submitted?: boolean` field to `QuestionsDraftState`; Submit now sets `submitted: true`
instead of clearing the store, and the block renders a read-only view of the submitted answers.
`QuestionsCallout`'s existing "document has all answers" branch takes over once the document
catches up, and a new `useEffect` there clears the draft store entry at that point.

## API Changes

None. No C# changes; `QuestionAnswers` and `questionsSource.ts` untouched, as scoped by the plan.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx`
- `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsContext.ts`
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilQuestions/ChatQuestionsBlock.tsx`
- `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx` (tests)
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx` (tests)

## Manual Testing

Not performed — this is a frontend widget change with no local dev server / browser available in
this execution environment. Verified via the vitest suites specified in the plan's Tests section
(`PlanMarkdown.questions.test.tsx`, `ChatWidget.questions.test.tsx`, `TendrilQuestions.test.tsx`),
which cover the optimistic-select, multi-select, free-text, Clear, reconciliation, and timeout
scenarios for the draft flow, and the submit/remount/document-takeover/multi-message scenarios for
the chat flow. Full frontend regression suite and a scoped .NET regression filter were also run;
see `Verification/DotnetTest.md` for details. Playwright specs are explicitly out of scope per the
plan.

---
## Commits
- 026b4ab1 Show plan-draft question answers optimistically (Plan 00479)
- bcb0f5fa Keep submitted chat question answers on screen (Plan 00479)

---
Created using [Ivy Tendril](https://ivy.app).
