### PR TITLE
[00478] Reconcile Model Limits Across Provider Catalogs

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Runtime/ModelCatalogConsistencyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/ModelCatalogConsistencyTests.cs
@@ -1,0 +1,208 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Antigravity;
+using Ivy.Tendril.Agents.Providers.Claude;
+using Ivy.Tendril.Agents.Providers.Codex;
+using Ivy.Tendril.Agents.Providers.Gemini;
+using Ivy.Tendril.Agents.Providers.Ivy;
+using Ivy.Tendril.Agents.Providers.OpenAiProxy;
+using Ivy.Tendril.Agents.Providers.OpenCode;
+using Ivy.Tendril.Agents.Runtime;
+
+namespace Ivy.Tendril.Agents.Test.Runtime;
+
+/// <summary>
+/// Guards the invariant that made <see cref="ModelSpecs" /> necessary: one model has one context
+/// window, one output limit and one price list, whichever catalog you reach it through.
+/// <see cref="Providers.Copilot.CopilotModelCatalog" /> is excluded because it deliberately declares
+/// no numbers — Copilot is subscription-billed, so pricing its models would start attributing
+/// per-token costs to runs that have none.
+/// </summary>
+public class ModelCatalogConsistencyTests
+{
+    /// <summary>The OpenCode default entry is a "whatever the CLI picks" placeholder with no model behind it.</summary>
+    private const string PlaceholderId = "default";
+
+    private static IReadOnlyList<(string Agent, ModelInfo Model)> AllEntries()
+    {
+        IModelCatalogProvider[] catalogs =
+        [
+            new ClaudeModelCatalog(),
+            new AntigravityModelCatalog(),
+            new CodexModelCatalog(),
+            new GeminiModelCatalog(),
+            new OpenCodeModelCatalog(),
+            new IvyModelCatalog(),
+            // The one endpoint whose model list contains an entry OpenAiProxy declares itself.
+            new OpenAiProxyModelCatalog(() => "https://api.berget.ai/v1"),
+        ];
+
+        return
+        [
+            .. catalogs.SelectMany(c => c.GetStaticModels()
+                .Where(m => m.Id != PlaceholderId)
+                .Select(m => (c.AgentId, m)))
+        ];
+    }
+
+    [Fact]
+    public void EveryCatalogEntry_HasCanonicalSpec()
+    {
+        var orphans = AllEntries()
+            .Where(e => ModelSpecs.Find(e.Model.Id) is null)
+            .Select(e => $"{e.Agent}/{e.Model.Id}")
+            .Distinct()
+            .ToList();
+
+        Assert.Empty(orphans);
+    }
+
+    [Fact]
+    public void EveryCatalogEntry_MatchesCanonicalWindow()
+    {
+        foreach (var (agent, model) in AllEntries())
+        {
+            var spec = ModelSpecs.Require(model.Id);
+            Assert.True(
+                model.ContextWindow == spec.ContextWindow,
+                $"{agent}/{model.Id} declares a {model.ContextWindow} context window, canonical is {spec.ContextWindow}");
+        }
+    }
+
+    [Fact]
+    public void EveryCatalogEntry_DoesNotExceedCanonicalOutput()
+    {
+        // `<=`, not `==`: a provider whose harness truncates below the model's own limit (Antigravity
+        // caps anthropic responses at 64k) is legitimate. Claiming more than the model can produce
+        // is not.
+        foreach (var (agent, model) in AllEntries())
+        {
+            var spec = ModelSpecs.Require(model.Id);
+            Assert.NotNull(model.MaxOutputTokens);
+            Assert.True(
+                model.MaxOutputTokens <= spec.MaxOutputTokens,
+                $"{agent}/{model.Id} declares a {model.MaxOutputTokens} output limit above its canonical {spec.MaxOutputTokens}");
+        }
+    }
+
+    [Fact]
+    public void EveryCatalogEntry_MatchesCanonicalRates()
+    {
+        foreach (var (agent, model) in AllEntries())
+        {
+            var spec = ModelSpecs.Require(model.Id);
+
+            Assert.Equal(spec.InputPerMillion, model.InputPerMillion);
+            Assert.Equal(spec.OutputPerMillion, model.OutputPerMillion);
+            Assert.Equal(spec.CacheReadPerMillion, model.CacheReadPerMillion);
+            Assert.Equal(spec.CacheWritePerMillion, model.CacheWritePerMillion);
+        }
+    }
+
+    [Fact]
+    public void SharedModelIds_AgreeAcrossCatalogs()
+    {
+        var shared = AllEntries()
+            .GroupBy(e => e.Model.Id, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Select(e => e.Agent).Distinct().Count() > 1);
+
+        foreach (var group in shared)
+        {
+            Assert.Single(group.Select(e => e.Model.ContextWindow).Distinct());
+            Assert.Single(group.Select(e => e.Model.InputPerMillion).Distinct());
+            Assert.Single(group.Select(e => e.Model.OutputPerMillion).Distinct());
+            Assert.Single(group.Select(e => e.Model.CacheReadPerMillion).Distinct());
+            Assert.Single(group.Select(e => e.Model.CacheWritePerMillion).Distinct());
+
+            // Output limits may differ only downwards, and only per provider cap.
+            var canonical = ModelSpecs.Require(group.Key).MaxOutputTokens;
+            Assert.All(group, e => Assert.True(e.Model.MaxOutputTokens <= canonical));
+        }
+    }
+
+    [Fact]
+    public void DottedAndDashedSpellingsOfTheSameModel_ReportTheSameLimits()
+    {
+        var entries = AllEntries();
+        var dashed = entries.Single(e => e.Agent == AgentId.Claude && e.Model.Id == "claude-3-7-sonnet").Model;
+        var dotted = entries.Single(e => e.Agent == AgentId.Claude && e.Model.Id == "claude-3.7-sonnet").Model;
+
+        Assert.Equal(dashed.ContextWindow, dotted.ContextWindow);
+        Assert.Equal(dashed.MaxOutputTokens, dotted.MaxOutputTokens);
+        Assert.Equal(dashed.OutputPerMillion, dotted.OutputPerMillion);
+    }
+
+    [Fact]
+    public void ClaudeSonnetAlias_IsPricedLikeTheModelItResolvesTo()
+    {
+        var claude = new ClaudeModelCatalog().GetStaticModels();
+        var alias = claude.Single(m => m.Id == "sonnet");
+        var concrete = claude.Single(m => m.Id == "claude-sonnet-5");
+
+        Assert.Equal(concrete.InputPerMillion, alias.InputPerMillion);
+        Assert.Equal(concrete.OutputPerMillion, alias.OutputPerMillion);
+    }
+
+    [Fact]
+    public void AntigravityAnthropicModels_KeepTheirHarnessOutputCap()
+    {
+        var anthropic = new AntigravityModelCatalog().GetStaticModels()
+            .Where(m => m.Provider == "anthropic")
+            .ToList();
+
+        Assert.NotEmpty(anthropic);
+        Assert.All(anthropic, m => Assert.Equal(65_536, m.MaxOutputTokens));
+        // ...while still reporting the model's real context window.
+        Assert.All(anthropic, m => Assert.Equal(1_000_000, m.ContextWindow));
+    }
+
+    [Fact]
+    public void TryGetLimits_ForOpus46_ReturnsOneMillionContext()
+    {
+        // The launch-path bug: `anthropic/claude-opus-4-6` has no OpenCode static row, so the private
+        // pricing table answered with 200k and OpenCodeCli wrote that into the process's
+        // `limit.context` — one fifth of the model's real window.
+        var limits = OpenCodeModelCatalog.TryGetLimits("anthropic/claude-opus-4-6");
+
+        Assert.NotNull(limits);
+        Assert.Equal(1_000_000, limits.Value.Context);
+        Assert.Equal(128_000, limits.Value.Output);
+    }
+
+    [Fact]
+    public void TryGetLimits_ForLegacyDashedClaudeId_Resolves()
+    {
+        // Catalog IDs use dashes, the old table used dots, so these resolved to nothing at all.
+        var limits = OpenCodeModelCatalog.TryGetLimits("anthropic/claude-3-5-sonnet");
+
+        Assert.NotNull(limits);
+        Assert.Equal(200_000, limits.Value.Context);
+        Assert.Equal(64_000, limits.Value.Output);
+    }
+
+    [Fact]
+    public async Task ParseModelsListAsync_ForOpus48_UsesItsOwnRateNotOpus4s()
+    {
+        // Declaration-order matching charged a discovered `claude-opus-4-8` at the `claude-opus-4`
+        // rate, inflating its cost threefold.
+        var models = await OpenCodeModelCatalog.ParseModelsListAsync("anthropic/claude-opus-4-8");
+
+        Assert.NotNull(models);
+        var model = Assert.Single(models);
+        Assert.Equal(5.00m, model.InputPerMillion);
+        Assert.Equal(25.00m, model.OutputPerMillion);
+        Assert.Equal(1_000_000, model.ContextWindow);
+    }
+
+    [Fact]
+    public async Task ParseModelsListAsync_ForLegacyDashedClaudeId_HasLimitsAndRates()
+    {
+        var models = await OpenCodeModelCatalog.ParseModelsListAsync("claude-3-5-sonnet");
+
+        Assert.NotNull(models);
+        var model = Assert.Single(models);
+        Assert.Equal(200_000, model.ContextWindow);
+        Assert.Equal(64_000, model.MaxOutputTokens);
+        Assert.Equal(3.00m, model.InputPerMillion);
+        Assert.Equal(15.00m, model.OutputPerMillion);
+    }
+}

