### PR TITLE
[00476] Resolve Symlinked Path Segments in Local File Root Check

### DIFF
--- a/src/Ivy.Tendril.Test/LocalFileGuardMiddlewareTests.cs
+++ b/src/Ivy.Tendril.Test/LocalFileGuardMiddlewareTests.cs
@@ -605,6 +605,30 @@ public class LocalFileGuardMiddlewareTests
         Assert.True(tracker.Called);
     }
 
+    [Fact]
+    public async Task PngViaSymlinkedDirectoryOutsideRoots_Returns404()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var home = CreateTempDir();
+        var outside = CreateTempDir();
+        var sharedLink = Path.Combine(home, "shared");
+        Directory.CreateSymbolicLink(sharedLink, outside);
+
+        var (middleware, context, tracker, _) = CreateMiddleware(tendrilHome: home);
+        context.Request.Path = "/ivy/local-file";
+        context.Request.Host = new HostString("localhost", 5000);
+        context.Request.QueryString = new QueryString($"?path={Path.Combine(sharedLink, "photo.png")}");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(tracker.Called);
+        Assert.Equal(404, context.Response.StatusCode);
+    }
+
     private static string CreateTempDir()
     {
         var dir = Path.Combine(Path.GetTempPath(), "tendril-lfgm-test-" + Guid.NewGuid().ToString("N"));

--- a/src/Ivy.Tendril.Test/LocalFileRootPolicyTests.cs
+++ b/src/Ivy.Tendril.Test/LocalFileRootPolicyTests.cs
@@ -9,7 +9,11 @@ public class LocalFileRootPolicyTests
     {
         var dir = Path.Combine(Path.GetTempPath(), "tendril-lfrp-test-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
-        return dir;
+
+        // The OS temp dir itself can sit behind a symlink (e.g. macOS's /var -> /private/var).
+        // Canonicalize so a raw root passed directly to TryResolve (bypassing ComputeRoots, which
+        // adds the resolved form separately) still matches the resolved request path.
+        return LocalFileRootPolicy.TryResolveRealPath(dir, out var real) ? real : dir;
     }
 
     [Fact]
@@ -147,5 +151,136 @@ public class LocalFileRootPolicyTests
         var allowed = LocalFileRootPolicy.TryResolve("/anything/at/all.png", new List<string>(), out _);
 
         Assert.False(allowed);
+    }
+
+    [Fact]
+    public void TryResolve_SymlinkedDirectoryInsideRootPointingOutside_Rejected()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var root = CreateTempDir();
+        var outside = CreateTempDir();
+        var outsideFile = Path.Combine(outside, "photo.png");
+        File.WriteAllText(outsideFile, "");
+        var sharedLink = Path.Combine(root, "shared");
+        Directory.CreateSymbolicLink(sharedLink, outside);
+
+        var allowed = LocalFileRootPolicy.TryResolve(Path.Combine(sharedLink, "photo.png"), new List<string> { root }, out _);
+
+        Assert.False(allowed);
+    }
+
+    [Fact]
+    public void TryResolve_SymlinkedDirectoryMidPathWithNestedFile_Rejected()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var root = CreateTempDir();
+        var outside = CreateTempDir();
+        var sharedLink = Path.Combine(root, "shared");
+        Directory.CreateSymbolicLink(sharedLink, outside);
+
+        var allowed = LocalFileRootPolicy.TryResolve(
+            Path.Combine(sharedLink, "nested", "photo.png"), new List<string> { root }, out _);
+
+        Assert.False(allowed);
+    }
+
+    [Fact]
+    public void TryResolve_SymlinkedDirectoryPointingBackInsideRoot_Allowed()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var root = CreateTempDir();
+        var real = Path.Combine(root, "real");
+        Directory.CreateDirectory(real);
+        File.WriteAllText(Path.Combine(real, "photo.png"), "");
+        var alias = Path.Combine(root, "alias");
+        Directory.CreateSymbolicLink(alias, real);
+
+        var allowed = LocalFileRootPolicy.TryResolve(Path.Combine(alias, "photo.png"), new List<string> { root }, out _);
+
+        Assert.True(allowed);
+    }
+
+    [Fact]
+    public void TryResolve_RootItselfBehindSymlink_Allowed()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var parent = CreateTempDir();
+        var real = Path.Combine(parent, "real");
+        Directory.CreateDirectory(real);
+        File.WriteAllText(Path.Combine(real, "photo.png"), "");
+        var link = Path.Combine(parent, "link");
+        Directory.CreateSymbolicLink(link, real);
+
+        var settings = new TendrilSettings
+        {
+            Security = new SecuritySettings { LocalFileRoots = new List<string> { link } }
+        };
+        var config = new ConfigService(settings, CreateTempDir());
+        var roots = LocalFileRootPolicy.ComputeRoots(config);
+
+        var allowed = LocalFileRootPolicy.TryResolve(Path.Combine(link, "photo.png"), roots, out _);
+
+        Assert.True(allowed);
+    }
+
+    [Fact]
+    public void TryResolve_SymlinkLoop_Rejected()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var root = CreateTempDir();
+        var a = Path.Combine(root, "a");
+        var b = Path.Combine(root, "b");
+        Directory.CreateSymbolicLink(a, b);
+        Directory.CreateSymbolicLink(b, a);
+
+        var allowed = LocalFileRootPolicy.TryResolve(Path.Combine(a, "x.png"), new List<string> { root }, out _);
+
+        Assert.False(allowed);
+    }
+
+    [Fact]
+    public void ComputeRoots_IncludesResolvedFormOfEachRoot()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var parent = CreateTempDir();
+        var real = Path.Combine(parent, "real");
+        Directory.CreateDirectory(real);
+        var link = Path.Combine(parent, "link");
+        Directory.CreateSymbolicLink(link, real);
+
+        var settings = new TendrilSettings
+        {
+            Security = new SecuritySettings { LocalFileRoots = new List<string> { link } }
+        };
+        var config = new ConfigService(settings, CreateTempDir());
+        var roots = LocalFileRootPolicy.ComputeRoots(config);
+
+        Assert.Contains(Path.GetFullPath(link), roots, StringComparer.OrdinalIgnoreCase);
+        Assert.True(LocalFileRootPolicy.TryResolveRealPath(link, out var resolvedLink));
+        Assert.Contains(resolvedLink, roots, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Ivy.Tendril/Controllers/LocalFileRootPolicy.cs
+++ b/src/Ivy.Tendril/Controllers/LocalFileRootPolicy.cs
@@ -10,6 +10,8 @@ namespace Ivy.Tendril.Controllers;
 /// </summary>
 internal static class LocalFileRootPolicy
 {
+    private const int MaxLinkHops = 40;
+
     public static List<string> ComputeRoots(IConfigService config)
     {
         var candidates = new List<string?> { config.TendrilHome, config.PlanFolder };
@@ -47,6 +49,17 @@ internal static class LocalFileRootPolicy
             {
                 roots.Add(normalized);
             }
+
+            // A root can itself sit behind a symlink (e.g. macOS's /var -> /private/var), so a
+            // request resolved to its real path would otherwise never match. Keep both forms.
+            if (normalized.Length > 0 && TryResolveRealPath(normalized, out var resolvedRoot))
+            {
+                resolvedRoot = resolvedRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                if (resolvedRoot.Length > 0 && !roots.Contains(resolvedRoot, StringComparer.OrdinalIgnoreCase))
+                {
+                    roots.Add(resolvedRoot);
+                }
+            }
         }
 
         return roots;
@@ -71,18 +84,9 @@ internal static class LocalFileRootPolicy
             return false;
         }
 
-        var target = resolved;
-        try
+        if (!TryResolveRealPath(resolved, out var target))
         {
-            var linkTarget = new FileInfo(resolved).ResolveLinkTarget(returnFinalTarget: true);
-            if (linkTarget != null)
-            {
-                target = linkTarget.FullName;
-            }
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or SecurityException)
-        {
-            // Leave target as the unresolved path; containment is still checked below.
+            return false;
         }
 
         foreach (var root in roots)
@@ -106,5 +110,109 @@ internal static class LocalFileRootPolicy
 
         return path.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
             || path.StartsWith(root + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// realpath-style resolution: walks every path segment (not just the final one) and resolves
+    /// each symlink it finds, so a symlinked directory in the middle of the path is followed too.
+    /// Resolves one hop at a time (<c>returnFinalTarget: false</c>) and tracks hops itself rather
+    /// than delegating multi-hop resolution to <see cref="FileSystemInfo.ResolveLinkTarget"/>'s own
+    /// <c>true</c> mode: that mode throws on a symlink cycle instead of returning, which would make
+    /// the caller fall back to the unresolved (still-contained-looking) input path. Counting hops
+    /// ourselves lets a cycle be rejected outright instead of silently passing containment.
+    /// Internal (rather than private) so tests can canonicalize their own fixture paths the same
+    /// way, since ambient test roots (e.g. the OS temp dir) can themselves sit behind a symlink.
+    /// </summary>
+    internal static bool TryResolveRealPath(string fullPath, out string realPath)
+    {
+        var pathRoot = Path.GetPathRoot(fullPath) ?? string.Empty;
+        var pending = new Queue<string>(SplitComponents(fullPath, pathRoot.Length));
+        var root = pathRoot;
+        var accepted = new List<string>();
+        var hops = 0;
+
+        while (pending.Count > 0)
+        {
+            var component = pending.Dequeue();
+
+            if (component == ".")
+            {
+                continue;
+            }
+
+            if (component == "..")
+            {
+                if (accepted.Count > 0)
+                {
+                    accepted.RemoveAt(accepted.Count - 1);
+                }
+                continue;
+            }
+
+            var candidate = BuildPath(root, accepted.Append(component));
+
+            FileSystemInfo? linkTarget;
+            try
+            {
+                linkTarget = new FileInfo(candidate).ResolveLinkTarget(returnFinalTarget: false);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or SecurityException)
+            {
+                // Missing or unreadable component: it cannot be a symlink, so keep walking and let
+                // containment decide (preserves today's behaviour for e.g. a deleted screenshot).
+                linkTarget = null;
+            }
+
+            if (linkTarget == null)
+            {
+                accepted.Add(component);
+                continue;
+            }
+
+            hops++;
+            if (hops > MaxLinkHops)
+            {
+                realPath = "";
+                return false;
+            }
+
+            var targetPath = linkTarget.FullName;
+            var targetRoot = Path.GetPathRoot(targetPath) ?? string.Empty;
+            var requeued = new Queue<string>(SplitComponents(targetPath, targetRoot.Length));
+            foreach (var remaining in pending)
+            {
+                requeued.Enqueue(remaining);
+            }
+
+            root = targetRoot;
+            accepted = [];
+            pending = requeued;
+        }
+
+        realPath = BuildPath(root, accepted);
+        return true;
+    }
+
+    private static IEnumerable<string> SplitComponents(string path, int rootLength)
+    {
+        return path
+            .Substring(rootLength)
+            .Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static string BuildPath(string root, IEnumerable<string> components)
+    {
+        var list = components as ICollection<string> ?? components.ToList();
+        if (list.Count == 0)
+        {
+            return root;
+        }
+
+        var needsSeparator = root.Length == 0
+            || (root[^1] != Path.DirectorySeparatorChar && root[^1] != Path.AltDirectorySeparatorChar);
+
+        return needsSeparator
+            ? root + Path.DirectorySeparatorChar + string.Join(Path.DirectorySeparatorChar, list)
+            : root + string.Join(Path.DirectorySeparatorChar, list);
     }
 }


### PR DESCRIPTION
# Summary

## Changes

`LocalFileRootPolicy.TryResolve` previously resolved symlinks by calling
`ResolveLinkTarget` once on the full request path, which only follows a symlink if the
*final* path component is itself a symlink. A symlinked directory anywhere earlier in the
path (e.g. `root/shared -> /elsewhere`, requesting `root/shared/photo.png`) went unresolved,
so the unresolved literal path — which still starts with `root` — passed containment even
though the real file it pointed to lives outside every configured root.

Replaced that single-shot resolution with a realpath-style walk (`TryResolveRealPath`) that
resolves every path segment, one symlink hop at a time, restarting the walk on a link's own
target so a directory-level symlink partway through the path is followed too. The walk counts
hops itself (`MaxLinkHops = 40`) and rejects outright if the budget is exceeded, which also
makes it safe against symlink cycles without hanging.

Configured roots are resolved the same way in `ComputeRoots`, since a root can itself sit
behind a symlink (e.g. macOS's `/var -> /private/var`) — both the raw and resolved form of
each root are now kept, so a request that resolves to a root's real path still matches.

## API Changes

None public. `LocalFileRootPolicy.TryResolveRealPath` was added as `internal` (rather than
`private`) so the test project — already trusted via the existing
`InternalsVisibleTo("Ivy.Tendril.Test")` — can canonicalize its own fixture paths; see
Verification/CheckResult.md for why this was necessary.

## Files Modified

- `src/Ivy.Tendril/Controllers/LocalFileRootPolicy.cs` — core fix: `TryResolveRealPath`,
  `ComputeRoots` resolving each root, `TryResolve` rejecting when resolution fails.
- `src/Ivy.Tendril.Test/LocalFileRootPolicyTests.cs` — six new tests covering symlinked
  intermediate directories (rejected/allowed), a resolved-root scenario, a symlink cycle, and
  `ComputeRoots` including each root's resolved form; `CreateTempDir()` canonicalized to avoid
  a macOS temp-dir symlink regression in two pre-existing tests.
- `src/Ivy.Tendril.Test/LocalFileGuardMiddlewareTests.cs` — one new end-to-end test asserting
  404 for a request that escapes through a symlinked directory.

## Manual Testing

Verified via the full automated test suite rather than manual exploration:
- Filtered run (`LocalFileRootPolicyTests` + `LocalFileGuardMiddlewareTests`), Release config:
  52 passed, 0 failed.
- Full `Ivy.Tendril.Test.csproj` suite, Debug config: 3797 passed, 1 pre-existing unrelated
  skip, 0 failed — confirming no regressions elsewhere.
- A throwaway probe app (outside the repo) was used during implementation to empirically
  confirm .NET's `ResolveLinkTarget(returnFinalTarget: true)` throws `IOException` on a
  genuine symlink cycle, which drove the single-hop-plus-hop-counter design documented in
  Verification/CheckResult.md.

---
- 74de8043 Resolve symlinked path segments in LocalFileRootPolicy containment check
- 1c5adfa2 Add end-to-end symlinked-directory regression test for local file guard

---
Created using [Ivy Tendril](https://ivy.app).
