### PR TITLE
[00483] Stop Plan View Scrolling to Top While Jobs Run

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/PlansContentViewRefreshTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/PlansContentViewRefreshTests.cs
@@ -176,4 +176,18 @@ public class PlansContentViewRefreshTests
         {
         }
     }
+
+    // A revalidation (loading: true, hasLoadedContent: true) keeping the last-known-good content mounted
+    // is the regression #2650 is about: without it the placeholder swaps in a different widget, unmounting
+    // PlanMarkdown's scroll box and throwing the reader back to the top of the plan.
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    public void ShouldShowLoadingPlaceholder_OnlyForAFetchWithNothingYetToShow(
+        bool loading, bool hasLoadedContent, bool expected)
+    {
+        Assert.Equal(expected, PlansContentView.ShouldShowLoadingPlaceholder(loading, hasLoadedContent));
+    }
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.scroll.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.scroll.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { PlanMarkdown } from "./PlanMarkdown";
+
+// #2650: the Plans app used to swap the document for a "Loading..." placeholder on every background
+// revalidation, unmounting PlanMarkdown and its .pmv-shell scroll box with it and throwing the reader
+// back to the top of the plan. The server-side fix keeps PlanMarkdown mounted across a revalidation;
+// this test asserts the invariant that fix relies on - a mounted PlanMarkdown does not reset its own
+// scroll offset when its content/annotations props change underneath it.
+describe("PlanMarkdown scroll offset across a revalidation", () => {
+  it("keeps .pmv-shell scrollTop when content and annotations props change", () => {
+    const { container, rerender } = render(
+      <PlanMarkdown id="w1" content="# First\n\nSome content." annotations={[]} />,
+    );
+
+    const shell = container.querySelector(".pmv-shell") as HTMLDivElement;
+    expect(shell).not.toBeNull();
+
+    let scrollTop = 240;
+    Object.defineProperty(shell, "scrollTop", {
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = v;
+      },
+      configurable: true,
+    });
+
+    rerender(
+      <PlanMarkdown id="w1" content="# First\n\nSome different content." annotations={[]} />,
+    );
+
+    expect(shell.scrollTop).toBe(240);
+  });
+});

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -121,6 +121,7 @@ public class ContentView(
 
         var planWatcher = UseService<Ivy.Tendril.Services.Plans.IPlanWatcherService>();
         var localRefresh = UseRefreshToken();
+        var hasLoadedContent = UseRef(false);
 
         var planContentQuery = UseQuery<PlanContentData, string>(
             selectedPlan?.FolderPath ?? "",
@@ -190,6 +191,7 @@ public class ContentView(
         if (lastPlanId.Value != (selectedPlan?.Id ?? -1))
         {
             lastPlanId.Set(selectedPlan?.Id ?? -1);
+            hasLoadedContent.Value = false;
             selectedTab.Set(PlanTab);
             isEditing.Set(false);
             var loaded = selectedPlan != null
@@ -307,13 +309,14 @@ public class ContentView(
         var tabs = new List<PlanTabDto> { new(PlanTab, "Plan"), new(DetailsTab, "Details") };
         object tabContent;
 
-        if (planContentQuery.Loading)
+        if (ShouldShowLoadingPlaceholder(planContentQuery.Loading, hasLoadedContent.Value))
         {
             tabContent = Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                          | Text.Muted("Loading...");
         }
         else
         {
+            if (!planContentQuery.Loading) hasLoadedContent.Value = true;
             var planData = planContentQuery.Value;
             var gitData = planData.GitData ?? new GitTabDataBuilder.GitTabData([], []);
             var gitItemCount = GitTabDataBuilder.CountGitItems(gitData, selectedPlan);
@@ -462,6 +465,15 @@ public class ContentView(
     ///     <c>UseInboxAutoRefresh</c> use, so a plan mutation that raises several events costs one rebuild.
     /// </summary>
     internal static readonly TimeSpan PlanRefreshWindow = TimeSpan.FromMilliseconds(400);
+
+    /// <summary>
+    ///     Whether the tab body should be the "Loading..." placeholder rather than the content. Only a
+    ///     fetch with nothing yet to show qualifies: a revalidation keeps the last-known-good content,
+    ///     because swapping the document for a placeholder unmounts PlanMarkdown and its scroll box with
+    ///     it, throwing the reader back to the top of the plan (#2650).
+    /// </summary>
+    internal static bool ShouldShowLoadingPlaceholder(bool loading, bool hasLoadedContent) =>
+        loading && !hasLoadedContent;
 
     /// <summary>
     ///     Revalidates the plan content when the plan on screen changes on disk, owning a coalescer on the


### PR DESCRIPTION
Fixes #2650

# Summary

## Changes

The Plans app's content view swapped the whole tab body for a "Loading..." placeholder on every
background revalidation (30s poll, watcher rescans, job completion), not just the first fetch. This
unmounted `PlanMarkdown` and its scroll box, throwing the reader back to the top of whatever plan
they were reading (#2650). `ContentView` now tracks whether content has already loaded once and
only shows the placeholder for a fetch with nothing yet to display; a revalidation keeps the
last-known-good content mounted.

## API Changes

Added `internal static bool ShouldShowLoadingPlaceholder(bool loading, bool hasLoadedContent)` to
`ContentView` in `src/Ivy.Tendril/Apps/Plans/ContentView.cs`. Internal to the assembly (exposed to
`Ivy.Tendril.Test` via existing `InternalsVisibleTo`), not a public API.

## Files Modified

- `src/Ivy.Tendril/Apps/Plans/ContentView.cs` — new `hasLoadedContent` ref, reset on plan switch,
  new `ShouldShowLoadingPlaceholder` predicate gating the "Loading..." placeholder.
- `src/Ivy.Tendril.Test/Apps/PlansContentViewRefreshTests.cs` — new theory covering all four
  `(loading, hasLoadedContent)` combinations of the predicate.
- `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.scroll.test.tsx` (new) — asserts
  `.pmv-shell` scrollTop survives a `content`/`annotations` prop change on a mounted `PlanMarkdown`.

## Manual Testing

1. Run the Tendril app and open the Plans app.
2. Open a plan with a long revision document, scroll partway down.
3. Trigger a background revalidation while the plan is open — e.g. run a job that touches the
   plans folder (create/execute another plan), or just wait ~30s for the poll timer.
4. The plan document should stay at its current scroll position instead of jumping to the top, and
   the Git tab (if present) should stay selectable throughout.

---
Commits:
- e79b5fc1 Keep plan content mounted during background revalidation (Plan 00483)
- 1ebf3353 Add tests for plan content placeholder gating and scroll preservation (Plan 00483)

---
Created using [Ivy Tendril](https://ivy.app).