--- a/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
@@ -73,11 +73,13 @@ public class ModelPricingProviderTests
     [Fact]
     public void GetPricing_Sonnet_ReturnsPricing()
     {
+        // The alias is priced like the model it resolves to, claude-sonnet-5, rather than carrying its
+        // own stale 2/10 rate.
         var pricing = _provider.GetPricing("sonnet");
 
         Assert.NotNull(pricing);
-        Assert.Equal(2m, pricing.InputPerMillion);
-        Assert.Equal(10m, pricing.OutputPerMillion);
+        Assert.Equal(3m, pricing.InputPerMillion);
+        Assert.Equal(15m, pricing.OutputPerMillion);
     }
 
     [Fact]
@@ -86,8 +88,8 @@ public class ModelPricingProviderTests
         var pricing = _provider.GetPricing("claude-sonnet-4");
 
         Assert.NotNull(pricing);
-        Assert.Equal(2m, pricing.InputPerMillion);
-        Assert.Equal(10m, pricing.OutputPerMillion);
+        Assert.Equal(3m, pricing.InputPerMillion);
+        Assert.Equal(15m, pricing.OutputPerMillion);
     }
 
     [Fact]
@@ -165,7 +167,7 @@ public class ModelPricingProviderTests
             inputTokens: 1000,
             outputTokens: 500);
 
-        var expected = (1000m * 2m / 1_000_000m) + (500m * 10m / 1_000_000m);
+        var expected = (1000m * 3m / 1_000_000m) + (500m * 15m / 1_000_000m);
         Assert.Equal(expected, cost);
     }
 

