### PR TITLE
[00482] Persist Truncated Output and Honor Reported Failure Reason

### DIFF
--- a/src/Ivy.Tendril.Test/ContentViewTests.cs
+++ b/src/Ivy.Tendril.Test/ContentViewTests.cs
@@ -140,6 +140,26 @@ public class ContentViewTests
     }
 
     [Fact]
+    public void BuildFailureCallout_WithTruncatedFinalOutput_ShowsTheSection()
+    {
+        var (tendrilHome, planDir) = CreateHome(
+            "# Job Log 00007-00001-ExecutePlan\n\n- **Status:** Completed\n\n## Final Output (truncated)\n\n*Model output truncated.*\n\npartial answer\n");
+        try
+        {
+            var result = ContentView.BuildFailureCallout(CreateFailedPlan(planDir), tendrilHome);
+
+            var callout = Assert.IsType<Callout>(result);
+            Assert.Equal(CalloutVariant.Destructive, callout.Variant);
+            Assert.Equal("Execution Failed", callout.Title);
+        }
+        finally
+        {
+            if (Directory.Exists(tendrilHome))
+                Directory.Delete(tendrilHome, true);
+        }
+    }
+
+    [Fact]
     public void BuildUpdatePrompt_NumbersAnnotationsAndQuotesSelectedText()
     {
         var annotations = new[]

--- a/src/Ivy.Tendril.Test/JobLogWriterFinalOutputTests.cs
+++ b/src/Ivy.Tendril.Test/JobLogWriterFinalOutputTests.cs
@@ -1,0 +1,115 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobLogWriterFinalOutputTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new();
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    private JobService CreateJobService()
+    {
+        var configService = new ConfigService(new TendrilSettings(), _tempDir.Path);
+        return new JobService(configService);
+    }
+
+    private string ReadLog(string jobId, string planId)
+        => File.ReadAllText(Path.Combine(_tempDir.Path, "Jobs", $"{jobId}-{planId}-ExecutePlan.md"));
+
+    [Fact]
+    public void WriteJobLog_TruncatedRun_WritesPartialTextUnderFlaggedHeading()
+    {
+        var jobService = CreateJobService();
+        var job = new JobItem { Id = "10", Type = "ExecutePlan", PlanFile = "00010-TestPlan", Status = JobStatus.Failed };
+        job.OutputLines.Enqueue("""{"kind":"text","text":"I'll start by reading the plan and understanding what needs to be done."}""");
+        job.OutputLines.Enqueue(
+            """{"kind":"error","message":"Model output truncated at the max output token limit (4096 output tokens in the final step); any pending tool call was aborted.","code":"output_truncated"}""");
+
+        jobService.WriteJobLog(job);
+
+        var log = ReadLog("10", "00010");
+        Assert.Contains("## Final Output (truncated)", log);
+        Assert.Contains("*Model output truncated at the max output token limit (4096 output tokens in the final step); any pending tool call was aborted.*", log);
+        Assert.Contains("I'll start by reading the plan and understanding what needs to be done.", log);
+    }
+
+    [Fact]
+    public void WriteJobLog_TruncatedRun_IgnoresTendrilSyntheticText()
+    {
+        var jobService = CreateJobService();
+        var job = new JobItem { Id = "11", Type = "ExecutePlan", PlanFile = "00011-TestPlan", Status = JobStatus.Failed };
+        job.OutputLines.Enqueue("""{"kind":"text","text":"the model's own partial answer"}""");
+        job.OutputLines.Enqueue("""{"kind":"text","text":"[Tendril] Permission denied: rm -rf /"}""");
+        job.OutputLines.Enqueue("""{"kind":"error","message":"stopped early","code":"output_truncated"}""");
+
+        jobService.WriteJobLog(job);
+
+        var log = ReadLog("11", "00011");
+        Assert.Contains("the model's own partial answer", log);
+        Assert.DoesNotContain("Permission denied", log);
+    }
+
+    [Fact]
+    public void WriteJobLog_TruncatedRun_ConcatenatesDeltaText()
+    {
+        var jobService = CreateJobService();
+        var job = new JobItem { Id = "12", Type = "ExecutePlan", PlanFile = "00012-TestPlan", Status = JobStatus.Failed };
+        job.OutputLines.Enqueue("""{"kind":"text","text":"first half ","delta":true}""");
+        job.OutputLines.Enqueue("""{"kind":"text","text":"second half","delta":true}""");
+        job.OutputLines.Enqueue("""{"kind":"error","message":"stopped early","code":"output_truncated"}""");
+
+        jobService.WriteJobLog(job);
+
+        var log = ReadLog("12", "00012");
+        Assert.Contains("first half second half", log);
+    }
+
+    [Fact]
+    public void WriteJobLog_UnhandledStopReason_WritesIncompleteHeading()
+    {
+        var jobService = CreateJobService();
+        var job = new JobItem { Id = "13", Type = "ExecutePlan", PlanFile = "00013-TestPlan", Status = JobStatus.Failed };
+        job.OutputLines.Enqueue("""{"kind":"text","text":"partial work before an unhandled stop"}""");
+        job.OutputLines.Enqueue("""{"kind":"error","message":"Unhandled stop reason: tool_use_limit","code":"unhandled_stop_reason"}""");
+
+        jobService.WriteJobLog(job);
+
+        var log = ReadLog("13", "00013");
+        Assert.Contains("## Final Output (incomplete)", log);
+        Assert.Contains("partial work before an unhandled stop", log);
+    }
+
+    [Fact]
+    public void WriteJobLog_SuccessfulRun_KeepsPlainHeading()
+    {
+        var jobService = CreateJobService();
+        var job = new JobItem { Id = "14", Type = "ExecutePlan", PlanFile = "00014-TestPlan", Status = JobStatus.Completed };
+        job.OutputLines.Enqueue("""{"kind":"result","response":"All done.","is_success":true}""");
+
+        jobService.WriteJobLog(job);
+
+        var log = ReadLog("14", "00014");
+        Assert.Contains("## Final Output\n", log);
+        Assert.DoesNotContain("## Final Output (", log);
+        Assert.Contains("All done.", log);
+    }
+
+    [Fact]
+    public void WriteJobLog_TextOnlyWithoutTruncation_OmitsFinalOutput()
+    {
+        var jobService = CreateJobService();
+        var job = new JobItem { Id = "15", Type = "ExecutePlan", PlanFile = "00015-TestPlan", Status = JobStatus.Completed };
+        job.OutputLines.Enqueue("""{"kind":"text","text":"some intermediate narration"}""");
+
+        jobService.WriteJobLog(job);
+
+        var log = ReadLog("15", "00015");
+        Assert.DoesNotContain("## Final Output", log);
+        Assert.DoesNotContain("some intermediate narration", log);
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobServiceFailureReasonTests.cs
@@ -270,6 +270,38 @@ public class JobServiceFailureReasonTests : IDisposable
     }
 
     [Fact]
+    public void CompleteJob_ZeroExit_WithReportedFailureReason_MarksFailed()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
+        var job = service.GetJob(id)!;
+        job.ReportedFailureReason = "Task already resolved/redundant";
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Equal("Task already resolved/redundant", job.StatusMessage);
+    }
+
+    [Fact]
+    public void CompleteJob_ZeroExit_ReportedReasonWinsOverErrorEvent()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
+        var job = service.GetJob(id)!;
+        job.ReportedFailureReason = "Task already resolved/redundant";
+        job.OutputLines.Enqueue(
+            """{"kind":"error","timestamp":"2026-05-26T12:18:29Z","message":"Access to Meta Llama models is not allowed from unsupported regions","is_retryable":false,"is_auth_error":false}""");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Equal("Task already resolved/redundant", job.StatusMessage);
+    }
+
+    [Fact]
     public void CompleteJob_NonZeroExit_NoReportedReason_FallsBackToScraper()
     {
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));

