### PR TITLE
[00457] Enable Answer Selection While a Chat Turn Is Streaming

### DIFF
--- a/src/Ivy.Tendril.Test/ChatExecutionServiceQuestionAnswersTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceQuestionAnswersTests.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Runtime;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+/// Covers the streaming-turn half of plan 00457: the live in-progress assistant message must be
+/// discoverable by id (<see cref="IChatExecutionService.GetStreamingMessageId"/>) and answers submitted
+/// while it is still streaming must land in the in-memory buffer so the periodic persist tick (and the
+/// final flush on completion/cancellation) don't clobber them.
+/// </summary>
+public class ChatExecutionServiceQuestionAnswersTests
+{
+    private sealed class TestSession : IAgentSession
+    {
+        private readonly System.Reactive.Subjects.Subject<AgentEvent> _events = new();
+        private readonly TaskCompletionSource<ResultEvent> _completion = new();
+
+        public string SessionId { get; } = "sess-questions-test";
+        public string AgentId { get; } = "codex";
+        public SessionState State => SessionState.Running;
+        public DateTimeOffset StartedAt { get; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset? CompletedAt => null;
+        public SessionMetadata? Metadata => null;
+        public IObservable<AgentEvent> Events => _events;
+        public IObservable<string>? RawOutput => null;
+        public IObservable<string>? RawStderr => null;
+        public ResultEvent? Result => null;
+        public bool SupportsPermissionResponse => false;
+        public bool SupportsQuestionResponse => false;
+        public bool SupportsMultiTurn => false;
+
+        public bool HasObservers => _events.HasObservers;
+
+        public void Emit(AgentEvent evt) => _events.OnNext(evt);
+
+        public void Complete(ResultEvent result) => _completion.TrySetResult(result);
+
+        public async Task<ResultEvent> WaitForCompletionAsync(CancellationToken ct = default)
+        {
+            using var reg = ct.Register(() => _completion.TrySetCanceled(ct));
+            return await _completion.Task;
+        }
+
+        public Task StopAsync(CancellationToken ct = default)
+        {
+            _completion.TrySetCanceled();
+            return Task.CompletedTask;
+        }
+
+        public Task KillAsync()
+        {
+            _completion.TrySetCanceled();
+            return Task.CompletedTask;
+        }
+
+        public Task RespondToPermissionAsync(string requestId, PermissionDecision decision, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task RespondToQuestionAsync(string questionId, QuestionResponse response, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task SendFollowUpAsync(string message, CancellationToken ct = default) => throw new NotSupportedException();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class TestAgentRunnerWrapper : IAgentRunner
+    {
+        private readonly IAgentRunner _inner;
+        private readonly IAgentSession _session;
+
+        public TestAgentRunnerWrapper(IAgentRunner inner, IAgentSession session)
+        {
+            _inner = inner;
+            _session = session;
+        }
+
+        public Task<IAgentSession> LaunchAsync(AgentResolutionContext context, CancellationToken ct = default)
+            => Task.FromResult(_session);
+
+        public Task<ResultEvent> RunToCompletionAsync(AgentResolutionContext context, CancellationToken ct = default)
+            => _inner.RunToCompletionAsync(context, ct);
+
+        public IReadOnlyList<IAgentSession> ActiveSessions => _inner.ActiveSessions;
+        public IObservable<IAgentSession> Sessions => _inner.Sessions;
+        public Task StopAllAsync(CancellationToken ct = default) => _inner.StopAllAsync(ct);
+        public IReadOnlyList<string> RegisteredAgents => _inner.RegisteredAgents;
+        public IAgentCli GetCli(string agentId) => _inner.GetCli(agentId);
+        public IEventParser GetParser(string agentId) => _inner.GetParser(agentId);
+        public IAgentHealthCheck GetHealthCheck(string agentId) => _inner.GetHealthCheck(agentId);
+        public IAgentDescriptor GetDescriptor(string agentId) => _inner.GetDescriptor(agentId);
+        public IFailureAnalyzer? GetFailureAnalyzer(string agentId) => _inner.GetFailureAnalyzer(agentId);
+        public ISessionCostParser? GetCostParser(string agentId) => _inner.GetCostParser(agentId);
+        public IAgentPty? GetPty(string agentId) => _inner.GetPty(agentId);
+        public IModelCatalogProvider? GetModelCatalog(string agentId) => _inner.GetModelCatalog(agentId);
+        public IEnumerable<IModelCatalogProvider> ModelCatalogs => _inner.ModelCatalogs;
+    }
+
+    private static (ChatExecutionService ExecService, ChatHistoryService ChatService, TestSession Session, string TempDir) CreateHarness()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilQuestionAnswersTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var configService = new ConfigService(new TendrilSettings { CodingAgent = "codex" }, tempDir);
+        var chatService = new ChatHistoryService(configService);
+        var session = new TestSession();
+        var agentRunner = new TestAgentRunnerWrapper(TestAgentRunner.Create(), session);
+        var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+        var execService = new ChatExecutionService(
+            configService,
+            chatService,
+            agentRunner,
+            namingService,
+            new JsonEventSerializer());
+
+        return (execService, chatService, session, tempDir);
+    }
+
+    private static async Task WaitUntilGeneratingAndSubscribed(ChatExecutionService execService, TestSession session, string sessionId)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while ((!execService.IsGenerating(sessionId) || !session.HasObservers) && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(20);
+        }
+        Assert.True(execService.IsGenerating(sessionId));
+        Assert.True(session.HasObservers);
+    }
+
+    [Fact]
+    public async Task GetStreamingMessageId_ReturnsTheInProgressAssistantMessageId_ThenNullOnceItSettles()
+    {
+        var (execService, chatService, session, tempDir) = CreateHarness();
+        try
+        {
+            var chatSession = chatService.CreateSession("codex", "gpt-5.6-sol");
+            var sendTask = execService.SendMessageAsync(chatSession.Id, "Where should we deploy?");
+
+            await WaitUntilGeneratingAndSubscribed(execService, session, chatSession.Id);
+
+            var streamingMessageId = execService.GetStreamingMessageId(chatSession.Id);
+            Assert.NotNull(streamingMessageId);
+
+            var assistantMsg = chatService.GetSession(chatSession.Id)?.Messages
+                .FirstOrDefault(m => m.Role == "assistant");
+            Assert.NotNull(assistantMsg);
+            Assert.Equal(assistantMsg!.Id, streamingMessageId);
+
+            await execService.CancelAsync(chatSession.Id);
+
+            Assert.Null(execService.GetStreamingMessageId(chatSession.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void GetStreamingMessageId_WithNoActiveExecution_ReturnsNull()
+    {
+        var (execService, chatService, _, tempDir) = CreateHarness();
+        try
+        {
+            var chatSession = chatService.CreateSession("codex", "gpt-5.6-sol");
+            Assert.Null(execService.GetStreamingMessageId(chatSession.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ApplyQuestionAnswers_PatchesTheLiveBufferSoTheAnswerSurvivesTheFinalFlush()
+    {
+        var (execService, chatService, session, tempDir) = CreateHarness();
+        try
+        {
+            var chatSession = chatService.CreateSession("codex", "gpt-5.6-sol");
+            var sendTask = execService.SendMessageAsync(chatSession.Id, "Where should we deploy?");
+
+            await WaitUntilGeneratingAndSubscribed(execService, session, chatSession.Id);
+
+            const string questionsText =
+                "Which env?\n\n```questions\n- id: target_env\n  title: Which env?\n  options:\n    - title: Staging\n      value: staging\n```\n";
+            session.Emit(new TextEvent
+            {
+                Kind = AgentEventKind.Text,
+                Text = questionsText,
+                IsDelta = false,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+
+            // The event handler runs synchronously off the Rx subject, but give it a moment either way.
+            var bufferedDeadline = DateTime.UtcNow.AddSeconds(2);
+            while (!execService.GetStreamSnapshot(chatSession.Id).Contains("target_env") && DateTime.UtcNow < bufferedDeadline)
+            {
+                await Task.Delay(20);
+            }
+            Assert.Contains("target_env", execService.GetStreamSnapshot(chatSession.Id));
+
+            var answers = new Dictionary<string, string[]>
+            {
+                ["target_env"] = ["staging"]
+            };
+            execService.ApplyQuestionAnswers(chatSession.Id, answers);
+
+            // The submitted answer must be visible in the live buffer immediately, before any persist tick runs.
+            Assert.Contains("answer: staging", execService.GetStreamSnapshot(chatSession.Id));
+
+            // Ending the turn flushes the live buffer into the persisted message; the answer must not be
+            // reverted by that flush, which is exactly the bug this plan fixes.
+            await execService.CancelAsync(chatSession.Id);
+
+            var assistantMsg = chatService.GetSession(chatSession.Id)?.Messages
+                .FirstOrDefault(m => m.Role == "assistant");
+            Assert.NotNull(assistantMsg);
+            Assert.Contains("answer: staging", assistantMsg!.Content);
+            Assert.NotNull(assistantMsg.RawStream);
+            Assert.Contains("answer: staging", assistantMsg.RawStream);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ApplyQuestionAnswers_WithNoActiveExecution_DoesNotThrow()
+    {
+        var (execService, chatService, _, tempDir) = CreateHarness();
+        try
+        {
+            var chatSession = chatService.CreateSession("codex", "gpt-5.6-sol");
+            var answers = new Dictionary<string, string[]> { ["target_env"] = ["staging"] };
+
+            execService.ApplyQuestionAnswers(chatSession.Id, answers);
+
+            await Task.CompletedTask;
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test/PlanChatTests.cs
+++ b/src/Ivy.Tendril.Test/PlanChatTests.cs
@@ -205,6 +205,7 @@ public class PlanChatTests
 #pragma warning restore CS0067
         public bool IsGenerating(string sessionId) => false;
         public string GetStreamSnapshot(string sessionId) => string.Empty;
+        public string? GetStreamingMessageId(string sessionId) => null;
         public IObservable<string> GetLiveStreamObservable(string sessionId) => System.Reactive.Linq.Observable.Empty<string>();
 
         public Task SendMessageAsync(string sessionId, string prompt, IReadOnlyList<ChatAttachmentDto>? attachments = null,
@@ -216,6 +217,7 @@ public class PlanChatTests
 
         public Task CancelAsync(string sessionId) => Task.CompletedTask;
         public Task InterruptAsync(string sessionId) => Task.CompletedTask;
+        public void ApplyQuestionAnswers(string sessionId, IReadOnlyDictionary<string, string[]> answers) { }
 
         public Task NotifyPlanEditAsync(string planFolderName, string summary, string? reason = null,
             string? sourceChatSessionId = null, string? revisionFile = null, PlanEditOrigin origin = PlanEditOrigin.Chat)
@@ -371,6 +373,7 @@ public class PlanChatTests
 #pragma warning restore CS0067
         public bool IsGenerating(string sessionId) => false;
         public string GetStreamSnapshot(string sessionId) => string.Empty;
+        public string? GetStreamingMessageId(string sessionId) => null;
         public IObservable<string> GetLiveStreamObservable(string sessionId) => System.Reactive.Linq.Observable.Empty<string>();
 
         public Task SendMessageAsync(string sessionId, string prompt, IReadOnlyList<ChatAttachmentDto>? attachments = null,
@@ -381,6 +384,8 @@ public class PlanChatTests
 
         public Task CancelAsync(string sessionId) => throw new InvalidOperationException("Simulated failure");
         public Task InterruptAsync(string sessionId) => throw new InvalidOperationException("Simulated failure");
+        public void ApplyQuestionAnswers(string sessionId, IReadOnlyDictionary<string, string[]> answers) =>
+            throw new InvalidOperationException("Simulated failure");
 
         public Task NotifyPlanEditAsync(string planFolderName, string summary, string? reason = null,
             string? sourceChatSessionId = null, string? revisionFile = null, PlanEditOrigin origin = PlanEditOrigin.Chat)

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -113,6 +113,7 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Prop] public bool SupportsEffort { get; init; } = true;
     [Prop] public bool IsStreaming { get; init; } = false;
     [Prop] public string? StreamingText { get; init; }
+    [Prop] public string? StreamingMessageId { get; init; }
     [Prop] public List<ChatQueuedMessageDto> QueuedMessages { get; init; } = new();
     [Prop] public List<ChatJobDto>? RunningJobs { get; init; }
     [Prop] public string? Greeting { get; init; }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx
@@ -322,3 +322,156 @@ describe("ChatWidget Interactive Question Draft Persistence", () => {
     expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
   });
 });
+
+describe("ChatWidget Interactive Question — Streaming Live Row", () => {
+  beforeEach(() => {
+    setupChatWidgetTestEnvironment();
+  });
+
+  const deployQuestion = questionsFence(
+    "- id: deploy_target",
+    "  title: Which environment should we deploy to?",
+    "  options:",
+    "    - title: Staging Environment",
+    "      value: staging",
+    "    - title: Production Environment",
+    "      value: prod",
+  );
+
+  const streamingTextFor = (content: string) =>
+    JSON.stringify({ kind: "text", text: content, delta: false });
+
+  const emptySession = (id: string): ChatSessionDto => ({
+    id,
+    title: id,
+    agentId: "claude",
+    modelId: "opus",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    messages: [],
+  });
+
+  it("renders the live streaming row interactively when a streamingMessageId is supplied", () => {
+    const handleEvent = vi.fn();
+    const session = emptySession("sess-live");
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-live"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText={streamingTextFor(deployQuestion)}
+        streamingMessageId="msg-live-1"
+      />,
+    );
+
+    const submitBtn = screen.getByRole("button", { name: /Submit Response/i });
+    expect(submitBtn).toBeDisabled();
+
+    const stagingRadio = screen.getByRole("radio", { name: /Staging Environment/i });
+    fireEvent.click(stagingRadio);
+    expect(stagingRadio).toBeChecked();
+    expect(submitBtn).not.toBeDisabled();
+
+    fireEvent.click(submitBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnAnswerQuestion",
+      "test-chat",
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: "sess-live",
+          messageId: "msg-live-1",
+          answers: { deploy_target: ["staging"] },
+        }),
+      ]),
+    );
+  });
+
+  it("falls back to read-only rendering on the live row when no streamingMessageId is supplied", () => {
+    const session = emptySession("sess-live-none");
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-live-none"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText={streamingTextFor(deployQuestion)}
+      />,
+    );
+
+    expect(screen.getByText("Which environment should we deploy to?")).toBeInTheDocument();
+    expect(screen.getByText("Not answered (agent decided)")).toBeInTheDocument();
+    expect(screen.queryByRole("radio", { name: /Staging Environment/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Submit Response/i })).not.toBeInTheDocument();
+  });
+
+  it("carries a draft made on the live row over to the settled row once the turn completes", () => {
+    const session = emptySession("sess-live-settle");
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-live-settle"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText={streamingTextFor(deployQuestion)}
+        streamingMessageId="msg-live-2"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+
+    const settledSession: ChatSessionDto = {
+      ...session,
+      messages: [
+        {
+          id: "msg-live-2",
+          role: "assistant",
+          content: deployQuestion,
+          timestamp: "12:00 PM",
+        },
+      ],
+    };
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-live-settle"
+        sessions={[settledSession]}
+        events={["OnAnswerQuestion"]}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+  });
+
+  it("selects an option on the live row when clicking its card, not just the radio", () => {
+    const session = emptySession("sess-live-card");
+
+    const { container } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-live-card"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText={streamingTextFor(deployQuestion)}
+        streamingMessageId="msg-live-3"
+      />,
+    );
+
+    const card = container.querySelector<HTMLElement>(".tq-option");
+    expect(card).not.toBeNull();
+    fireEvent.click(card!);
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -185,6 +185,7 @@ export function ChatWidget({
   supportsEffort = true,
   isStreaming = false,
   streamingText = "",
+  streamingMessageId,
   queuedMessages: queuedMessagesProp,
   runningJobs = [],
   greeting,
@@ -875,11 +876,20 @@ export function ChatWidget({
                 );
               })}
 
-              {effectiveIsStreaming && (
-                <div className="chat-message-row assistant chat-message-row--live">
-                  <AssistantTurn stream={streamingText} live />
-                </div>
-              )}
+              {effectiveIsStreaming &&
+                (streamingMessageId ? (
+                  <div className="chat-message-row assistant chat-message-row--live">
+                    <QuestionsDraftContext.Provider value={draftStoreFor(streamingMessageId)}>
+                      <QuestionsSubmitContext.Provider value={submitHandlerFor(streamingMessageId)}>
+                        <AssistantTurn stream={streamingText} live />
+                      </QuestionsSubmitContext.Provider>
+                    </QuestionsDraftContext.Provider>
+                  </div>
+                ) : (
+                  <div className="chat-message-row assistant chat-message-row--live">
+                    <AssistantTurn stream={streamingText} live />
+                  </div>
+                ))}
             </>
           ) : (
             <div className="chat-empty-state">

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts
@@ -105,6 +105,8 @@ export interface ChatWidgetProps {
   supportsEffort?: boolean;
   isStreaming?: boolean;
   streamingText?: string;
+  /** Id of the in-progress assistant message the live row previews. Absent on an older host that hasn't sent it — the live row then stays read-only. */
+  streamingMessageId?: string;
   queuedMessages?: ChatQueuedMessageDto[];
   runningJobs?: ChatJobDto[];
   /** Shown above the headline while the conversation is empty, e.g. "Good Morning, Joel!". */

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -301,6 +301,7 @@ public class ChatApp : ViewBase
         var activeSession = currentSessionId != null ? chatService.GetSession(currentSessionId) : null;
         var isSessionGenerating = currentSessionId != null && executionService.IsGenerating(currentSessionId);
         var streamSnapshot = isSessionGenerating ? executionService.GetStreamSnapshot(currentSessionId!) : string.Empty;
+        var streamingMessageId = isSessionGenerating ? executionService.GetStreamingMessageId(currentSessionId!) : null;
 
         var currentModelOptions = GetModelsForAgent(agentRunner, selectedAgent.Value);
         var effectiveModel = ResolveModel(currentModelOptions, selectedModel.Value);
@@ -418,6 +419,7 @@ public class ChatApp : ViewBase
             supportsEffort,
             isSessionGenerating,
             streamSnapshot,
+            streamingMessageId,
             DashboardApp.BuildGreeting(DateTime.Now),
             "What Are We Producing Today?",
             chatService,

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -29,6 +29,7 @@ public class ContentView(
     bool supportsEffort,
     bool isStreaming,
     string streamingText,
+    string? streamingMessageId,
     string greeting,
     string headline,
     IChatHistoryService chatService,
@@ -133,6 +134,7 @@ public class ContentView(
             SupportsEffort = supportsEffort,
             IsStreaming = isStreaming,
             StreamingText = streamingText,
+            StreamingMessageId = streamingMessageId,
             QueuedMessages = queuedMessageDtos,
             RunningJobs = runningJobs,
             Greeting = greeting,
@@ -264,6 +266,10 @@ public class ContentView(
                 if (e.Value != null)
                 {
                     chatService.ApplyQuestionAnswers(e.Value.SessionId, e.Value.MessageId, e.Value.Answers);
+                    if (executionService.IsGenerating(e.Value.SessionId))
+                    {
+                        executionService.ApplyQuestionAnswers(e.Value.SessionId, e.Value.Answers);
+                    }
                     sessionVersion.Set(v => v + 1);
                     if (!string.IsNullOrWhiteSpace(e.Value.ResponseText))
                     {

--- a/src/Ivy.Tendril/Apps/Views/PlanChatView.cs
+++ b/src/Ivy.Tendril/Apps/Views/PlanChatView.cs
@@ -102,6 +102,7 @@ public class PlanChatView(PlanFile plan) : ViewBase
 
         var isGenerating = session != null && executionService.IsGenerating(session.Id);
         var streamSnapshot = isGenerating ? executionService.GetStreamSnapshot(session!.Id) : string.Empty;
+        var streamingMessageId = isGenerating ? executionService.GetStreamingMessageId(session!.Id) : null;
         var sessionDtos = session != null
             ? [ChatApp.ToSessionDto(session, true, executionService, jobService, chatService)]
             : new List<ChatSessionDto>();
@@ -146,6 +147,7 @@ public class PlanChatView(PlanFile plan) : ViewBase
             supportsEffort,
             isGenerating,
             streamSnapshot,
+            streamingMessageId,
             $"#{plan.Id} {plan.Title}",
             Headline,
             chatService,

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -236,6 +236,87 @@ public sealed class ChatExecutionService : IChatExecutionService
         return string.Empty;
     }
 
+    public string? GetStreamingMessageId(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return null;
+        return _activeExecutions.TryGetValue(sessionId, out var exec) ? exec.AssistantMessageId : null;
+    }
+
+    public void ApplyQuestionAnswers(string sessionId, IReadOnlyDictionary<string, string[]> answers)
+    {
+        if (string.IsNullOrEmpty(sessionId) || answers == null || answers.Count == 0) return;
+        if (!_activeExecutions.TryGetValue(sessionId, out var exec)) return;
+
+        lock (exec.Lock)
+        {
+            if (!string.IsNullOrEmpty(exec.LastText))
+            {
+                var lastText = exec.LastText;
+                foreach (var (qId, ansValues) in answers)
+                {
+                    if (QuestionAnswers.TryApply(lastText, new QuestionAnswer(qId, ansValues), out var updated))
+                    {
+                        lastText = updated;
+                    }
+                }
+                exec.LastText = lastText;
+            }
+
+            for (int i = 0; i < exec.RawLines.Count; i++)
+            {
+                var line = exec.RawLines[i].Trim();
+                if (string.IsNullOrEmpty(line)) continue;
+                try
+                {
+                    var node = System.Text.Json.Nodes.JsonNode.Parse(line);
+                    if (node is not System.Text.Json.Nodes.JsonObject obj) continue;
+
+                    bool lineChanged = false;
+                    if (obj.TryGetPropertyValue("text", out var textNode) && textNode != null)
+                    {
+                        var textVal = textNode.GetValue<string>();
+                        foreach (var (qId, ansValues) in answers)
+                        {
+                            if (QuestionAnswers.TryApply(textVal, new QuestionAnswer(qId, ansValues), out var updatedTextVal))
+                            {
+                                textVal = updatedTextVal;
+                                lineChanged = true;
+                            }
+                        }
+                        if (lineChanged) obj["text"] = textVal;
+                    }
+                    if (obj.TryGetPropertyValue("response", out var respNode) && respNode != null)
+                    {
+                        var respVal = respNode.GetValue<string>();
+                        bool respChanged = false;
+                        foreach (var (qId, ansValues) in answers)
+                        {
+                            if (QuestionAnswers.TryApply(respVal, new QuestionAnswer(qId, ansValues), out var updatedRespVal))
+                            {
+                                respVal = updatedRespVal;
+                                respChanged = true;
+                            }
+                        }
+                        if (respChanged)
+                        {
+                            obj["response"] = respVal;
+                            lineChanged = true;
+                        }
+                    }
+
+                    if (lineChanged)
+                    {
+                        exec.RawLines[i] = obj.ToJsonString();
+                    }
+                }
+                catch
+                {
+                    // ignore malformed lines
+                }
+            }
+        }
+    }
+
     public IObservable<string> GetLiveStreamObservable(string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return Observable.Empty<string>();
@@ -516,8 +597,6 @@ public sealed class ChatExecutionService : IChatExecutionService
         // Launch background agent execution
         var executionTask = Task.Run(async () =>
         {
-            string? lastTextEvent = null;
-
             try
             {
                 var effortOverride = targetEffort != "default" ? AgentProviderFactory.ParseEffort(targetEffort) : null;
@@ -554,18 +633,9 @@ public sealed class ChatExecutionService : IChatExecutionService
                         {
                             lock (activeExec.Lock)
                             {
-                                if (textEvt.IsDelta)
-                                {
-                                    lastTextEvent = (lastTextEvent ?? "") + textEvt.Text;
-                                }
-                                else
-                                {
-                                    lastTextEvent = textEvt.Text;
-                                }
-                            }
-                            lock (activeExec.Lock)
-                            {
-                                activeExec.LastText = textEvt.Text;
+                                activeExec.LastText = textEvt.IsDelta
+                                    ? (activeExec.LastText ?? "") + textEvt.Text
+                                    : textEvt.Text;
                             }
                         }
 
@@ -605,7 +675,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                 string? fullRawStream = null;
                 lock (activeExec.Lock)
                 {
-                    collectedText = lastTextEvent ?? activeExec.LastText;
+                    collectedText = activeExec.LastText;
 
                     // Reconcile any unclosed tool calls
                     var missingResults = ToolStreamReconciler.BuildMissingResultLines(
@@ -646,7 +716,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                     : $"Agent execution timed out: total timeout limit of {(int)totalTimeout.TotalMinutes} minutes exceeded.";
                 lock (activeExec.Lock)
                 {
-                    collectedText = lastTextEvent ?? activeExec.LastText;
+                    collectedText = activeExec.LastText;
 
                     // Reconcile any unclosed tool calls
                     var missingResults = ToolStreamReconciler.BuildMissingResultLines(
@@ -695,7 +765,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                 string? collectedText = null;
                 lock (activeExec.Lock)
                 {
-                    collectedText = lastTextEvent ?? activeExec.LastText;
+                    collectedText = activeExec.LastText;
 
                     // Reconcile any unclosed tool calls
                     var missingResults = ToolStreamReconciler.BuildMissingResultLines(

--- a/src/Ivy.Tendril/Services/IChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/IChatExecutionService.cs
@@ -12,6 +12,7 @@ public interface IChatExecutionService : IDisposable
     event Action<string>? StreamUpdated;
     bool IsGenerating(string sessionId);
     string GetStreamSnapshot(string sessionId);
+    string? GetStreamingMessageId(string sessionId);
     IObservable<string> GetLiveStreamObservable(string sessionId);
     Task SendMessageAsync(
         string sessionId,
@@ -24,6 +25,14 @@ public interface IChatExecutionService : IDisposable
         CancellationToken ct = default);
     Task CancelAsync(string sessionId);
     Task InterruptAsync(string sessionId);
+
+    /// <summary>
+    ///     Patches the buffer of an in-progress execution so a mid-run question answer survives the
+    ///     next persist tick, which otherwise overwrites the stored message's <c>Content</c>/
+    ///     <c>RawStream</c> from this same buffer roughly once a second. No-ops when
+    ///     <paramref name="sessionId"/> has no active execution.
+    /// </summary>
+    void ApplyQuestionAnswers(string sessionId, IReadOnlyDictionary<string, string[]> answers);
 
     /// <summary>
     ///     Announces a direct edit to a plan — one made without a job, from a chat or the CLI — to


### PR DESCRIPTION
Fixes #2642

# Summary — Plan 00457: Enable Answer Selection While a Chat Turn Is Streaming

Fixes [issue #2642](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/2642): the chat
questions picker rendered read-only while a turn was still streaming, only becoming interactive
once the entire agent run finished.

## API changes

- `IChatExecutionService`:
  - `string? GetStreamingMessageId(string sessionId)` — returns the in-progress assistant
    message id for an active execution, or `null` if none.
  - `void ApplyQuestionAnswers(string sessionId, IReadOnlyDictionary<string, string[]> answers)`
    — patches an active execution's in-memory stream buffer (`RawLines`/`LastText`) so a mid-run
    answer survives the periodic persist tick and the final flush on completion/cancel/error.
- `ChatWidget` (Ivy widget): new `StreamingMessageId` prop, threaded through from the frontend
  `streamingMessageId` prop on `<ChatWidget>`.
- `ContentView` constructor: new `string? streamingMessageId` parameter, supplied by both
  `ChatApp.cs` and `PlanChatView.cs` (the plan side panel shares the same code path and bug).

## Files modified

**Backend**
- `src/Ivy.Tendril/Services/IChatExecutionService.cs` — new interface members.
- `src/Ivy.Tendril/Services/ChatExecutionService.cs` — implementations of both new members, plus
  a bugfix consolidating two duplicate "latest accumulated text" trackers into one.
- `src/Ivy.Tendril/Apps/Chat/ChatApp.cs`, `src/Ivy.Tendril/Apps/Chat/ContentView.cs`,
  `src/Ivy.Tendril/Apps/Views/PlanChatView.cs` — thread the streaming message id through, and call
  `ApplyQuestionAnswers` from the `OnAnswerQuestion` handler when the session is still generating.
- `src/Ivy.Tendril.Widgets/ChatWidget.cs` — new `StreamingMessageId` prop.
- `src/Ivy.Tendril.Test/PlanChatTests.cs` — updated fake `IChatExecutionService` implementations
  to satisfy the new interface members.
- `src/Ivy.Tendril.Test/ChatExecutionServiceQuestionAnswersTests.cs` (new) — 4 tests covering
  `GetStreamingMessageId` and `ApplyQuestionAnswers`, using a fake agent runner/session.

**Frontend**
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx` — the live streaming row is now
  wrapped in `QuestionsDraftContext`/`QuestionsSubmitContext` keyed by `streamingMessageId` when
  present; falls back to the prior read-only rendering when absent (backward compatible).
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/types.ts` — new `streamingMessageId` prop type.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.questions.test.tsx` — 4 new tests
  (interactive live row, read-only fallback, draft continuity across streaming→settled, card
  click).

## Bugfix beyond the plan's literal steps

While implementing step 3 (patch the live buffer), found that `ChatExecutionService.SendMessageAsync`'s
background task tracked "latest accumulated text" in two places: the patchable
`activeExec.LastText`, and a closure-local `lastTextEvent` that was not patchable. All three
finalize paths (success, `OperationCanceledException`, and generic exception) preferred the stale
`lastTextEvent` over the patched value, so an answer applied via `ApplyQuestionAnswers` was
silently reverted the moment the turn actually ended — success, cancel, or error. Consolidated
both trackers onto the single patchable `activeExec.LastText` field. This was necessary for the
plan's stated goal (the submitted answer must not be reverted) to actually hold; without it, the
fix would have appeared to work during the ~1-second window before the turn's own completion
handler ran, then silently failed.

## Manual testing steps

1. Start a chat turn with an agent/prompt likely to emit a `\`\`\`questions` fence mid-run (e.g. a
   research prompt that asks a clarifying question before continuing).
2. While the turn is still generating (status shows "Thinking…"/spinner), confirm the questions
   block now renders with radio buttons/checkboxes and an enabled Submit button once an option is
   selected, instead of static "Not answered (agent decided)" text.
3. Select an answer and click Submit while still generating. Confirm:
   - The choice is reflected immediately (no revert) in the UI.
   - After the turn finishes, reload the page (or switch sessions and back) and confirm the answer
     is still recorded — it was patched into the persisted transcript, not just the client draft.
4. Repeat from the plan's side panel (`PlanChatView`), which shares the same code path.
5. Confirm an older/unrelated host that doesn't send `streamingMessageId` still renders the live
   row read-only (no crash, no interactive controls) — this path is exercised by an automated test
   but is worth a quick sanity check if touching this area again.

## Test results

- Backend: `dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --configuration Release --filter "FullyQualifiedName~ChatHistoryServiceTests|FullyQualifiedName~QuestionAnswersTests|FullyQualifiedName~ChatExecutionServiceQuestionAnswersTests|FullyQualifiedName~PlanChatTests"` — 112/112 passed.
- Frontend: `npx vitest run src/ChatWidget/ChatWidget.questions.test.tsx src/TendrilQuestions/TendrilQuestions.test.tsx src/PlanMarkdown/PlanMarkdown.questions.test.tsx` — 67/67 passed.
- `dotnet build --configuration Release --warnaserror` on `Ivy.Tendril` and `Ivy.Tendril.Test` — 0 warnings, 0 errors.
- `dotnet format` on all three touched projects — no changes required.

---

## Commits

- f7f1d402 Surface the streaming message id and patch live answers server-side (plan 00457)
- b19290b7 Make the live streaming question row interactive (plan 00457)

---
Created using [Ivy Tendril](https://ivy.app).