--- a/src/Ivy.Tendril.Agents.Test/Runtime/ModelSpecsTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/ModelSpecsTests.cs
@@ -1,0 +1,174 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Runtime;
+
+namespace Ivy.Tendril.Agents.Test.Runtime;
+
+public class ModelSpecsTests
+{
+    [Fact]
+    public void Find_ExactId_ReturnsSpec()
+    {
+        var spec = ModelSpecs.Find("claude-opus-5");
+
+        Assert.NotNull(spec);
+        Assert.Equal(1_000_000, spec.ContextWindow);
+        Assert.Equal(128_000, spec.MaxOutputTokens);
+        Assert.Equal(5.00m, spec.InputPerMillion);
+        Assert.Equal(25.00m, spec.OutputPerMillion);
+        Assert.Equal(0.50m, spec.CacheReadPerMillion);
+        Assert.Equal(6.25m, spec.CacheWritePerMillion);
+    }
+
+    [Fact]
+    public void Find_IsCaseInsensitive()
+    {
+        Assert.Same(ModelSpecs.Find("claude-opus-5"), ModelSpecs.Find("CLAUDE-OPUS-5"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData(null)]
+    [InlineData("llama-3-70b")]
+    [InlineData("mistral-large")]
+    public void Find_UnknownId_ReturnsNull(string? modelId)
+    {
+        Assert.Null(ModelSpecs.Find(modelId));
+    }
+
+    [Theory]
+    [InlineData("anthropic/claude-opus-5")]
+    [InlineData("eu.anthropic.claude-opus-5")]
+    [InlineData("global.anthropic.claude-opus-5")]
+    [InlineData("us.anthropic.claude-opus-5")]
+    [InlineData("bedrock/anthropic.claude-opus-5")]
+    public void Find_StripsProviderPrefix(string formattedModel)
+    {
+        Assert.Same(ModelSpecs.Find("claude-opus-5"), ModelSpecs.Find(formattedModel));
+    }
+
+    [Theory]
+    [InlineData("claude-3-5-sonnet", "claude-3.5-sonnet")]
+    [InlineData("claude-3-7-sonnet", "claude-3.7-sonnet")]
+    [InlineData("claude-opus-5-1", "claude-opus-5.1")]
+    [InlineData("claude-sonnet-5-1", "claude-sonnet-5.1")]
+    public void Find_DotAndDashSpellings_ResolveSameSpec(string dashed, string dotted)
+    {
+        var spec = ModelSpecs.Find(dashed);
+
+        Assert.NotNull(spec);
+        Assert.Same(spec, ModelSpecs.Find(dotted));
+    }
+
+    [Fact]
+    public void Find_LegacyClaude3xSonnet_Is200KWindow()
+    {
+        // The catalogs claimed 1M/128k for models that publish 200k/64k, and nothing read the value
+        // so nothing caught it.
+        var spec = ModelSpecs.Find("claude-3-5-sonnet");
+
+        Assert.NotNull(spec);
+        Assert.Equal(200_000, spec.ContextWindow);
+        Assert.Equal(64_000, spec.MaxOutputTokens);
+    }
+
+    [Fact]
+    public void Find_PrefersLongestPattern()
+    {
+        // The old table scanned in declaration order, so a dated `claude-opus-4-8` was captured by
+        // the `claude-opus-4` row and priced at 15/75 — three times its real rate — with a 200k
+        // window instead of 1M.
+        var spec = ModelSpecs.Find("anthropic/claude-opus-4-8-20260101");
+
+        Assert.NotNull(spec);
+        Assert.Equal(1_000_000, spec.ContextWindow);
+        Assert.Equal(5.00m, spec.InputPerMillion);
+        Assert.Equal(25.00m, spec.OutputPerMillion);
+    }
+
+    [Theory]
+    [InlineData("gpt-5.4-mini-2026-01-01", 16_000)]
+    [InlineData("gpt-4.1-nano-preview", 16_000)]
+    [InlineData("gpt-4.1-2025-04-14", 32_000)]
+    public void Find_PrefersLongestPattern_ForOpenAiSuffixes(string modelId, int expectedOutput)
+    {
+        var spec = ModelSpecs.Find(modelId);
+
+        Assert.NotNull(spec);
+        Assert.Equal(expectedOutput, spec.MaxOutputTokens);
+    }
+
+    [Fact]
+    public void Find_ClaudeAliases_MatchTheModelTheyResolveTo()
+    {
+        // Separate rows, so value equality rather than reference equality: an alias is its own key
+        // whose numbers must track the model it stands for.
+        Assert.Equal(ModelSpecs.Find("claude-opus-5"), ModelSpecs.Find("opus"));
+        Assert.Equal(ModelSpecs.Find("claude-sonnet-5"), ModelSpecs.Find("sonnet"));
+        Assert.Equal(ModelSpecs.Find("claude-haiku-5-1"), ModelSpecs.Find("haiku"));
+    }
+
+    [Fact]
+    public void Require_DeclaredId_ReturnsSpec()
+    {
+        // Declared with the provider prefix stripped, which is how the catalog spells it.
+        var spec = ModelSpecs.Require("moonshotai/Kimi-K3");
+
+        Assert.Equal(256_000, spec.ContextWindow);
+        Assert.Equal(32_000, spec.MaxOutputTokens);
+    }
+
+    [Fact]
+    public void Require_UnknownId_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => ModelSpecs.Require("llama-3-70b"));
+        Assert.Contains("llama-3-70b", ex.Message);
+    }
+
+    [Fact]
+    public void Require_DoesNotFallBackToSubstringMatch()
+    {
+        // A catalog entry nobody has priced must break loudly rather than inherit a shorter row's
+        // numbers, even though the same ID resolves through Find's substring fallback.
+        Assert.NotNull(ModelSpecs.Find("claude-opus-4-8-20260101"));
+        Assert.Throws<InvalidOperationException>(() => ModelSpecs.Require("claude-opus-4-8-20260101"));
+    }
+
+    [Fact]
+    public void WithSpec_FillsEveryNumericField()
+    {
+        var model = new ModelInfo { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5" }.WithSpec();
+
+        Assert.Equal(1_000_000, model.ContextWindow);
+        Assert.Equal(128_000, model.MaxOutputTokens);
+        Assert.Equal(3.00m, model.InputPerMillion);
+        Assert.Equal(15.00m, model.OutputPerMillion);
+        Assert.Equal(0.30m, model.CacheReadPerMillion);
+        Assert.Equal(3.75m, model.CacheWritePerMillion);
+    }
+
+    [Fact]
+    public void WithSpec_AppliesProviderOutputCap()
+    {
+        var model = new ModelInfo { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5" }.WithSpec(65_536);
+
+        Assert.Equal(65_536, model.MaxOutputTokens);
+        Assert.Equal(1_000_000, model.ContextWindow);
+    }
+
+    [Fact]
+    public void WithSpec_RejectsOutputCapAboveCanonical()
+    {
+        var model = new ModelInfo { Id = "claude-haiku-5-1", DisplayName = "Claude Haiku 5.1" };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => model.WithSpec(128_000));
+    }
+
+    [Fact]
+    public void WithSpec_UnknownId_Throws()
+    {
+        var model = new ModelInfo { Id = "llama-3-70b", DisplayName = "Llama 3 70B" };
+
+        Assert.Throws<InvalidOperationException>(() => model.WithSpec());
+    }
+}

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
@@ -9,6 +9,13 @@ namespace Ivy.Tendril.Agents.Providers.Antigravity;
 
 public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
 {
+    /// <summary>
+    /// The Antigravity harness truncates a response below the anthropic models' own 128k output
+    /// limit, so those rows cap <see cref="ModelInfo.MaxOutputTokens" /> here rather than in
+    /// <see cref="ModelSpecs" />: it is a property of this provider, not of the model.
+    /// </summary>
+    private const int AnthropicOutputCap = 65_536;
+
     private static readonly ModelCapabilities FullCaps =
         ModelCapabilities.Reasoning |
         ModelCapabilities.ImageInput |
@@ -25,136 +32,97 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
 
     public override IReadOnlyList<ModelInfo> GetStaticModels() =>
     [
-        new()
+        new ModelInfo
         {
             Id = "gemini-3.8-flash", DisplayName = "Gemini 3.8 Flash",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Antigravity,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash",
             Capabilities = MidCaps, IsDefault = true,
             SupportedEfforts = EffortLevels.Antigravity,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Antigravity,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Antigravity,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 1.25m, OutputPerMillion = 10.00m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.315m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-fable-5", DisplayName = "Claude Fable 5",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
-            InputPerMillion = 10.00m, OutputPerMillion = 50.00m,
-            CacheWritePerMillion = 12.50m, CacheReadPerMillion = 1.00m,
-        },
-        new()
+        }.WithSpec(AnthropicOutputCap),
+        new ModelInfo
         {
             Id = "claude-opus-5-1", DisplayName = "Claude Opus 5.1",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
+        }.WithSpec(AnthropicOutputCap),
+        new ModelInfo
         {
             Id = "claude-opus-5", DisplayName = "Claude Opus 5",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
+        }.WithSpec(AnthropicOutputCap),
+        new ModelInfo
         {
             Id = "claude-opus-4-6", DisplayName = "Claude Opus 4.6",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
+        }.WithSpec(AnthropicOutputCap),
+        new ModelInfo
         {
             Id = "claude-sonnet-5-1", DisplayName = "Claude Sonnet 5.1",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(AnthropicOutputCap),
+        new ModelInfo
         {
             Id = "claude-5.1", DisplayName = "Claude 5.1",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(AnthropicOutputCap),
+        new ModelInfo
         {
             Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(AnthropicOutputCap),
+        new ModelInfo
         {
             Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(AnthropicOutputCap),
+        new ModelInfo
         {
             Id = "gpt-oss-120b", DisplayName = "GPT-OSS 120B",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Antigravity,
-            ContextWindow = 128_000, MaxOutputTokens = 32_768,
             Provider = "openai",
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0m,
-        },
+        }.WithSpec(),
     ];
 
     protected override Task<IReadOnlyList<ModelInfo>?> DiscoverModelsAsync(CancellationToken ct)

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
@@ -27,197 +27,145 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
 
     public override string AgentId => Abstractions.AgentId.Claude;
 
+    /// <summary>
+    /// Limits and rates come from <see cref="ModelSpecs" />; this list declares identity only. The
+    /// bare <c>opus</c> / <c>sonnet</c> / <c>haiku</c> aliases therefore report the same numbers as
+    /// the concrete model each resolves to.
+    /// </summary>
     public override IReadOnlyList<ModelInfo> GetStaticModels() =>
     [
-        new()
+        new ModelInfo
         {
             Id = "claude-fable-5", DisplayName = "Claude Fable 5",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 10.00m, OutputPerMillion = 50.00m,
-            CacheWritePerMillion = 12.50m, CacheReadPerMillion = 1.00m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-opus-5-1", DisplayName = "Claude Opus 5.1",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-opus-5", DisplayName = "Claude Opus 5",
             Capabilities = FullCaps, IsDefault = true,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-opus-4-8", DisplayName = "Claude Opus 4.8",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-opus-4-7", DisplayName = "Claude Opus 4.7",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-opus-4-6", DisplayName = "Claude Opus 4.6",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "opus", DisplayName = "Claude Opus (Default)",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-sonnet-5-1", DisplayName = "Claude Sonnet 5.1",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-5.1", DisplayName = "Claude 5.1",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-3-7-sonnet", DisplayName = "Claude Sonnet 3.7",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-3.7-sonnet", DisplayName = "Claude Sonnet 3.7 (Alt)",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-3-5-sonnet", DisplayName = "Claude Sonnet 3.5",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "sonnet", DisplayName = "Claude Sonnet",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 2.00m, OutputPerMillion = 10.00m,
-            CacheWritePerMillion = 2.50m, CacheReadPerMillion = 0.20m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-haiku-5-1", DisplayName = "Claude Haiku 5.1",
             Capabilities = LiteCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 200_000, MaxOutputTokens = 64_000,
             Provider = "anthropic",
-            InputPerMillion = 1.00m, OutputPerMillion = 5.00m,
-            CacheWritePerMillion = 1.25m, CacheReadPerMillion = 0.10m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-haiku-4-5", DisplayName = "Claude Haiku 4.5",
             Capabilities = LiteCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 200_000, MaxOutputTokens = 64_000,
             Provider = "anthropic",
-            InputPerMillion = 1.00m, OutputPerMillion = 5.00m,
-            CacheWritePerMillion = 1.25m, CacheReadPerMillion = 0.10m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-3-5-haiku", DisplayName = "Claude Haiku 3.5",
             Capabilities = LiteCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 200_000, MaxOutputTokens = 64_000,
             Provider = "anthropic",
-            InputPerMillion = 1.00m, OutputPerMillion = 5.00m,
-            CacheWritePerMillion = 1.25m, CacheReadPerMillion = 0.10m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "haiku", DisplayName = "Claude Haiku",
             Capabilities = LiteCaps,
             SupportedEfforts = EffortLevels.Claude,
-            ContextWindow = 200_000, MaxOutputTokens = 64_000,
             Provider = "anthropic",
-            InputPerMillion = 1.00m, OutputPerMillion = 5.00m,
-            CacheWritePerMillion = 1.25m, CacheReadPerMillion = 0.10m,
-        },
+        }.WithSpec(),
     ];
 }

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexModelCatalog.cs
@@ -17,126 +17,90 @@ public sealed class CodexModelCatalog : CachedModelCatalogProvider
 
     public override IReadOnlyList<ModelInfo> GetStaticModels() =>
     [
-        new()
+        new ModelInfo
         {
             Id = "gpt-6-astra", DisplayName = "GPT-6 Astra",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 400_000, MaxOutputTokens = 32_000,
             Provider = "openai",
-            InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
-            CacheReadPerMillion = 2.50m, CacheWritePerMillion = 12.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gpt-5.6-sol", DisplayName = "GPT-5.6-Sol",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 400_000, MaxOutputTokens = 32_000,
             Provider = "openai",
-            InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
-            CacheReadPerMillion = 2.50m, CacheWritePerMillion = 12.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gpt-5.6-terra", DisplayName = "GPT-5.6-Terra",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 272_000, MaxOutputTokens = 16_000,
             Provider = "openai", IsDefault = true,
-            InputPerMillion = 1.10m, OutputPerMillion = 4.40m,
-            CacheReadPerMillion = 0.275m, CacheWritePerMillion = 1.375m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gpt-5.6-luna", DisplayName = "GPT-5.6-Luna",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 272_000, MaxOutputTokens = 16_000,
             Provider = "openai",
-            InputPerMillion = 1.50m, OutputPerMillion = 6.00m,
-            CacheReadPerMillion = 0.375m, CacheWritePerMillion = 1.875m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gpt-5.5", DisplayName = "GPT-5.5",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 400_000, MaxOutputTokens = 32_000,
             Provider = "openai",
-            InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
-            CacheReadPerMillion = 2.50m, CacheWritePerMillion = 12.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gpt-5.4", DisplayName = "GPT-5.4",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 400_000, MaxOutputTokens = 32_000,
             Provider = "openai",
-            InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
-            CacheReadPerMillion = 2.50m, CacheWritePerMillion = 12.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gpt-5.4-mini", DisplayName = "GPT-5.4 Mini",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 400_000, MaxOutputTokens = 16_000,
             Provider = "openai",
-            InputPerMillion = 1.10m, OutputPerMillion = 4.40m,
-            CacheReadPerMillion = 0.275m, CacheWritePerMillion = 1.375m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gpt-5.3-codex", DisplayName = "GPT-5.3 Codex",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 400_000, MaxOutputTokens = 16_000,
             Provider = "openai",
-            InputPerMillion = 1.50m, OutputPerMillion = 6.00m,
-            CacheReadPerMillion = 0.375m, CacheWritePerMillion = 1.875m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "o3", DisplayName = "O3",
             Capabilities = DefaultCaps | ModelCapabilities.ExtendedThinking,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 200_000, MaxOutputTokens = 100_000,
             Provider = "openai",
-            InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
-            CacheReadPerMillion = 2.50m, CacheWritePerMillion = 12.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "o4-mini", DisplayName = "O4 Mini",
             Capabilities = DefaultCaps | ModelCapabilities.ExtendedThinking,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 200_000, MaxOutputTokens = 100_000,
             Provider = "openai",
-            InputPerMillion = 1.10m, OutputPerMillion = 4.40m,
-            CacheReadPerMillion = 0.275m, CacheWritePerMillion = 1.375m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gpt-4.1", DisplayName = "GPT-4.1",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 1_047_576, MaxOutputTokens = 32_000,
             Provider = "openai",
-            InputPerMillion = 2.00m, OutputPerMillion = 8.00m,
-            CacheReadPerMillion = 0.50m, CacheWritePerMillion = 2.50m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "codex-mini", DisplayName = "Codex Mini",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,
-            ContextWindow = 400_000, MaxOutputTokens = 16_000,
             Provider = "openai",
-            InputPerMillion = 1.50m, OutputPerMillion = 6.00m,
-            CacheReadPerMillion = 0.375m, CacheWritePerMillion = 1.875m,
-        },
+        }.WithSpec(),
     ];
 
     protected override async Task<IReadOnlyList<ModelInfo>?> DiscoverModelsAsync(CancellationToken ct)

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
@@ -21,65 +21,47 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
 
     public override IReadOnlyList<ModelInfo> GetStaticModels() =>
     [
-        new()
+        new ModelInfo
         {
             Id = "gemini-3.8-flash", DisplayName = "Gemini 3.8 Flash",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Gemini,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Gemini,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google", IsDefault = true,
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Gemini,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Gemini,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 1.25m, OutputPerMillion = 10.00m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.315m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gemini-3-pro-preview", DisplayName = "Gemini 3 Pro",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Gemini,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 1.25m, OutputPerMillion = 10.00m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.315m,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gemini-3-flash-preview", DisplayName = "Gemini 3 Flash",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Gemini,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
-        },
+        }.WithSpec(),
     ];
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -7,6 +7,7 @@ using Ivy.Tendril.Agents.Providers.Codex;
 using Ivy.Tendril.Agents.Providers.Gemini;
 using Ivy.Tendril.Agents.Providers.Ivy;
 using Ivy.Tendril.Agents.Providers.OpenCode;