--- a/src/Ivy.Tendril.Test/Services/JobServiceRecoveredExecutionTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobServiceRecoveredExecutionTests.cs
@@ -153,6 +153,24 @@ public class JobServiceRecoveredExecutionTests : IDisposable
     }
 
     [Fact]
+    public void CompleteJob_ExitCode0_ReportedFailureReason_MarksFailedEvenWhenRecovered()
+    {
+        // A reported failure reason applies unconditionally, without consulting IsRecoveredJob — even
+        // when the job's artifacts (commits plus passing verifications) look complete.
+        var planFolder = CreatePlanFolder();
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(planFolder));
+        var job = service.GetJob(id)!;
+        job.ReportedFailureReason = "Task already resolved/redundant";
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Equal("Task already resolved/redundant", job.StatusMessage);
+    }
+
+    [Fact]
     public void CompleteJob_ExitCode0_WithUnrecoveredAntigravityToolError_MarksFailedWithCleanErrorMessage()
     {
         // When verifications failed and no commits were made, job is not recovered and should fail

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -664,7 +664,11 @@ public class ContentView(
 
     private static string? MatchSection(string content, string sectionName)
     {
-        var match = Regex.Match(content, $@"## {Regex.Escape(sectionName)}\s*\n([\s\S]*?)(?=\n## |\z)");
+        // The optional parenthesised suffix lets this match JobLogWriter's flagged headings
+        // ("## Final Output (truncated)" / "(incomplete)") without the other two call sites
+        // (Output / Issues Found in verification reports) starting to match a different heading
+        // that merely shares a prefix.
+        var match = Regex.Match(content, $@"## {Regex.Escape(sectionName)}(?: \([^)\n]*\))?[ \t]*\n([\s\S]*?)(?=\n## |\z)");
         return match.Success ? match.Groups[1].Value.Trim() : null;
     }
 

--- a/src/Ivy.Tendril/Commands/JobFailCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobFailCommand.cs
@@ -38,8 +38,10 @@ public class JobFailCommand : Command<JobFailSettings>
             return 0;
         }
 
-        // This only records the failure reason. The promptware is still responsible
-        // for exiting non-zero (e.g. `exit 1`) to actually fail the job.
+        // Recording the reason alone now fails the job (JobService.SetCompletionStatus honors
+        // ReportedFailureReason on any exit code). A non-zero exit (e.g. `exit 1`) remains the
+        // recommended practice regardless, since it is what surfaces the failure immediately
+        // rather than after the process eventually exits.
         Console.WriteLine($"Failure reported for job {settings.JobId}");
         return 0;
     }