+using Ivy.Tendril.Agents.Runtime;
 
 namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
 
@@ -281,8 +282,7 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
                     Capabilities = ModelCapabilities.CodeGeneration | ModelCapabilities.ToolUse | ModelCapabilities.Streaming,
                     SupportedEfforts = EffortLevels.OpenCode,
                     Provider = "berget",
-                    ContextWindow = 128000,
-                }
+                }.WithSpec()
             ];
         }
 

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
@@ -13,85 +13,72 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
 
     public override IReadOnlyList<ModelInfo> GetStaticModels() =>
     [
-        new()
+        new ModelInfo
         {
             Id = "moonshotai/Kimi-K3", DisplayName = "Kimi k3",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot", IsDefault = true,
-            ContextWindow = 256_000, MaxOutputTokens = 32_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "kimi-k2", DisplayName = "Kimi k2",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot",
-            ContextWindow = 128_000, MaxOutputTokens = 32_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "deepseek-v3", DisplayName = "DeepSeek V3",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek",
-            ContextWindow = 64_000, MaxOutputTokens = 8_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "deepseek-r1", DisplayName = "DeepSeek R1",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek",
-            ContextWindow = 64_000, MaxOutputTokens = 8_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-fable-5", DisplayName = "Claude Fable 5",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-opus-5-1", DisplayName = "Claude Opus 5.1",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-opus-5", DisplayName = "Claude Opus 5",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-opus-4-7", DisplayName = "Claude Opus 4.7",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-sonnet-5-1", DisplayName = "Claude Sonnet 5.1",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-5.1", DisplayName = "Claude 5.1",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
-            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "gpt-5.5", DisplayName = "GPT-5.5",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "openai",
-            ContextWindow = 400_000, MaxOutputTokens = 32_000,
-        },
-        new()
+        }.WithSpec(),
+        new ModelInfo
         {
             Id = "default", DisplayName = "OpenCode Default",
             Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "opencode",
@@ -122,7 +109,7 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
             if (string.IsNullOrWhiteSpace(id)) continue;
 
             var provider = ExtractProvider(id);
-            var pricing = LookupPricing(id);
+            var spec = ModelSpecs.Find(id);
 
             results.Add(new ModelInfo
             {
@@ -134,12 +121,12 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
                     : EffortLevels.OpenCode,
                 Provider = provider,
                 IsDefault = first,
-                ContextWindow = pricing?.ContextWindow,
-                MaxOutputTokens = pricing?.MaxOutput,
-                InputPerMillion = pricing?.Input ?? 0m,
-                OutputPerMillion = pricing?.Output ?? 0m,
-                CacheReadPerMillion = pricing?.CacheRead ?? 0m,
-                CacheWritePerMillion = pricing?.CacheWrite ?? 0m,
+                ContextWindow = spec?.ContextWindow,
+                MaxOutputTokens = spec?.MaxOutputTokens,
+                InputPerMillion = spec?.InputPerMillion ?? 0m,
+                OutputPerMillion = spec?.OutputPerMillion ?? 0m,
+                CacheReadPerMillion = spec?.CacheReadPerMillion ?? 0m,
+                CacheWritePerMillion = spec?.CacheWritePerMillion ?? 0m,
             });
             first = false;
         }
@@ -154,12 +141,10 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
         return slash > 0 ? modelId[..slash] : "opencode";
     }
 
-    private record KnownPricing(decimal Input, decimal Output, decimal CacheRead = 0m, decimal CacheWrite = 0m, int? ContextWindow = null, int? MaxOutput = null);
-
     /// <summary>
     /// Resolves the context and output token limits for a formatted model string (e.g.
-    /// <c>anthropic/claude-opus-5</c>), checking the static catalog first and falling back to
-    /// <see cref="LookupPricing"/>. Returns null when neither source has both values.
+    /// <c>anthropic/claude-opus-5</c>), checking the static catalog first and falling back to the
+    /// canonical <see cref="ModelSpecs"/> table. Returns null when neither source knows the model.
     /// </summary>
     internal static (int Context, int Output)? TryGetLimits(string formattedModel)
     {
@@ -177,87 +162,8 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
         if (staticMatch is not null)
             return (staticMatch.ContextWindow!.Value, staticMatch.MaxOutputTokens!.Value);
 
-        var pricing = LookupPricing(formattedModel);
-        if (pricing is { ContextWindow: not null, MaxOutput: not null })
-            return (pricing.ContextWindow.Value, pricing.MaxOutput.Value);
-
-        return null;
+        return ModelSpecs.Find(formattedModel) is { } spec
+            ? (spec.ContextWindow, spec.MaxOutputTokens)
+            : null;
     }
-
-    private static KnownPricing? LookupPricing(string modelId)
-    {
-        var name = modelId;
-        var slash = modelId.IndexOf('/');
-        if (slash > 0) name = modelId[(slash + 1)..];
-
-        // Strip common prefixes (anthropic., eu.anthropic., global.anthropic., etc.)
-        var dotIdx = name.IndexOf('.');
-        if (dotIdx > 0 && name[..dotIdx] is "anthropic" or "au" or "eu" or "global" or "us")
-        {
-            var afterDot = name[(dotIdx + 1)..];
-            dotIdx = afterDot.IndexOf('.');
-            if (dotIdx > 0 && afterDot[..dotIdx] == "anthropic")
-                name = afterDot[(dotIdx + 1)..];
-            else if (afterDot.StartsWith("claude") || afterDot.StartsWith("gpt") || afterDot.StartsWith("o"))
-                name = afterDot;
-        }
-
-        foreach (var (pattern, pricing) in KnownPricingTable)
-        {
-            if (name.Contains(pattern, StringComparison.OrdinalIgnoreCase))
-                return pricing;
-        }
-        return null;
-    }
-
-    private static readonly (string Pattern, KnownPricing Pricing)[] KnownPricingTable =
-    [
-        // Anthropic
-        ("claude-fable-5",    new(10.00m, 50.00m, 1.00m, 12.50m, 1_000_000, 128_000)),
-        ("claude-opus-5-1",   new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000, 128_000)),
-        ("claude-opus-5.1",   new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000, 128_000)),
-        ("claude-opus-5",     new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000, 128_000)),
-        ("claude-sonnet-5-1", new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000, 128_000)),
-        ("claude-sonnet-5.1", new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000, 128_000)),
-        ("claude-5.1",        new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000, 128_000)),
-        ("claude-sonnet-5",   new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000, 128_000)),
-        ("claude-haiku-5-1",  new(1.00m, 5.00m, 0.10m, 1.25m, 200_000, 64_000)),
-        ("claude-opus-4-7",   new(10.00m, 50.00m, 1.00m, 12.50m, 200_000, 128_000)),
-        ("claude-opus-4-6",   new(5.00m, 25.00m, 0.50m, 6.25m, 200_000, 128_000)),
-        ("claude-opus-4-5",   new(5.00m, 25.00m, 0.50m, 6.25m, 200_000, 128_000)),
-        ("claude-opus-4-1",   new(15.00m, 75.00m, 1.50m, 18.75m, 200_000, 128_000)),
-        ("claude-opus-4",     new(15.00m, 75.00m, 1.50m, 18.75m, 200_000, 128_000)),
-        ("claude-sonnet-4-6", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 128_000)),
-        ("claude-sonnet-4-5", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 128_000)),
-        ("claude-sonnet-4",   new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 128_000)),
-        ("claude-3.7-sonnet", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 64_000)),
-        ("claude-3.5-sonnet", new(3.00m, 15.00m, 0.30m, 3.75m, 200_000, 64_000)),
-        ("claude-3.5-haiku",  new(0.80m, 4.00m, 0.08m, 1.00m, 200_000, 64_000)),
-        ("claude-3-haiku",    new(0.25m, 1.25m, 0.03m, 0.30m, 200_000, 64_000)),
-        ("claude-3-opus",     new(15.00m, 75.00m, 1.50m, 18.75m, 200_000, 64_000)),
-        // OpenAI
-        ("gpt-5.5",       new(10.00m, 40.00m, 2.50m, 12.50m, 400_000, 32_000)),
-        ("gpt-5.4",       new(10.00m, 40.00m, 2.50m, 12.50m, 400_000, 32_000)),
-        ("gpt-5.4-mini",  new(1.10m, 4.40m, 0.275m, 1.375m, 400_000, 16_000)),
-        ("gpt-4.5",       new(75.00m, 150.00m, 37.50m, 93.75m, 128_000, 16_000)),
-        ("gpt-4.1-mini",  new(0.40m, 1.60m, 0.10m, 0.50m, 1_047_576, 16_000)),
-        ("gpt-4.1-nano",  new(0.10m, 0.40m, 0.025m, 0.125m, 1_047_576, 16_000)),
-        ("gpt-4.1",       new(2.00m, 8.00m, 0.50m, 2.50m, 1_047_576, 32_000)),
-        ("gpt-4o-mini",   new(0.15m, 0.60m, 0.075m, 0.1875m, 128_000, 16_000)),
-        ("gpt-4o",        new(2.50m, 10.00m, 1.25m, 3.125m, 128_000, 16_000)),
-        ("o4-mini",       new(1.10m, 4.40m, 0.275m, 1.375m, 200_000, 100_000)),
-        ("o3-mini",       new(1.10m, 4.40m, 0.275m, 1.375m, 200_000, 100_000)),
-        ("o3",            new(10.00m, 40.00m, 2.50m, 12.50m, 200_000, 100_000)),
-        ("o1-mini",       new(1.10m, 4.40m, 0.275m, 1.375m, 128_000, 100_000)),
-        ("o1-pro",        new(150.00m, 600.00m, 0m, 0m, 128_000, 100_000)),
-        ("o1",            new(15.00m, 60.00m, 7.50m, 18.75m, 200_000, 100_000)),
-        // Google
-        ("gemini-3.8-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576, 65_536)),
-        ("gemini-3.7-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576, 65_536)),
-        ("gemini-3.6-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576, 65_536)),
-        ("gemini-3.1-pro",   new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576, 65_536)),
-        ("gemini-2.5-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576, 65_536)),
-        ("gemini-2.5",       new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576, 65_536)),
-        ("gemini-2.0-flash", new(0.10m, 0.40m, 0.025m, 0.125m, 1_048_576, 65_536)),
-    ];
 }