--- a/src/Ivy.Tendril/Services/Jobs/JobLogWriter.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLogWriter.cs
@@ -1,4 +1,7 @@
 using System.Text;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.OpenCode;
+using Ivy.Tendril.Agents.Runtime;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 
@@ -112,12 +115,19 @@ public static class JobLogWriter
             sb.AppendLine();
         }
 
-        var result = ExtractFinalOutput(job);
-        if (!string.IsNullOrEmpty(result))
+        var finalOutput = ExtractFinalOutput(job);
+        if (finalOutput != null)
         {
-            sb.AppendLine("## Final Output");
+            sb.AppendLine(finalOutput.HeadingSuffix != null
+                ? $"## Final Output ({finalOutput.HeadingSuffix})"
+                : "## Final Output");
             sb.AppendLine();
-            sb.AppendLine(result);
+            if (!string.IsNullOrEmpty(finalOutput.IncompleteReason))
+            {
+                sb.AppendLine($"*{finalOutput.IncompleteReason}*");
+                sb.AppendLine();
+            }
+            sb.AppendLine(finalOutput.Text);
             sb.AppendLine();
         }
 
@@ -153,21 +163,66 @@ public static class JobLogWriter
         }
     }
 
-    private static string? ExtractFinalOutput(JobItem job)
+    /// <param name="Text">The assistant's final response, or its partial text when truncated/incomplete.</param>
+    /// <param name="IncompleteReason">The flagged <see cref="ErrorEvent.Message"/>, rendered as an italic note.</param>
+    /// <param name="HeadingSuffix">Appended to the <c>## Final Output</c> heading in parentheses, e.g. <c>truncated</c>.</param>
+    private sealed record FinalOutput(string Text, string? IncompleteReason, string? HeadingSuffix);
+
+    /// <summary>
+    /// Only <see cref="ResultEvent.Response"/> counts as today's "final output". When a run ends without one
+    /// (a truncation or unhandled stop reason flagged by <see cref="OpenCodeEventParser"/>), fall back to the
+    /// assistant's partial <see cref="TextEvent"/> text instead of discarding it — but only for those flagged
+    /// codes, so every other job log stays byte-identical to before.
+    /// </summary>
+    private static FinalOutput? ExtractFinalOutput(JobItem job)
     {
         if (job.OutputLines.Count == 0) return null;
 
         try
         {
-            var serializer = new Ivy.Tendril.Agents.Runtime.JsonEventSerializer();
-            string? lastResult = null;
+            var serializer = new JsonEventSerializer();
+            string? lastResponse = null;
+            string? partialText = null;
+            string? incompleteReason = null;
+            string? headingSuffix = null;
+
             foreach (var line in job.OutputLines)
             {
-                var evt = serializer.Deserialize(line);
-                if (evt is Ivy.Tendril.Agents.Abstractions.ResultEvent r && r.Response != null)
-                    lastResult = r.Response;
+                switch (serializer.Deserialize(line))
+                {
+                    case ResultEvent { Response: { } response }:
+                        lastResponse = response;
+                        break;
+
+                    // Skip Tendril's own synthetic completion/hook lines — they're enqueued as TextEvents
+                    // too (JobItem.EnqueueSystemOutput) and would otherwise look like the model's own text.
+                    case TextEvent text when text.Text.StartsWith("[Tendril] ", StringComparison.Ordinal)
+                        || text.Text.StartsWith("[hook:", StringComparison.Ordinal):
+                        break;
+
+                    case TextEvent text:
+                        partialText = text.IsDelta ? (partialText ?? "") + text.Text : text.Text;
+                        break;
+
+                    case ErrorEvent { Code: OpenCodeEventParser.OutputTruncatedCode } error:
+                        incompleteReason = error.Message;
+                        headingSuffix = "truncated";
+                        break;
+
+                    case ErrorEvent { Code: OpenCodeEventParser.UnhandledStopReasonCode } error:
+                        incompleteReason = error.Message;
+                        headingSuffix = "incomplete";
+                        break;
+                }
             }
-            return lastResult;
+
+            if (!string.IsNullOrEmpty(lastResponse))
+                return new FinalOutput(lastResponse, headingSuffix != null ? incompleteReason : null, headingSuffix);
+
+            if (headingSuffix != null && !string.IsNullOrEmpty(partialText))
+                return new FinalOutput(partialText, incompleteReason, headingSuffix);
+
+            return null;
         }
         catch
         {

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -212,7 +212,16 @@ public class JobService : IJobService
         else
         {
             var success = exitCode == 0;
-            if (success)
+            if (!string.IsNullOrEmpty(job.ReportedFailureReason))
+            {
+                // A reason explicitly declared by the promptware via `tendril job fail` is a terminal
+                // verdict about its own run, so it outranks the exit code in both directions: over a
+                // stale `tendril job status` progress message, and over a zero exit from a promptware
+                // that reported the failure but never exited non-zero (issue #2626).
+                success = false;
+                job.StatusMessage = job.ReportedFailureReason;
+            }
+            else if (success)
             {
                 var errorMessage = JobFailureAnalyzer.TryExtractErrorEvent(job.OutputLines);
                 if (errorMessage != null)
@@ -229,13 +238,6 @@ public class JobService : IJobService
                         job.StatusMessage = errorMessage;
                     }
                 }
-            }
-            else if (!string.IsNullOrEmpty(job.ReportedFailureReason))
-            {
-                // A reason explicitly declared by the promptware via `tendril job fail`
-                // wins outright — including over any progress message previously set via
-                // `tendril job status` (which would otherwise leave a stale message shown).
-                job.StatusMessage = job.ReportedFailureReason;
             }
             else
             {


### PR DESCRIPTION
Fixes #2626

# Summary

## Changes

Job logs previously discarded the model's partial output whenever a run ended without a final `ResultEvent` — most notably a truncated response or an unhandled stop reason — since `ExtractFinalOutput` only ever rendered `ResultEvent.Response`. It now falls back to the concatenated assistant text in that case, under a flagged heading (`## Final Output (truncated)` / `## Final Output (incomplete)`) with the reported reason shown as an italic note, while every other job log stays byte-identical to before. The Review tab's failure callout was updated to still recognize these flagged headings. Separately, `JobService.SetCompletionStatus` now honors a promptware's self-reported failure reason (`tendril job fail`) unconditionally rather than only on a non-zero exit code, so a promptware that reports a failure but exits 0 is still recorded `Failed`.

## API Changes

None (internal service/rendering behavior only).

## Files Modified

- `src/Ivy.Tendril/Services/Jobs/JobLogWriter.cs`: `ExtractFinalOutput` falls back to partial `TextEvent` text (skipping Tendril's own synthetic lines, concatenating deltas) when the run is flagged truncated/incomplete; renders a flagged heading and reason note.
- `src/Ivy.Tendril/Apps/Plans/ContentView.cs`: `MatchSection`'s regex allows an optional parenthesised heading suffix, scoped to avoid collateral matches at other call sites.
- `src/Ivy.Tendril/Services/Jobs/JobService.cs`: `SetCompletionStatus` checks `job.ReportedFailureReason` before the exit-code branch, so it always wins.
- `src/Ivy.Tendril/Commands/JobFailCommand.cs`: Updated a stale comment to match the new behavior.
- `src/Ivy.Tendril.Test/JobLogWriterFinalOutputTests.cs`: New test file covering truncated/incomplete final output rendering.
- `src/Ivy.Tendril.Test/ContentViewTests.cs`: Added a test for the flagged-heading failure callout.
- `src/Ivy.Tendril.Test/Services/JobServiceFailureReasonTests.cs`: Added tests for a reported reason winning on a zero exit.
- `src/Ivy.Tendril.Test/Services/JobServiceRecoveredExecutionTests.cs`: Added a test for a reported reason winning even when the job looks "recovered".

## Manual Testing

Verified via the automated test suite (85/85 targeted tests, 3800/3801 full suite, 1 pre-existing skip unrelated to this change) since this is backend-only job log/service behavior with no UI surface to exercise beyond the existing `ContentView` unit tests.

---
- b5460c33 [00482] Honor a reported failure reason regardless of exit code
- 6980f152 [00482] Match flagged Final Output headings in the Review failure callout
- f378a3b0 [00482] Persist partial output when a run ends truncated or incomplete

---
Created using [Ivy Tendril](https://ivy.app).