--- a/src/Ivy.Tendril.Agents/Runtime/ModelSpecs.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/ModelSpecs.cs
@@ -1,0 +1,243 @@
+using Ivy.Tendril.Agents.Abstractions;
+
+namespace Ivy.Tendril.Agents.Runtime;
+
+/// <summary>
+/// The limits and per-million rates of one model, independent of which provider serves it. A model
+/// has one context window and one price list, so exactly one <see cref="ModelSpec" /> describes it
+/// and every catalog that lists it reads the same row.
+/// </summary>
+public sealed record ModelSpec(
+    int ContextWindow,
+    int MaxOutputTokens,
+    decimal InputPerMillion,
+    decimal OutputPerMillion,
+    decimal CacheReadPerMillion = 0m,
+    decimal CacheWritePerMillion = 0m);
+
+/// <summary>
+/// The canonical model limits table. Before this existed, six catalogs and a private pricing table
+/// each hardcoded their own numbers for overlapping model IDs and disagreed: the same model resolved
+/// to a 1M window through one catalog and 200k through another, and <c>claude-opus-4-8</c> was priced
+/// three times over because a declaration-order substring scan captured it with the
+/// <c>claude-opus-4</c> row. Catalogs now declare identity only (ID, display name, capabilities,
+/// efforts, provider) and take every number from here.
+/// </summary>
+public static class ModelSpecs
+{
+    /// <summary>
+    /// One row per model ID any catalog declares, plus the IDs the CLIs emit that no catalog lists.
+    /// Rows are keyed by <see cref="Normalize" />d ID, so a dotted and a dashed spelling of the same
+    /// model (<c>claude-3.5-sonnet</c> / <c>claude-3-5-sonnet</c>) are one row, not two that can drift.
+    /// </summary>
+    private static readonly (string Id, ModelSpec Spec)[] Rows =
+    [
+        // ── Anthropic ────────────────────────────────────────────────────────────────────────────
+        // The 4.6/4.7 rows resolve the 5x window and 2x price disagreement in favour of the
+        // anthropic-native catalog, which is what the `ivy` provider already runs on.
+        ("claude-fable-5",    new(1_000_000, 128_000, 10.00m, 50.00m, 1.00m, 12.50m)),
+        ("claude-opus-5-1",   new(1_000_000, 128_000, 5.00m, 25.00m, 0.50m, 6.25m)),
+        ("claude-opus-5",     new(1_000_000, 128_000, 5.00m, 25.00m, 0.50m, 6.25m)),
+        ("claude-opus-4-8",   new(1_000_000, 128_000, 5.00m, 25.00m, 0.50m, 6.25m)),
+        ("claude-opus-4-7",   new(1_000_000, 128_000, 5.00m, 25.00m, 0.50m, 6.25m)),
+        ("claude-opus-4-6",   new(1_000_000, 128_000, 5.00m, 25.00m, 0.50m, 6.25m)),
+        ("claude-opus-4-5",   new(200_000, 128_000, 5.00m, 25.00m, 0.50m, 6.25m)),
+        ("claude-opus-4-1",   new(200_000, 128_000, 15.00m, 75.00m, 1.50m, 18.75m)),
+        ("claude-opus-4",     new(200_000, 128_000, 15.00m, 75.00m, 1.50m, 18.75m)),
+        ("claude-3-opus",     new(200_000, 64_000, 15.00m, 75.00m, 1.50m, 18.75m)),
+        ("claude-sonnet-5-1", new(1_000_000, 128_000, 3.00m, 15.00m, 0.30m, 3.75m)),
+        ("claude-5.1",        new(1_000_000, 128_000, 3.00m, 15.00m, 0.30m, 3.75m)),
+        ("claude-sonnet-5",   new(1_000_000, 128_000, 3.00m, 15.00m, 0.30m, 3.75m)),
+        ("claude-sonnet-4-6", new(1_000_000, 128_000, 3.00m, 15.00m, 0.30m, 3.75m)),
+        ("claude-sonnet-4-5", new(200_000, 128_000, 3.00m, 15.00m, 0.30m, 3.75m)),
+        ("claude-sonnet-4",   new(200_000, 128_000, 3.00m, 15.00m, 0.30m, 3.75m)),
+        // The 3.x models publish a 200k window and a 64k output limit; the catalogs claimed 1M/128k.
+        ("claude-3-7-sonnet", new(200_000, 64_000, 3.00m, 15.00m, 0.30m, 3.75m)),
+        ("claude-3-5-sonnet", new(200_000, 64_000, 3.00m, 15.00m, 0.30m, 3.75m)),
+        ("claude-haiku-5-1",  new(200_000, 64_000, 1.00m, 5.00m, 0.10m, 1.25m)),
+        ("claude-haiku-4-5",  new(200_000, 64_000, 1.00m, 5.00m, 0.10m, 1.25m)),
+        ("claude-3-5-haiku",  new(200_000, 64_000, 0.80m, 4.00m, 0.08m, 1.00m)),
+        ("claude-3-haiku",    new(200_000, 64_000, 0.25m, 1.25m, 0.03m, 0.30m)),
+
+        // Bare Claude CLI aliases. Each carries the spec of the model it resolves to in practice,
+        // which is what removes the alias-vs-concrete price split (`sonnet` used to be 2/10 while
+        // `claude-sonnet-5` was 3/15).
+        ("opus",   new(1_000_000, 128_000, 5.00m, 25.00m, 0.50m, 6.25m)),
+        ("sonnet", new(1_000_000, 128_000, 3.00m, 15.00m, 0.30m, 3.75m)),
+        ("haiku",  new(200_000, 64_000, 1.00m, 5.00m, 0.10m, 1.25m)),
+
+        // ── OpenAI ───────────────────────────────────────────────────────────────────────────────
+        ("gpt-6-astra",   new(400_000, 32_000, 10.00m, 40.00m, 2.50m, 12.50m)),
+        ("gpt-5.6-sol",   new(400_000, 32_000, 10.00m, 40.00m, 2.50m, 12.50m)),
+        ("gpt-5.6-terra", new(272_000, 16_000, 1.10m, 4.40m, 0.275m, 1.375m)),
+        ("gpt-5.6-luna",  new(272_000, 16_000, 1.50m, 6.00m, 0.375m, 1.875m)),
+        ("gpt-5.5",       new(400_000, 32_000, 10.00m, 40.00m, 2.50m, 12.50m)),
+        ("gpt-5.4",       new(400_000, 32_000, 10.00m, 40.00m, 2.50m, 12.50m)),
+        ("gpt-5.4-mini",  new(400_000, 16_000, 1.10m, 4.40m, 0.275m, 1.375m)),
+        ("gpt-5.3-codex", new(400_000, 16_000, 1.50m, 6.00m, 0.375m, 1.875m)),
+        ("gpt-4.5",       new(128_000, 16_000, 75.00m, 150.00m, 37.50m, 93.75m)),
+        ("gpt-4.1",       new(1_047_576, 32_000, 2.00m, 8.00m, 0.50m, 2.50m)),
+        ("gpt-4.1-mini",  new(1_047_576, 16_000, 0.40m, 1.60m, 0.10m, 0.50m)),
+        ("gpt-4.1-nano",  new(1_047_576, 16_000, 0.10m, 0.40m, 0.025m, 0.125m)),
+        ("gpt-4o",        new(128_000, 16_000, 2.50m, 10.00m, 1.25m, 3.125m)),
+        ("gpt-4o-mini",   new(128_000, 16_000, 0.15m, 0.60m, 0.075m, 0.1875m)),
+        ("gpt-oss-120b",  new(128_000, 32_768, 0.15m, 0.60m)),
+        ("codex-mini",    new(400_000, 16_000, 1.50m, 6.00m, 0.375m, 1.875m)),
+        ("o4-mini",       new(200_000, 100_000, 1.10m, 4.40m, 0.275m, 1.375m)),
+        ("o3-mini",       new(200_000, 100_000, 1.10m, 4.40m, 0.275m, 1.375m)),
+        ("o3",            new(200_000, 100_000, 10.00m, 40.00m, 2.50m, 12.50m)),
+        ("o1-mini",       new(128_000, 100_000, 1.10m, 4.40m, 0.275m, 1.375m)),
+        ("o1-pro",        new(128_000, 100_000, 150.00m, 600.00m)),
+        ("o1",            new(200_000, 100_000, 15.00m, 60.00m, 7.50m, 18.75m)),
+
+        // ── Google ───────────────────────────────────────────────────────────────────────────────
+        // The 3.x rows take the two native catalogs' 0.60 output rate over the pricing table's 3.50,
+        // and their 1M window over the table's 1_048_576.
+        ("gemini-3.8-flash",        new(1_000_000, 65_536, 0.15m, 0.60m, 0.0375m)),
+        ("gemini-3.7-flash",        new(1_000_000, 65_536, 0.15m, 0.60m, 0.0375m)),
+        ("gemini-3.6-flash",        new(1_000_000, 65_536, 0.15m, 0.60m, 0.0375m)),
+        ("gemini-3-flash-preview",  new(1_000_000, 65_536, 0.15m, 0.60m, 0.0375m)),
+        ("gemini-3.1-pro",          new(1_000_000, 65_536, 1.25m, 10.00m, 0.315m)),
+        ("gemini-3-pro-preview",    new(1_000_000, 65_536, 1.25m, 10.00m, 0.315m)),
+        ("gemini-2.5-flash",        new(1_048_576, 65_536, 0.15m, 3.50m, 0.0375m, 0.15m)),
+        ("gemini-2.5",              new(1_048_576, 65_536, 1.25m, 10.00m, 0.3125m, 1.5625m)),
+        ("gemini-2.0-flash",        new(1_048_576, 65_536, 0.10m, 0.40m, 0.025m, 0.125m)),
+
+        // ── Open-weight models ───────────────────────────────────────────────────────────────────
+        // Rates stay 0 because no catalog has ever declared any for these and inventing one would
+        // start attributing per-token costs to runs that were previously reported as free.
+        ("Kimi-K3",                    new(256_000, 32_000, 0m, 0m)),
+        ("kimi-k2",                    new(128_000, 32_000, 0m, 0m)),
+        ("deepseek-v3",                new(64_000, 8_000, 0m, 0m)),
+        ("deepseek-r1",                new(64_000, 8_000, 0m, 0m)),
+        ("Qwen2.5-Coder-32B-Instruct", new(128_000, 32_000, 0m, 0m)),
+    ];
+
+    private static readonly Dictionary<string, ModelSpec> Table =
+        Rows.ToDictionary(r => Normalize(r.Id), r => r.Spec, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Substring patterns tried longest first, not in declaration order. Declaration order is what
+    /// let <c>claude-opus-4</c> capture <c>claude-opus-4-8</c>; longest-first cannot, because a
+    /// longer pattern that matches is always more specific. Same reason
+    /// <see cref="ModelPricingProvider" /> length-orders its keys.
+    /// </summary>
+    private static readonly string[] PatternsLongestFirst =
+        [.. Table.Keys.OrderByDescending(k => k.Length)];
+
+    /// <summary>
+    /// Resolves <paramref name="modelId" /> to its canonical spec, or null when nothing matches.
+    /// Tries the declared ID (exact, provider-prefix-stripped, dot/dash-insensitive) and then falls
+    /// back to a longest-first substring match, which is how a dated or suffixed ID from a CLI
+    /// (<c>anthropic/claude-opus-4-8-20260101</c>) still resolves.
+    /// </summary>
+    public static ModelSpec? Find(string? modelId)
+    {
+        if (string.IsNullOrWhiteSpace(modelId))
+            return null;
+
+        if (FindDeclared(modelId) is { } declared)
+            return declared;
+
+        var normalized = Normalize(StripProviderPrefix(modelId));
+        foreach (var pattern in PatternsLongestFirst)
+        {
+            if (normalized.Contains(pattern, StringComparison.Ordinal))
+                return Table[pattern];
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The catalog-facing lookup: returns the spec for a model ID a catalog declares, and throws
+    /// when the table has no row for it. Deliberately does not fall back to
+    /// <see cref="Find" />'s substring match — a new catalog entry whose ID nobody has priced should
+    /// break the build rather than silently inherit a shorter row's numbers.
+    /// </summary>
+    public static ModelSpec Require(string modelId) =>
+        FindDeclared(modelId) ?? throw new InvalidOperationException(
+            $"No canonical ModelSpec is declared for model id '{modelId}'. " +
+            "Add a row to ModelSpecs.Rows so every catalog that lists this model reports the same limits.");
+
+    /// <summary>
+    /// Matches only IDs the table declares: exactly, or after stripping a provider prefix, or in the
+    /// other of the two spellings (<c>claude-opus-5.1</c> for <c>claude-opus-5-1</c>).
+    /// </summary>
+    private static ModelSpec? FindDeclared(string modelId)
+    {
+        if (Table.TryGetValue(Normalize(modelId), out var exact))
+            return exact;
+
+        return Table.TryGetValue(Normalize(StripProviderPrefix(modelId)), out var stripped)
+            ? stripped
+            : null;
+    }
+
+    /// <summary>
+    /// Folds the spellings that mean the same model into one key: case, and <c>.</c> versus <c>-</c>
+    /// as the version separator. Catalog IDs use dashes (<c>claude-3-5-sonnet</c>) where the pricing
+    /// table used dots (<c>claude-3.5-sonnet</c>), which is why those IDs used to resolve to nothing.
+    /// </summary>
+    internal static string Normalize(string modelId) =>
+        modelId.Trim().Replace('.', '-').ToLowerInvariant();
+
+    /// <summary>
+    /// Drops the routing prefix a provider puts in front of a model name: everything up to the first
+    /// <c>/</c>, then a <c>anthropic.</c> / <c>eu.anthropic.</c> / <c>global.anthropic.</c>-style
+    /// vendor and region prefix.
+    /// </summary>
+    internal static string StripProviderPrefix(string modelId)
+    {
+        var name = modelId.Trim();
+
+        var slash = name.IndexOf('/');
+        if (slash > 0) name = name[(slash + 1)..];
+
+        var dotIdx = name.IndexOf('.');
+        if (dotIdx > 0 && name[..dotIdx] is "anthropic" or "au" or "eu" or "global" or "us")
+        {
+            var afterDot = name[(dotIdx + 1)..];
+            dotIdx = afterDot.IndexOf('.');
+            if (dotIdx > 0 && afterDot[..dotIdx] == "anthropic")
+                name = afterDot[(dotIdx + 1)..];
+            else if (afterDot.StartsWith("claude") || afterDot.StartsWith("gpt") || afterDot.StartsWith("o"))
+                name = afterDot;
+        }
+
+        return name;
+    }
+}
+
+public static class ModelSpecExtensions
+{
+    /// <summary>
+    /// Fills a catalog entry's six numeric fields from the canonical table, so a catalog declares
+    /// only what is genuinely its own: the ID, display name, capabilities, efforts and provider.
+    /// </summary>
+    /// <param name="maxOutputTokens">
+    /// A provider-specific cap on the response length, for a harness that truncates below the
+    /// model's own limit (the Antigravity CLI caps every anthropic model at 64k). Must not exceed
+    /// the canonical limit: a provider may serve less of a model than it has, never more.
+    /// </param>
+    public static ModelInfo WithSpec(this ModelInfo model, int? maxOutputTokens = null)
+    {
+        var spec = ModelSpecs.Require(model.Id);
+
+        if (maxOutputTokens > spec.MaxOutputTokens)
+            throw new ArgumentOutOfRangeException(
+                nameof(maxOutputTokens),
+                maxOutputTokens,
+                $"'{model.Id}' cannot declare a {maxOutputTokens} output limit above its canonical {spec.MaxOutputTokens}.");
+
+        return model with
+        {
+            ContextWindow = spec.ContextWindow,
+            MaxOutputTokens = maxOutputTokens ?? spec.MaxOutputTokens,
+            InputPerMillion = spec.InputPerMillion,
+            OutputPerMillion = spec.OutputPerMillion,
+            CacheReadPerMillion = spec.CacheReadPerMillion,
+            CacheWritePerMillion = spec.CacheWritePerMillion,
+        };
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Six model catalogs (`ClaudeModelCatalog`, `AntigravityModelCatalog`, `CodexModelCatalog`,
`GeminiModelCatalog`, `OpenCodeModelCatalog`, and `OpenAiProxyModelCatalog`'s one numeric entry) plus
`OpenCodeModelCatalog`'s private `KnownPricingTable` each hardcoded `ContextWindow`,
`MaxOutputTokens` and per-million rates for overlapping model IDs and disagreed with each other —
resolving the same model through two of them gave two different answers, with real runtime damage:
`claude-opus-4-6` launched opencode with a 200k window instead of 1M, a dated `claude-opus-4-8`
inherited `claude-opus-4`'s price via a declaration-order substring scan (3x overcharge), legacy
dashed Claude 3.x IDs resolved to nothing at all, and the Gemini flash output rate had a 6x spread.

A new canonical table, `ModelSpecs`, is now the single source of truth for every model's limits and
rates. Each catalog declares identity only (ID, display name, capabilities, efforts, provider) and
fills its six numeric fields via a shared `WithSpec()` extension, which throws if a catalog entry's ID
has no canonical row rather than silently defaulting to nulls and zeros. `ModelSpecs.Find` resolves an
ID by exact match, then provider-prefix-stripped, then with dot and dash spellings folded together,
then by longest-matching substring — replacing the old declaration-order scan that let a shorter
pattern capture a longer one.

Three commits: `4cbe2360` (the table), `f2ea6144` (catalogs read from it, private pricing table
deleted), `19daf029` (tests).

## Decisions

### Plan questions, resolved to their recommended option

No answers were recorded on the revision and this execution is non-interactive, so each of the three
questions took its `recommended` option. Logged to job 02390 as `ResolvedQuestions`.

| Question | Answer | Effect |
| --- | --- | --- |
| `disputed-anthropic-window` | `claude-wins` | `claude-opus-4-6`, `claude-opus-4-7`, `claude-sonnet-4-6` are 1M / 128k; opus rows 5/25, sonnet 3/15. The anthropic-native catalog wins over the private pricing table's 200k and 10/50. |
| `legacy-claude-3x-window` | `correct-to-200k` | `claude-3-7-sonnet` and `claude-3-5-sonnet` drop from a claimed 1M / 128k to their published 200k / 64k. |
| `antigravity-output-cap` | `keep-override` | `AntigravityModelCatalog` keeps `AnthropicOutputCap = 65_536`, applied as `WithSpec(AnthropicOutputCap)`, while reporting the model's real 1M window. `WithSpec` throws on a cap *above* the canonical limit, so a provider can serve less of a model than it has and never more. |

### Judgment calls the questions did not cover

Three conflicts in the union of the tables were not enumerated by either question. Each was resolved
towards the narrowest behaviour change.

1. **Gemini 3.x rows** take the two native catalogs' `1_000_000` window and 0.60 output rate over
   `KnownPricingTable`'s `1_048_576` and 3.50. Two sources agreed against one, the plan's Problem
   section itself flagged 3.50 as the suspect half of the 6x spread, and this keeps
   `AntigravityModelCatalogTests`' existing `cost == 0.75m` assertion green. The `gemini-2.x` rows keep
   `1_048_576` and the table's rates, since no native catalog contradicts them.
2. **`claude-3-5-haiku`** takes the pricing table's 0.80 / 4.00 / 0.08 / 1.00 over
   `ClaudeModelCatalog`'s 1.00 / 5.00, which duplicated the `claude-haiku-4-5` row directly above it.
   Consistent with the `correct-to-200k` decision to prefer published values for legacy 3.x rows.
3. **`Qwen2.5-Coder-32B-Instruct`** gains a canonical row at 128k / 32k with zero rates. It previously
   declared a window and no output limit; it now reports both. Rates stay zero for it and the other
   open-weight rows (`Kimi-K3`, `kimi-k2`, `deepseek-v3`, `deepseek-r1`), because inventing one would
   start attributing per-token cost to runs previously reported as free — the reasoning the plan itself
   gives for excluding Copilot.

### Pre-existing test expectations that had to move

Three assertions in `ModelPricingProviderTests` pinned the bare `sonnet` alias at 2.00 / 10.00 and now
expect 3.00 / 15.00: `GetPricing_Sonnet_ReturnsPricing`,
`GetPricing_Sonnet4_SubstringMatch_ReturnsPricing` and `CalculateCost_SmallUsage_ReturnsProportionalCost`.
The revision asks for exactly this ("Point the `opus` / `sonnet` / `haiku` aliases at the same spec as
the concrete model each resolves to, which also removes the 2/10 vs 3/15 `sonnet` discrepancy"), so
these tests were encoding the bug. Every other existing test passes unedited.

One documentation note: the revision says `ClaudeModelCatalog` has "all 20 entries". It has 19,
verified by line numbers against the pre-change file during PreExecution. No entry was missed.

## API Changes

- New: `Ivy.Tendril.Agents.Runtime.ModelSpec` — record with `ContextWindow`, `MaxOutputTokens`,
  `InputPerMillion`, `OutputPerMillion`, `CacheReadPerMillion`, `CacheWritePerMillion`.
- New: `Ivy.Tendril.Agents.Runtime.ModelSpecs.Find(string?)` → `ModelSpec?` (full resolution chain,
  including the substring fallback) and `.Require(string)` → `ModelSpec` (declared IDs only, throws
  `InvalidOperationException` otherwise — deliberately no substring fallback, so an unpriced new
  catalog entry breaks loudly instead of inheriting a shorter row's numbers).
- New: `Ivy.Tendril.Agents.Runtime.ModelSpecExtensions.WithSpec(this ModelInfo, int? maxOutputTokens = null)`.
- Removed: `OpenCodeModelCatalog.KnownPricing`, `KnownPricingTable`, `LookupPricing` — all private,
  no external consumers.
- No breaking change to `IModelCatalogProvider` or `ModelInfo`'s public shape. `Find` accepts a
  nullable ID and returns null for null/blank rather than throwing.

## Files Modified

- `src/Ivy.Tendril.Agents/Runtime/ModelSpecs.cs` — **new**, 63 canonical rows plus the resolver.
- `src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs` (19 entries),
  `Providers/Antigravity/AntigravityModelCatalog.cs` (13),
  `Providers/Codex/CodexModelCatalog.cs` (12),
  `Providers/Gemini/GeminiModelCatalog.cs` (6),
  `Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs` (1) — every static entry rewritten to declare
  identity only and call `.WithSpec()`.
- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs` — 263 → 169 lines. 13 static
  entries switched to `WithSpec()` (`default` keeps no limits, as before);
  `KnownPricing` / `KnownPricingTable` / `LookupPricing` deleted; `TryGetLimits` keeps its two-step
  shape with `ModelSpecs.Find` as the second step; `ParseModelsListAsync` reads limits and rates from
  the spec.
- `src/Ivy.Tendril.Agents.Test/Runtime/ModelSpecsTests.cs` — **new**, 17 methods covering the
  resolution rules, including the longest-pattern regression for the 3x mispricing.
- `src/Ivy.Tendril.Agents.Test/Runtime/ModelCatalogConsistencyTests.cs` — **new**, 13 methods
  asserting one model has one window, one output limit and one price list across all seven catalogs.
- `src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs` — three `sonnet` assertions
  updated as described above.

`CopilotModelCatalog.cs` and the models.dev enrichment/refresh paths were explicitly out of scope and
are untouched.

## Manual Testing

N/A — an internal data-layer change with no user-facing behaviour of its own, and no UI or process
orchestration surface to click through. What changed is only observable two ways, both covered
automatically:

- **Unit tests.** 41 new cases plus the existing catalog/pricing suites: 177 under the plan's filter,
  1200 in `Ivy.Tendril.Agents.Test` and 3790 in `Ivy.Tendril.Test`, all passing in Release. See
  `Verification/DotnetTest.md`.
- **At runtime**, through the `limit.context` value the OpenCode CLI is launched with. For
  `anthropic/claude-opus-4-6` that is now 1,000,000 rather than 200,000, which
  `ModelCatalogConsistencyTests.TryGetLimits_ForOpus46_ReturnsOneMillionContext` asserts at the point
  `OpenCodeCli` reads it. Verifying it by hand would need a live opencode session against that model;
  the test pins the same value the process would receive.

No artifacts (screenshots, logs) were produced — there is nothing visual in this change.

---
## Commits
- `4cbe2360` Add canonical ModelSpecs table (plan 00478)
- `f2ea6144` Read model limits and rates from ModelSpecs (plan 00478)
- `19daf029` Cover ModelSpecs and catalog consistency (plan 00478)

---
Created using [Ivy Tendril](https://ivy.app).